### PR TITLE
[bracket layers] support reverse, unbalanced and composite glyphs

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -31,9 +31,7 @@ from .axes import WEIGHT_AXIS_DEF, WIDTH_AXIS_DEF, find_base_style, class_to_val
 
 GLYPH_ORDER_KEY = PUBLIC_PREFIX + "glyphOrder"
 
-BRACKET_LAYER_RE = re.compile(
-    r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\].*"
-)
+BRACKET_LAYER_RE = re.compile(r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\s*\].*")
 BRACKET_GLYPH_TEMPLATE = "{glyph_name}.{rev}BRACKET.{location}"
 REVERSE_BRACKET_LABEL = "REV_"
 BRACKET_GLYPH_RE = re.compile(

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -206,7 +206,9 @@ class UFOBuilder(_LoggerMixin):
                 continue
 
             # Save processing bracket layers for when designspace() is called, as we
-            # have to extract them to free-standing glyphs.
+            # have to extract them to free-standing glyphs -- unless the parent glyph is
+            # set to non-export (in which case makes no sense to have Designspace rules
+            # referencing non existent glyphs).
             if (
                 BRACKET_LAYER_RE.match(layer.name)
                 and glyph.export

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -418,7 +418,7 @@ class UFOBuilder(_LoggerMixin):
         font = self.font
         master_ids = {m.id for m in font.masters}
         # when a glyph master layer doesn't have an explicitly associated bracket layer
-        # for any crosspoint locations, we assume the master layer itself will to be
+        # for any crosspoint locations, we assume the master layer itself will be
         # used implicitly as bracket layer for that location. See "Switching Only One
         # Master" paragraph in "Alternating Glyph Shapes" tutorial at:
         # https://glyphsapp.com/tutorials/alternating-glyph-shapes
@@ -634,6 +634,7 @@ class GlyphsBuilder(_LoggerMixin):
                     bracket_glyph_new = ufo_layer.newGlyph(base_glyph)
                     bracket_glyph_new.copyDataFromGlyph(bracket_glyph)
 
+                    # strip '*.BRACKET.123' suffix from the components' glyph names
                     for comp in bracket_glyph_new.components:
                         m = BRACKET_GLYPH_RE.match(comp.baseGlyph)
                         if m:

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -32,7 +32,7 @@ from .axes import WEIGHT_AXIS_DEF, WIDTH_AXIS_DEF, find_base_style, class_to_val
 GLYPH_ORDER_KEY = PUBLIC_PREFIX + "glyphOrder"
 
 BRACKET_LAYER_RE = re.compile(
-    r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+[\d\s,]*)[\]].*"
+    r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\].*"
 )
 BRACKET_GLYPH_TEMPLATE = "{glyph_name}.{rev}BRACKET.{location}"
 REVERSE_BRACKET_LABEL = "REV_"
@@ -342,15 +342,8 @@ class UFOBuilder(_LoggerMixin):
             assert m
 
             reverse = m.group("first_bracket") == "]"
+            bracket_crossover = int(m.group("value"))
 
-            try:
-                bracket_crossover = int(m.group("value"))
-            except ValueError:
-                raise ValueError(
-                    "Only bracket layers with one numerical (design space) location "
-                    "(meaning the first axis in the designspace file) are currently "
-                    "supported."
-                )
             if not bracket_axis_min <= bracket_crossover <= bracket_axis_max:
                 raise ValueError(
                     "Glyph {glyph_name}: Bracket layer {layer_name} must be within the "

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -15,8 +15,10 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import OrderedDict, defaultdict
+from functools import partial
 import logging
 import os
+import re
 from textwrap import dedent
 
 import defcon
@@ -28,6 +30,17 @@ from .constants import PUBLIC_PREFIX, FONT_CUSTOM_PARAM_PREFIX, GLYPHLIB_PREFIX
 from .axes import WEIGHT_AXIS_DEF, WIDTH_AXIS_DEF, find_base_style, class_to_value
 
 GLYPH_ORDER_KEY = PUBLIC_PREFIX + "glyphOrder"
+
+BRACKET_LAYER_RE = re.compile(
+    r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+[\d\s,]*)[\]].*"
+)
+BRACKET_GLYPH_TEMPLATE = "{glyph_name}.{rev}BRACKET.{location}"
+REVERSE_BRACKET_LABEL = "REV_"
+BRACKET_GLYPH_RE = re.compile(
+    r"(?P<glyph_name>.+)\.(?P<rev>{})?BRACKET\.(?P<location>\d+)$".format(
+        REVERSE_BRACKET_LABEL
+    )
+)
 
 
 class _LoggerMixin(object):
@@ -197,8 +210,8 @@ class UFOBuilder(_LoggerMixin):
             # Save processing bracket layers for when designspace() is called, as we
             # have to extract them to free-standing glyphs.
             if (
-                "[" in layer.name
-                and "]" in layer.name
+                BRACKET_LAYER_RE.match(layer.name)
+                and glyph.export
                 and ".background" not in layer.name
             ):
                 self.bracket_layers.append(layer)
@@ -319,23 +332,19 @@ class UFOBuilder(_LoggerMixin):
             bracket_axis_min = bracket_axis.minimum
             bracket_axis_max = bracket_axis.maximum
 
-        # 1. bracket_layer_map: Organize all bracket layers by crossover value, so
-        #    we can go through the layers by location and copy them to free-standing
-        #    glyphs.
-        # 2. glyph_crossovers: Keep track of the crossover values of a single glyph, so
-        #    we can easily sort them into rule buckets.
-        # 3. glyph_sanity_counter: Count the number of master layers providing
-        #    bracket layers per glyph and crossover value. We currently only support
-        #    the situation where there is a bracket layer for _all_ masters, what the
-        #    Glyphs.app tutorial calls 'Changing All Masters'.
-        bracket_layer_map = defaultdict(list)
-        glyph_crossovers = defaultdict(set)
-        glyph_sanity_counter = defaultdict(list)
+        # Organize all bracket layers by glyph name and crossover value, so later we
+        # can go through the layers by location and copy them to free-standing glyphs
+        bracket_layer_map = defaultdict(partial(defaultdict, list))
         for layer in self.bracket_layers:
             glyph_name = layer.parent.name
-            n = layer.name
+
+            m = BRACKET_LAYER_RE.match(layer.name)
+            assert m
+
+            reverse = m.group("first_bracket") == "]"
+
             try:
-                bracket_crossover = int(n[n.index("[") + 1 : n.index("]")])
+                bracket_crossover = int(m.group("value"))
             except ValueError:
                 raise ValueError(
                     "Only bracket layers with one numerical (design space) location "
@@ -348,80 +357,120 @@ class UFOBuilder(_LoggerMixin):
                     "design space bounds of the {bracket_axis_name} axis: minimum "
                     "{bracket_axis_minimum}, maximum {bracket_axis_maximum}.".format(
                         glyph_name=glyph_name,
-                        layer_name=n,
+                        layer_name=layer.name,
                         bracket_axis_name=bracket_axis.name,
                         bracket_axis_minimum=bracket_axis_min,
                         bracket_axis_maximum=bracket_axis_max,
                     )
                 )
-            bracket_layer_map[bracket_crossover].append(layer)
-            glyph_crossovers[glyph_name].add(bracket_crossover)
-            glyph_sanity_counter[(glyph_name, bracket_crossover)].append(
-                layer.associatedMasterId
-            )
+            bracket_layer_map[glyph_name][(bracket_crossover, reverse)].append(layer)
 
-        # Check that each bracket layer is present in all master layers.
-        unbalanced_bracket_layers = []
-        n_masters = len(list(self.masters))
-        for ((glyph_name, _), master_layer_ids) in glyph_sanity_counter.items():
-            if not len(master_layer_ids) == n_masters:
-                unbalanced_bracket_layers.append(glyph_name)
-        if unbalanced_bracket_layers:
-            raise ValueError(
-                "Currently, we only support bracket layers that are present on all "
-                "masters, i.e. what the Glyphs.app tutorial calls 'Changing All "
-                "Masters'. There is a/are bracket layer(s) missing "
-                "for glyph(s) {unbalanced_glyphs}.".format(
-                    unbalanced_glyphs=unbalanced_bracket_layers
+        # Sort crossovers into rule buckets, one for regular bracket layers (in which
+        # the location represents the min value) and one for 'reverse' bracket layers
+        # (in which the location is the max value).
+        max_rule_bucket = defaultdict(list)
+        min_rule_bucket = defaultdict(list)
+        for glyph_name, glyph_bracket_layers in sorted(bracket_layer_map.items()):
+            min_crossovers = set()
+            max_crossovers = set()
+            for location, reverse in glyph_bracket_layers.keys():
+                if reverse:
+                    max_crossovers.add(location)
+                else:
+                    min_crossovers.add(location)
+            # reverse and non-reverse bracket layers with overlapping ranges are
+            # tricky to implement as DS rules. They are relatively unlikely, and
+            # can usually be rewritten so that they do not overlap. For laziness/
+            # simplicity, where we simply warn that output may not be as expected.
+            invalid_locs = [
+                (mx, mn)
+                for mx, mn in zip(sorted(max_crossovers), sorted(min_crossovers))
+                if mx > mn
+            ]
+            if invalid_locs:
+                self.logger.warning(
+                    "Bracket layers for glyph '%s' have overlapping ranges: %s",
+                    glyph_name,
+                    ", ".join("]{}] > [{}]".format(*values) for values in invalid_locs),
                 )
-            )
-
-        # Sort crossovers into buckets.
-        rule_bucket = defaultdict(list)
-        for glyph_name, crossovers in sorted(glyph_crossovers.items()):
             for crossover_min, crossover_max in util.pairwise(
-                sorted(crossovers) + [bracket_axis_max]
+                [bracket_axis_min] + sorted(max_crossovers)
             ):
-                rule_bucket[(int(crossover_min), int(crossover_max))].append(glyph_name)
+                max_rule_bucket[(int(crossover_min), int(crossover_max))].append(
+                    glyph_name
+                )
+            for crossover_min, crossover_max in util.pairwise(
+                sorted(min_crossovers) + [bracket_axis_max]
+            ):
+                min_rule_bucket[(int(crossover_min), int(crossover_max))].append(
+                    glyph_name
+                )
 
         # Generate rules for the bracket layers.
-        for (axis_range_min, axis_range_max), glyph_names in sorted(
-            rule_bucket.items()
-        ):
-            rule_name = "BRACKET.{}.{}".format(axis_range_min, axis_range_max)
-            glyph_sub_suffix = ".BRACKET.{}".format(axis_range_min)
-            rule = designspaceLib.RuleDescriptor()
-            rule.name = rule_name
-            rule.conditionSets.append(
-                [
-                    {
-                        "name": bracket_axis.name,
-                        "minimum": axis_range_min,
-                        "maximum": axis_range_max,
-                    }
-                ]
-            )
-            rule.subs.extend(
-                [
-                    (glyph_name, glyph_name + glyph_sub_suffix)
-                    for glyph_name in glyph_names
-                ]
-            )
-            self._designspace.addRule(rule)
+        for reverse, rule_bucket in ((True, max_rule_bucket), (False, min_rule_bucket)):
+            for (axis_range_min, axis_range_max), glyph_names in sorted(
+                rule_bucket.items()
+            ):
+                rule = _make_designspace_rule(
+                    glyph_names,
+                    bracket_axis.name,
+                    axis_range_min,
+                    axis_range_max,
+                    reverse,
+                )
+                self._designspace.addRule(rule)
 
         # Finally, copy bracket layers to their own glyphs.
-        for location, layers in bracket_layer_map.items():
-            for layer in layers:
-                ufo_font = self._sources[
-                    layer.associatedMasterId or layer.layerId
-                ].font.layers.defaultLayer
-                ufo_glyph_name = "{glyph_name}.BRACKET.{location}".format(
-                    glyph_name=layer.parent.name, location=location
-                )
-                ufo_glyph = ufo_font.newGlyph(ufo_glyph_name)
-                self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
-                ufo_glyph.unicodes = []  # Avoid cmap interference
-                ufo_glyph.lib[GLYPHLIB_PREFIX + "_originalLayerName"] = layer.name
+        self._copy_bracket_layers_to_ufo_glyphs(bracket_layer_map)
+
+    def _copy_bracket_layers_to_ufo_glyphs(self, bracket_layer_map):
+        font = self.font
+        master_ids = {m.id for m in font.masters}
+        # when a glyph master layer doesn't have an explicitly associated bracket layer
+        # for any crosspoint locations, we assume the master layer itself will to be
+        # used implicitly as bracket layer for that location. See "Switching Only One
+        # Master" paragraph in "Alternating Glyph Shapes" tutorial at:
+        # https://glyphsapp.com/tutorials/alternating-glyph-shapes
+        implicit_bracket_layers = set()
+        # collect all bracket glyph names for resolving composite references
+        bracket_glyphs = set()
+
+        for glyph_name, glyph_bracket_layers in bracket_layer_map.items():
+            glyph = font.glyphs[glyph_name]
+            for (location, reverse), bracket_layers in glyph_bracket_layers.items():
+
+                for missing_master_layer_id in master_ids.difference(
+                    bl.associatedMasterId for bl in bracket_layers
+                ):
+                    master_layer = glyph.layers[missing_master_layer_id]
+                    bracket_layers.append(master_layer)
+                    implicit_bracket_layers.add(id(master_layer))
+
+                bracket_glyphs.add(_bracket_glyph_name(glyph_name, reverse, location))
+
+        for glyph_name, glyph_bracket_layers in bracket_layer_map.items():
+            for (location, reverse), layers in glyph_bracket_layers.items():
+                for layer in layers:
+                    ufo_font = self._sources[
+                        layer.associatedMasterId or layer.layerId
+                    ].font.layers.defaultLayer
+                    ufo_glyph_name = _bracket_glyph_name(glyph_name, reverse, location)
+                    ufo_glyph = ufo_font.newGlyph(ufo_glyph_name)
+                    self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
+                    ufo_glyph.unicodes = []  # Avoid cmap interference
+                    # implicit bracket layers have no distinct name, they are simply
+                    # references to master layers; the empty string is a signal when
+                    # roundtripping back to Glyphs to skip the duplicate layers.
+                    ufo_glyph.lib[GLYPHLIB_PREFIX + "_originalLayerName"] = (
+                        "" if id(layer) in implicit_bracket_layers else layer.name
+                    )
+                    # swap components if base glyph contains matching bracket layers.
+                    for comp in ufo_glyph.components:
+                        bracket_comp_name = _bracket_glyph_name(
+                            comp.baseGlyph, reverse, location
+                        )
+                        if bracket_comp_name in bracket_glyphs:
+                            comp.baseGlyph = bracket_comp_name
 
     # Implementation is split into one file per feature
     from .anchors import to_ufo_propagate_font_anchors, to_ufo_glyph_anchors
@@ -454,6 +503,28 @@ class UFOBuilder(_LoggerMixin):
         to_ufo_layer_user_data,
         to_ufo_node_user_data,
     )
+
+
+def _bracket_glyph_name(glyph_name, reverse, location):
+    return BRACKET_GLYPH_TEMPLATE.format(
+        glyph_name=glyph_name,
+        rev=REVERSE_BRACKET_LABEL if reverse else "",
+        location=location,
+    )
+
+
+def _make_designspace_rule(glyph_names, axis_name, range_min, range_max, reverse=False):
+    rule_name = "BRACKET.{}.{}".format(range_min, range_max)
+    rule = designspaceLib.RuleDescriptor()
+    rule.name = rule_name
+    rule.conditionSets.append(
+        [{"name": axis_name, "minimum": range_min, "maximum": range_max}]
+    )
+    location = range_max if reverse else range_min
+    for glyph_name in glyph_names:
+        sub_glyph_name = _bracket_glyph_name(glyph_name, reverse, location)
+        rule.subs.append((glyph_name, sub_glyph_name))
+    return rule
 
 
 def filter_instances_by_family(instances, family_name=None):
@@ -542,7 +613,7 @@ class GlyphsBuilder(_LoggerMixin):
                 source.font.lib[GLYPH_ORDER_KEY] = [
                     glyph_name
                     for glyph_name in source.font.lib[GLYPH_ORDER_KEY]
-                    if ".BRACKET." not in glyph_name
+                    if not BRACKET_GLYPH_RE.match(glyph_name)
                 ]
 
             self.to_glyphs_font_attributes(source, master, is_initial=(index == 0))
@@ -552,29 +623,35 @@ class GlyphsBuilder(_LoggerMixin):
 
             # First, move free-standing bracket glyphs back to layers to avoid dealing
             # with GSLayer transplantation.
-            for bracket_glyph in [g for g in source.font if ".BRACKET." in g.name]:
-                base_glyph, threshold = bracket_glyph.name.split(".BRACKET.")
-                try:
-                    int(threshold)
-                except ValueError:
-                    raise ValueError(
-                        "Glyph '{}' has malformed bracket layer name. Must be '<glyph "
-                        "name>.BRACKET.<crossover value>'.".format(bracket_glyph)
-                    )
+            for glyph_name in list(source.font.keys()):
+                m = BRACKET_GLYPH_RE.match(glyph_name)
+                if not m:
+                    continue
+                bracket_glyph = source.font[glyph_name]
+                base_glyph, reverse, threshold = m.groups()
                 layer_name = bracket_glyph.lib.get(
-                    GLYPHLIB_PREFIX + "_originalLayerName", "[{}]".format(threshold)
+                    GLYPHLIB_PREFIX + "_originalLayerName",
+                    "{}{}]".format("]" if reverse else "[", threshold),
                 )
-                if layer_name not in source.font.layers:
-                    ufo_layer = source.font.newLayer(layer_name)
-                else:
-                    ufo_layer = source.font.layers[layer_name]
-                bracket_glyph_new = ufo_layer.newGlyph(base_glyph)
-                bracket_glyph_new.copyDataFromGlyph(bracket_glyph)
+                # _originalLayerName is an empty string for 'implicit' bracket layers;
+                # we don't import these since they were copies of master layers.
+                if layer_name:
+                    if layer_name not in source.font.layers:
+                        ufo_layer = source.font.newLayer(layer_name)
+                    else:
+                        ufo_layer = source.font.layers[layer_name]
+                    bracket_glyph_new = ufo_layer.newGlyph(base_glyph)
+                    bracket_glyph_new.copyDataFromGlyph(bracket_glyph)
+
+                    for comp in bracket_glyph_new.components:
+                        m = BRACKET_GLYPH_RE.match(comp.baseGlyph)
+                        if m:
+                            comp.baseGlyph = m.group("glyph_name")
 
                 # Remove all freestanding bracket layer glyphs from all layers.
                 for layer in source.font.layers:
-                    if bracket_glyph.name in layer:
-                        del layer[bracket_glyph.name]
+                    if glyph_name in layer:
+                        del layer[glyph_name]
 
             for layer in _sorted_backgrounds_last(source.font.layers):
                 self.to_glyphs_layer_lib(layer)

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -309,11 +309,8 @@ def test_designspace_generation_bracket_unbalanced_brackets(datadir):
 
     # Delete the "Other [600]" layer to unbalance bracket layers.
     del font.glyphs["x"].layers["C5C3CA59-C2D0-46F6-B5D3-86541DE36ACB"]
-    with pytest.raises(ValueError, match=r"bracket layer\(s\) missing"):
-        to_designspace(font)
 
-    # Delete the other [600] layers to rebalance.
-    del font.glyphs["x"].layers["E729A72D-C6FF-4DDD-ADA1-BB5B6FD7E3DD"]
-    del font.glyphs["x"].layers["F5778F4C-2B04-4030-9D7D-09E3C951C089"]
-    del font.glyphs["x"].layers["24328DA8-2CE1-4D0A-9C91-214ED36F6393"]
-    assert to_designspace(font)
+    designspace = to_designspace(font)
+
+    for source in designspace.sources:
+        assert "x.BRACKET.600" in source.font

--- a/tests/data/BracketTestFont2.glyphs
+++ b/tests/data/BracketTestFont2.glyphs
@@ -1,0 +1,499 @@
+{
+.appVersion = "1230";
+DisplayStrings = (
+ABCDEF
+);
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+},
+{
+Name = Width;
+Tag = wdth;
+}
+);
+}
+);
+date = "2019-07-25 10:20:06 +0000";
+familyName = BracketTestFont2;
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+weightValue = 400;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+weight = Bold;
+weightValue = 700;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2019-07-29 12:07:03 +0000";
+layers = (
+{
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+paths = (
+{
+closed = 1;
+nodes = (
+"50 159 LINE",
+"202 159 LINE",
+"202 311 LINE",
+"50 311 LINE"
+);
+}
+);
+width = 252;
+},
+{
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+paths = (
+{
+closed = 1;
+nodes = (
+"50 77 LINE",
+"366 77 LINE",
+"366 393 LINE",
+"50 393 LINE"
+);
+}
+);
+width = 416;
+},
+{
+associatedMasterId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+layerId = "EC5C925B-6633-4542-A6D0-25A705C07D3A";
+name = "Regular [600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 145 OFFCURVE",
+"248 189 OFFCURVE",
+"248 244 CURVE SMOOTH",
+"248 299 OFFCURVE",
+"204 343 OFFCURVE",
+"149 343 CURVE SMOOTH",
+"94 343 OFFCURVE",
+"50 299 OFFCURVE",
+"50 244 CURVE SMOOTH",
+"50 189 OFFCURVE",
+"94 145 OFFCURVE",
+"149 145 CURVE SMOOTH"
+);
+}
+);
+width = 298;
+},
+{
+associatedMasterId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+layerId = "544838C0-0251-432C-BCBD-A505EB52F9E4";
+name = "Bold [600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"366 46 OFFCURVE",
+"457 137 OFFCURVE",
+"457 250 CURVE SMOOTH",
+"457 362 OFFCURVE",
+"366 453 OFFCURVE",
+"254 453 CURVE SMOOTH",
+"141 453 OFFCURVE",
+"50 362 OFFCURVE",
+"50 250 CURVE SMOOTH",
+"50 137 OFFCURVE",
+"141 46 OFFCURVE",
+"254 46 CURVE SMOOTH"
+);
+}
+);
+width = 507;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = B;
+lastChange = "2019-07-29 12:37:08 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+}
+);
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+width = 252;
+},
+{
+components = (
+{
+name = A;
+}
+);
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+width = 416;
+},
+{
+associatedMasterId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+components = (
+{
+name = A;
+}
+);
+layerId = "D2130EB1-1AC6-4D35-ACCA-0E1EDD0F7195";
+name = "Regular [600]";
+width = 298;
+},
+{
+associatedMasterId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+components = (
+{
+name = A;
+}
+);
+layerId = "82DCA10A-9CCD-47A7-962F-54D1CAFB7990";
+name = "Bold [600]";
+width = 507;
+}
+);
+unicode = 0042;
+},
+{
+glyphname = C;
+lastChange = "2019-07-25 14:16:37 +0000";
+layers = (
+{
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 0 LINE",
+"445 0 LINE",
+"445 616 LINE",
+"134 616 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+paths = (
+{
+closed = 1;
+nodes = (
+"-131 108 LINE",
+"727 108 LINE",
+"727 351 LINE",
+"-131 351 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+layerId = "B27C8969-8000-48F7-9D84-8DC46817C710";
+name = "Bold [600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"294 -60 LINE",
+"364 -60 LINE",
+"812 441 LINE",
+"-178 441 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0043;
+},
+{
+glyphname = D;
+lastChange = "2019-07-25 15:50:01 +0000";
+layers = (
+{
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 0 LINE",
+"445 0 LINE",
+"445 616 LINE",
+"134 616 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+paths = (
+{
+closed = 1;
+nodes = (
+"-131 108 LINE",
+"727 108 LINE",
+"727 351 LINE",
+"-131 351 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+layerId = "3B8EF315-03C2-48B0-99CD-68A39D05BC39";
+name = "Bold ]600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"294 -60 LINE",
+"364 -60 LINE",
+"812 441 LINE",
+"-178 441 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+layerId = "01DB0260-6B98-47ED-85C3-BA953963A053";
+name = "Regular ]600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 0 LINE",
+"445 0 LINE",
+"346 616 LINE",
+"303 616 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0044;
+},
+{
+glyphname = E;
+lastChange = "2019-07-25 17:42:44 +0000";
+layers = (
+{
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+paths = (
+{
+closed = 1;
+nodes = (
+"560 -105 LINE",
+"605 -64 LINE",
+"71 529 LINE",
+"39 500 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+paths = (
+{
+closed = 1;
+nodes = (
+"294 -60 LINE",
+"364 -60 LINE",
+"812 441 LINE",
+"-178 441 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+layerId = "3B8EF315-03C2-48B0-99CD-68A39D05BC39";
+name = "Bold ]570]";
+paths = (
+{
+closed = 1;
+nodes = (
+"-131 108 LINE",
+"727 108 LINE",
+"727 351 LINE",
+"-131 351 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+layerId = "01DB0260-6B98-47ED-85C3-BA953963A053";
+name = "Regular [630]";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 0 LINE",
+"445 0 LINE",
+"445 616 LINE",
+"134 616 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0045;
+},
+{
+glyphname = F;
+lastChange = "2019-07-26 09:56:33 +0000";
+layers = (
+{
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 0 LINE",
+"445 0 LINE",
+"445 616 LINE",
+"134 616 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+paths = (
+{
+closed = 1;
+nodes = (
+"-131 108 LINE",
+"727 108 LINE",
+"727 351 LINE",
+"-131 351 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+layerId = "3B8EF315-03C2-48B0-99CD-68A39D05BC39";
+name = "Bold [630]";
+paths = (
+{
+closed = 1;
+nodes = (
+"294 -60 LINE",
+"364 -60 LINE",
+"812 441 LINE",
+"-178 441 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+layerId = "01DB0260-6B98-47ED-85C3-BA953963A053";
+name = "Regular ]630]";
+paths = (
+{
+closed = 1;
+nodes = (
+"560 -105 LINE",
+"605 -64 LINE",
+"71 529 LINE",
+"39 500 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0046;
+},
+{
+glyphname = space;
+lastChange = "2019-07-25 10:21:14 +0000";
+layers = (
+{
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+width = 600;
+},
+{
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+width = 600;
+}
+);
+unicode = 0020;
+}
+);
+instances = (
+{
+interpolationWeight = 400;
+instanceInterpolations = {
+"AC80BBED-896D-4DAA-A852-C79F9201ACE8" = 1;
+};
+name = Regular;
+},
+{
+interpolationWeight = 600;
+instanceInterpolations = {
+"48798C20-C9A0-4BB9-9A3E-BDB30805D9C9" = 0.66667;
+"AC80BBED-896D-4DAA-A852-C79F9201ACE8" = 0.33333;
+};
+name = SemiBold;
+weightClass = SemiBold;
+},
+{
+interpolationWeight = 700;
+instanceInterpolations = {
+"48798C20-C9A0-4BB9-9A3E-BDB30805D9C9" = 1;
+};
+isBold = 1;
+name = Bold;
+weightClass = Bold;
+},
+{
+interpolationWeight = 500;
+instanceInterpolations = {
+"48798C20-C9A0-4BB9-9A3E-BDB30805D9C9" = 0.33333;
+"AC80BBED-896D-4DAA-A852-C79F9201ACE8" = 0.66667;
+};
+name = Medium;
+weightClass = Medium;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Prompted by https://github.com/googlefonts/glyphsLib/issues/535, I decided to work on completing the bracket layers support started in https://github.com/googlefonts/glyphsLib/issues/468.

This adds support for
- "reverse" bracket layers (e.g. `]500]`) where the location represent the range's maximum, as opposed to regular bracket layers (`[500]`) where value indicates a minimum. 
- what Nikolaus called "unbalanced" bracket layers, i.e. when only some of master layers have explicilty defined bracket layers. The missing master layers are implicitly duplicated as bracket layers.
- composite glyphs with bracket layers that match the definition of their components' bracket layers (#535): the components' base glyphs need to be adjusted accordingly.

The PR is marked as WIP because next week I want to refine and add more specific tests for the new features.