### PR TITLE
Fix axes mapping when using Axes custom param, fixes #409, #411

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -208,7 +208,13 @@ def to_designspace_axes(self):
 
 
 def font_uses_new_axes(font):
-    return bool(font.customParameters['Axes'])
+    # It's possible for fonts to have the 'Axes' parameter but to NOT specify
+    # the master locations using 'Axis Location', in which case we have to
+    # resort to using instances or other old tricks to get the mapping.
+    # https://github.com/googlei18n/glyphsLib/issues/409
+    # https://github.com/googlei18n/glyphsLib/issues/411
+    return font.customParameters['Axes'] and all(
+        master.customParameters['Axis Location'] for master in font.masters)
 
 
 def to_glyphs_axes(self):

--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -203,3 +203,35 @@ def test_master_user_location_goes_into_os2_classes():
 
     assert black.info.openTypeOS2WeightClass == 920
     assert black.info.openTypeOS2WidthClass == 1
+
+
+def test_mapping_is_same_regardless_of_axes_custom_parameter():
+    # https://github.com/googlei18n/glyphsLib/issues/409
+    # https://github.com/googlei18n/glyphsLib/issues/411
+
+    # First, try without the custom param
+    font = to_glyphs([defcon.Font(), defcon.Font(), defcon.Font()])
+    font.masters[0].name = 'ExtraLight'
+    font.masters[0].weightValue = 200
+    font.masters[1].name = 'Regular'
+    font.masters[1].weightValue = 400
+    font.masters[2].name = 'Bold'
+    font.masters[2].weightValue = 700
+
+    doc = to_designspace(font)
+    assert doc.axes[0].minimum == 200
+    assert doc.axes[0].maximum == 700
+    assert doc.axes[0].map == []
+
+    # Now with the custom parameter. Should produce the same results
+    font.customParameters['Axes'] = [
+        {
+            'Name': 'Weight',
+            'Tag': 'wght'
+        }
+    ]
+
+    doc = to_designspace(font)
+    assert doc.axes[0].minimum == 200
+    assert doc.axes[0].maximum == 700
+    assert doc.axes[0].map == []


### PR DESCRIPTION
I tested on Fah-Kwang, the new axes are like that:

```xml
    <axes>
        <axis default="400" maximum="700" minimum="200" name="Weight" tag="wght" />
        <axis default="0" maximum="10" minimum="0" name="Italic" tag="ital" />
    </axes>
```

The code wrongly assumed that the "Axes" custom parameter was always used in conjunction with the "Axis Location" parameters for masters.