### PR TITLE
Support Replace Prefix custom parameter

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -27,7 +27,7 @@ from .constants import (
     REVERSE_CODEPAGE_RANGES,
     PUBLIC_PREFIX,
 )
-from .features import replace_feature
+from .features import replace_feature, replace_prefix
 
 """Set Glyphs custom parameters in UFO info or lib, where appropriate.
 
@@ -669,6 +669,18 @@ class ReplaceFeatureParamHandler(AbstractParamHandler):
 
 
 register(ReplaceFeatureParamHandler())
+
+
+class ReplacePrefixParamHandler(AbstractParamHandler):
+    def to_ufo(self, builder, glyphs, ufo):
+        for value in glyphs.get_custom_values("Replace Prefix"):
+            tag, repl = re.split(r"\s*;\s*", value, 1)
+            ufo._owner.features.text = replace_prefix(
+                tag, repl, ufo._owner.features.text or ""
+            )
+
+
+register(ReplacePrefixParamHandler())
 
 
 class ReencodeGlyphsParamHandler(AbstractParamHandler):

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -55,6 +55,7 @@ def _to_ufo_features(self, master, ufo):
             strings.append("# Prefix: %s\n" % prefix.name)
         strings.append(autostr(prefix.automatic))
         strings.append(prefix.code)
+        strings.append("\n# End Prefix: %s\n" % prefix.name)
         prefixes.append("".join(strings))
 
     prefix_str = "\n\n".join(prefixes)
@@ -193,6 +194,18 @@ def replace_feature(tag, repl, features):
         repl += "\n"
     return re.sub(
         r"(?<=^feature {tag} {{\n)(.*?)(?=^}} {tag};$)".format(tag=tag),
+        repl,
+        features,
+        count=1,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+
+
+def replace_prefix(tag, repl, features):
+    if not repl.endswith("\n"):
+        repl += "\n"
+    return re.sub(
+        r"(?<=^# Prefix: {tag}\n)(.*?\n)# End Prefix: {tag}".format(tag=tag),
         repl,
         features,
         count=1,


### PR DESCRIPTION
Not sure if this is the most desirable way, but it's just a copy of the `Replace Feature` custom parameter and works if the `Replace Prefix` value is only code that needs to be inserted. If it's an `include()` statement pointing to external files then that's another issue to be dealt with.