### PR TITLE
 glyphdata: use importlib.resources instead of __file__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - python: 3.6
       env: TOXENV=lint
     - python: 3.6
+    - python: 3.7
+      dist: xenial
 
 cache:
   directories:

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -23,7 +23,7 @@ tripping.
 
 import collections
 import re
-import unicodedata
+from fontTools import unicodedata
 import xml.etree.ElementTree
 
 import fontTools.agl

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -22,14 +22,12 @@ tripping.
 
 
 import collections
-import os
 import re
 import unicodedata
 import xml.etree.ElementTree
 
 import fontTools.agl
 
-import glyphsLib
 
 __all__ = ["get_glyph", "GlyphData"]
 
@@ -96,15 +94,15 @@ def get_glyph(glyph_name, data=None):
     if data is None:
         global GLYPHDATA
         if GLYPHDATA is None:
+            try:
+                from importlib.resources import open_binary
+            except ImportError:
+                # use backport for python < 3.7
+                from importlib_resources import open_binary
+
             GLYPHDATA = GlyphData.from_files(
-                os.path.join(
-                    os.path.dirname(glyphsLib.__file__), "data", "GlyphData.xml"
-                ),
-                os.path.join(
-                    os.path.dirname(glyphsLib.__file__),
-                    "data",
-                    "GlyphData_Ideographs.xml",
-                ),
+                open_binary("glyphsLib.data", "GlyphData.xml"),
+                open_binary("glyphsLib.data", "GlyphData_Ideographs.xml"),
             )
         data = GLYPHDATA
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
     wheel
 install_requires =
     defcon >= 0.3.0
-    fonttools >= 3.24.0
+    fonttools[ufo] >= 3.24.0
     importlib_resources; python_version < '3.7'
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,12 +34,13 @@ setup_requires =
 install_requires =
     defcon >= 0.3.0
     fonttools >= 3.24.0
+    importlib_resources; python_version < '3.7'
 
 [options.extras_require]
 ufo_normalization = ufonormalizer
 
 [options.package_data]
-glyphsLib = data/*.xml, data/GlyphData_LICENSE
+glyphsLib.data = *.xml, GlyphData_LICENSE
 
 [options.packages.find]
 where = Lib


### PR DESCRIPTION
`__file__` attribute is not set on modules when they are embedded in zip files or in self-contained executables such as those built with PyOxidizer.
The recommended way to load resource files (i.e. the ones specified in ``package_data`` in setup.py) is by using the `importlib.resources` API, which was added in Python 3.7.
For < 3.7 we require the backport 'importlib_resources' which is available on PyPI.

Also:
- in glyphdata module we import `unicodedata` to look up categories; we can import `fontTools.unicodedata` which opportunistically uses `unicodedata2` when available (so we can get more up-to-date UCD than the built-in one on older pythons).
- setup.cfg `install_requires` needs to explicitly require `fonttools` with the `[ufo]` extra, which in turn is required by `defcon`...