### PR TITLE
Only write filters to masters

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -620,6 +620,9 @@ class FilterParamHandler(AbstractParamHandler):
         return (UFO2FT_FILTERS_KEY,)
 
     def to_glyphs(self, glyphs, ufo):
+        if glyphs.is_font():
+            return  # Only write filters to the masters
+
         ufo_filters = ufo.get_lib_value(UFO2FT_FILTERS_KEY)
         if ufo_filters is None:
             return
@@ -632,19 +635,21 @@ class FilterParamHandler(AbstractParamHandler):
             glyphs.set_custom_value(glyphs_filter_key, glyphs_filter)
 
     def to_ufo(self, builder, glyphs, ufo):
-        if not glyphs.is_font():  # Only write filters to the masters
-            ufo_filters = []
-            for pre_filter in glyphs.get_custom_values("PreFilter"):
-                ufo_filters.append(parse_glyphs_filter(pre_filter, is_pre=True))
-            for filter in glyphs.get_custom_values("Filter"):
-                ufo_filters.append(parse_glyphs_filter(filter, is_pre=False))
+        if glyphs.is_font():
+            return  # Only write filters to the masters
 
-            if not ufo_filters:
-                return
-            if not ufo.has_lib_key(UFO2FT_FILTERS_KEY):
-                ufo.set_lib_value(UFO2FT_FILTERS_KEY, [])
-            existing = ufo.get_lib_value(UFO2FT_FILTERS_KEY)
-            existing.extend(ufo_filters)
+        ufo_filters = []
+        for pre_filter in glyphs.get_custom_values("PreFilter"):
+            ufo_filters.append(parse_glyphs_filter(pre_filter, is_pre=True))
+        for filter in glyphs.get_custom_values("Filter"):
+            ufo_filters.append(parse_glyphs_filter(filter, is_pre=False))
+
+        if not ufo_filters:
+            return
+        if not ufo.has_lib_key(UFO2FT_FILTERS_KEY):
+            ufo.set_lib_value(UFO2FT_FILTERS_KEY, [])
+        existing = ufo.get_lib_value(UFO2FT_FILTERS_KEY)
+        existing.extend(ufo_filters)
 
 
 register(FilterParamHandler())
@@ -800,10 +805,11 @@ def _unset_default_params(glyphs):
             glyphs_name in glyphs.customParameters
             and glyphs.customParameters[glyphs_name] == default_value
         ):
-            del (glyphs.customParameters[glyphs_name])
+            del glyphs.customParameters[glyphs_name]
         # These parameters can be referred to with the two names in Glyphs
         if (
             glyphs_name in glyphs.customParameters
             and glyphs.customParameters[glyphs_name] == default_value
         ):
-            del (glyphs.customParameters[glyphs_name])
+            del glyphs.customParameters[glyphs_name]
+

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -333,6 +333,7 @@ class SetCustomParamsTest(unittest.TestCase):
         self.master.customParameters["PreFilter"] = glyphs_filter
         self.set_custom_params()
         self.assertEqual(self.ufo.lib[UFO2FT_FILTERS_KEY], ufo_filters)
+        self.assertNotIn(FONT_CUSTOM_PARAM_PREFIX + "PreFilter", self.ufo.lib)
 
         font_rt = glyphsLib.to_glyphs([self.ufo])
         self.assertEqual(
@@ -340,3 +341,4 @@ class SetCustomParamsTest(unittest.TestCase):
         )
         ufo_rt = glyphsLib.to_ufos(font_rt)[0]
         self.assertEqual(ufo_rt.lib[UFO2FT_FILTERS_KEY], ufo_filters)
+        self.assertNotIn(FONT_CUSTOM_PARAM_PREFIX + "PreFilter", ufo_rt.lib)


### PR DESCRIPTION
Before, going from UFO with ufo2ft filters to Glyphs and back to UFOs would leave you with `com.schriftgestaltung.customParameter.GSFont.*Filter` _and_ `com.github.googlei18n.ufo2ft.filters` in the UFO lib key. It still feels wrong to mix Glyphs filters and ufo2ft filters but ugh.