### PR TITLE
add support for ufoLib2 (in addition to defcon)

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -18,8 +18,6 @@ import collections
 import os
 import logging
 
-import ufoLib2
-
 from glyphsLib.classes import GSFont, __all__ as __all_classes__
 from glyphsLib.classes import *  # noqa
 from glyphsLib.builder import to_ufos, to_designspace, to_glyphs  # noqa
@@ -54,7 +52,7 @@ def load_to_ufos(
     include_instances=False,
     family_name=None,
     propagate_anchors=True,
-    ufo_module=ufoLib2,
+    ufo_module=None,
 ):
     """Load an unpacked .glyphs object to UFO objects."""
 
@@ -86,7 +84,7 @@ def build_masters(
     generate_GDEF=True,
     store_editor_state=True,
     write_skipexportglyphs=False,
-    ufo_module=ufoLib2,
+    ufo_module=None,
 ):
     """Write and return UFOs from the masters and the designspace defined in a
     .glyphs file.

--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -18,6 +18,8 @@ import collections
 import os
 import logging
 
+import ufoLib2
+
 from glyphsLib.classes import GSFont, __all__ as __all_classes__
 from glyphsLib.classes import *  # noqa
 from glyphsLib.builder import to_ufos, to_designspace, to_glyphs  # noqa
@@ -48,7 +50,11 @@ Masters = collections.namedtuple("Masters", ["ufos", "designspace_path"])
 
 
 def load_to_ufos(
-    file_or_path, include_instances=False, family_name=None, propagate_anchors=True
+    file_or_path,
+    include_instances=False,
+    family_name=None,
+    propagate_anchors=True,
+    ufo_module=ufoLib2,
 ):
     """Load an unpacked .glyphs object to UFO objects."""
 
@@ -63,6 +69,7 @@ def load_to_ufos(
         include_instances=include_instances,
         family_name=family_name,
         propagate_anchors=propagate_anchors,
+        ufo_module=ufo_module,
     )
 
 
@@ -79,6 +86,7 @@ def build_masters(
     generate_GDEF=True,
     store_editor_state=True,
     write_skipexportglyphs=False,
+    ufo_module=ufoLib2,
 ):
     """Write and return UFOs from the masters and the designspace defined in a
     .glyphs file.
@@ -114,6 +122,7 @@ def build_masters(
         generate_GDEF=generate_GDEF,
         store_editor_state=store_editor_state,
         write_skipexportglyphs=write_skipexportglyphs,
+        ufo_module=ufo_module,
     )
 
     # Only write full masters to disk. This assumes that layer sources are always part

--- a/Lib/glyphsLib/builder/__init__.py
+++ b/Lib/glyphsLib/builder/__init__.py
@@ -15,7 +15,6 @@
 import logging
 
 from glyphsLib import classes
-import ufoLib2
 
 from .builders import UFOBuilder, GlyphsBuilder
 
@@ -27,7 +26,7 @@ def to_ufos(
     include_instances=False,
     family_name=None,
     propagate_anchors=True,
-    ufo_module=ufoLib2,
+    ufo_module=None,
     minimize_glyphs_diffs=False,
     generate_GDEF=True,
     store_editor_state=True,
@@ -69,7 +68,7 @@ def to_designspace(
     family_name=None,
     instance_dir=None,
     propagate_anchors=True,
-    ufo_module=ufoLib2,
+    ufo_module=None,
     minimize_glyphs_diffs=False,
     generate_GDEF=True,
     store_editor_state=True,
@@ -112,7 +111,12 @@ def to_designspace(
     return builder.designspace
 
 
-def to_glyphs(ufos_or_designspace, glyphs_module=classes, minimize_ufo_diffs=False):
+def to_glyphs(
+    ufos_or_designspace,
+    glyphs_module=classes,
+    ufo_module=None,
+    minimize_ufo_diffs=False,
+):
     """
     Take a list of UFOs or a single DesignspaceDocument with attached UFOs
     and converts it into a GSFont object.
@@ -128,12 +132,14 @@ def to_glyphs(ufos_or_designspace, glyphs_module=classes, minimize_ufo_diffs=Fal
         builder = GlyphsBuilder(
             designspace=ufos_or_designspace,
             glyphs_module=glyphs_module,
+            ufo_module=ufo_module,
             minimize_ufo_diffs=minimize_ufo_diffs,
         )
     else:
         builder = GlyphsBuilder(
             ufos=ufos_or_designspace,
             glyphs_module=glyphs_module,
+            ufo_module=ufo_module,
             minimize_ufo_diffs=minimize_ufo_diffs,
         )
     return builder.font

--- a/Lib/glyphsLib/builder/__init__.py
+++ b/Lib/glyphsLib/builder/__init__.py
@@ -15,7 +15,7 @@
 import logging
 
 from glyphsLib import classes
-import defcon
+import ufoLib2
 
 from .builders import UFOBuilder, GlyphsBuilder
 
@@ -27,7 +27,7 @@ def to_ufos(
     include_instances=False,
     family_name=None,
     propagate_anchors=True,
-    ufo_module=defcon,
+    ufo_module=ufoLib2,
     minimize_glyphs_diffs=False,
     generate_GDEF=True,
     store_editor_state=True,
@@ -69,7 +69,7 @@ def to_designspace(
     family_name=None,
     instance_dir=None,
     propagate_anchors=True,
-    ufo_module=defcon,
+    ufo_module=ufoLib2,
     minimize_glyphs_diffs=False,
     generate_GDEF=True,
     store_editor_state=True,

--- a/Lib/glyphsLib/builder/anchors.py
+++ b/Lib/glyphsLib/builder/anchors.py
@@ -72,7 +72,7 @@ def _propagate_glyph_anchors(self, ufo, parent, processed):
     # we sort propagated anchors to append in a deterministic order
     for name, (x, y) in sorted(to_add.items()):
         anchor_dict = {"name": name, "x": x, "y": y}
-        parent.appendAnchor(glyph.anchorClass(anchorDict=anchor_dict))
+        parent.appendAnchor(anchor_dict)
 
 
 def _get_anchor_data(anchor_data, ufo, components, anchor_name):

--- a/Lib/glyphsLib/builder/blue_values.py
+++ b/Lib/glyphsLib/builder/blue_values.py
@@ -33,8 +33,8 @@ def to_glyphs_blue_values(self, ufo, master):
     """Sets the GSFontMaster alignmentZones from the postscript blue values."""
 
     zones = []
-    blue_values = _pairs(ufo.info.postscriptBlueValues)
-    other_blues = _pairs(ufo.info.postscriptOtherBlues)
+    blue_values = _pairs(ufo.info.postscriptBlueValues or [])
+    other_blues = _pairs(ufo.info.postscriptOtherBlues or [])
     for y1, y2 in blue_values:
         size = y2 - y1
         if y2 == 0:

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -443,11 +443,11 @@ class UFOBuilder(_LoggerMixin):
         for glyph_name, glyph_bracket_layers in bracket_layer_map.items():
             for (location, reverse), layers in glyph_bracket_layers.items():
                 for layer in layers:
-                    ufo_font = self._sources[
+                    ufo_layer = self._sources[
                         layer.associatedMasterId or layer.layerId
                     ].font.layers.defaultLayer
                     ufo_glyph_name = _bracket_glyph_name(glyph_name, reverse, location)
-                    ufo_glyph = ufo_font.newGlyph(ufo_glyph_name)
+                    ufo_glyph = ufo_layer.newGlyph(ufo_glyph_name)
                     self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
                     ufo_glyph.unicodes = []  # Avoid cmap interference
                     # implicit bracket layers have no distinct name, they are simply

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -20,8 +20,6 @@ import os
 import re
 from textwrap import dedent
 
-import ufoLib2
-
 from fontTools import designspaceLib
 
 from glyphsLib import classes, util
@@ -59,7 +57,7 @@ class UFOBuilder(_LoggerMixin):
     def __init__(
         self,
         font,
-        ufo_module=ufoLib2,
+        ufo_module=None,
         designspace_module=designspaceLib,
         family_name=None,
         instance_dir=None,
@@ -76,7 +74,7 @@ class UFOBuilder(_LoggerMixin):
         font -- The GSFont object to transform into UFOs
         ufo_module -- A Python module to use to build UFO objects (you can pass
                       a custom module that has the same classes as ufoLib2 or
-                      defcon to get instances of your own classes)
+                      defcon to get instances of your own classes). Default: ufoLib2
         designspace_module -- A Python module to use to build a Designspace
                               Document. Default is fontTools.designspaceLib.
         family_name -- if provided, the master UFOs will be given this name and
@@ -99,7 +97,12 @@ class UFOBuilder(_LoggerMixin):
                                          "com.schriftgestaltung.Glyphs.Export".
         """
         self.font = font
+
+        if ufo_module is None:
+            import ufoLib2 as ufo_module
+
         self.ufo_module = ufo_module
+
         self.designspace_module = designspace_module
         self.instance_dir = instance_dir
         self.propagate_anchors = propagate_anchors
@@ -534,6 +537,7 @@ class GlyphsBuilder(_LoggerMixin):
         ufos=None,
         designspace=None,
         glyphs_module=classes,
+        ufo_module=None,
         minimize_ufo_diffs=False,
     ):
         """Create a builder that goes from UFOs + designspace to Glyphs.
@@ -557,6 +561,9 @@ class GlyphsBuilder(_LoggerMixin):
                          instances of your own classes, or pass the Glyphs.app
                          module that holds the official classes to import UFOs
                          into Glyphs.app)
+        ufo_module -- A Python module to use to load UFO objects from DS source paths.
+                      You can pass a custom module that has the same classes as ufoLib2
+                      or defcon to get instances of your own classes (default: ufoLib2)
         minimize_ufo_diffs -- set to True to store extra info in .glyphs files
                               in order to get smaller diffs between UFOs
                               when going UFOs->glyphs->UFOs
@@ -567,7 +574,10 @@ class GlyphsBuilder(_LoggerMixin):
         if designspace is not None:
             if ufos:
                 raise NotImplementedError
-            self.designspace = self._valid_designspace(designspace)
+            if ufo_module is None:
+                import ufoLib2 as ufo_module
+
+            self.designspace = self._valid_designspace(designspace, ufo_module)
         elif ufos:
             self.designspace = self._fake_designspace(ufos)
         else:
@@ -678,7 +688,7 @@ class GlyphsBuilder(_LoggerMixin):
 
         return self._font
 
-    def _valid_designspace(self, designspace):
+    def _valid_designspace(self, designspace, ufo_module):
         """Make sure that the user-provided designspace has loaded fonts and
         that names are the same as those from the UFOs.
         """
@@ -690,11 +700,11 @@ class GlyphsBuilder(_LoggerMixin):
             if not hasattr(source, "font") or source.font is None:
                 if source.path:
                     # FIXME: (jany) consider not changing the caller's objects
-                    source.font = ufoLib2.Font.open(source.path)
+                    source.font = util.open_ufo(source.path, ufo_module.Font)
                 else:
                     dirname = os.path.dirname(designspace.path)
                     ufo_path = os.path.join(dirname, source.filename)
-                    source.font = ufoLib2.Font.open(ufo_path)
+                    source.font = util.open_ufo(ufo_path, ufo_module.Font)
             if source.location is None:
                 source.location = {}
             for name in ("familyName", "styleName"):

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -20,7 +20,7 @@ import os
 import re
 from textwrap import dedent
 
-import defcon
+import ufoLib2
 
 from fontTools import designspaceLib
 
@@ -59,7 +59,7 @@ class UFOBuilder(_LoggerMixin):
     def __init__(
         self,
         font,
-        ufo_module=defcon,
+        ufo_module=ufoLib2,
         designspace_module=designspaceLib,
         family_name=None,
         instance_dir=None,
@@ -75,7 +75,7 @@ class UFOBuilder(_LoggerMixin):
         Keyword arguments:
         font -- The GSFont object to transform into UFOs
         ufo_module -- A Python module to use to build UFO objects (you can pass
-                      a custom module that has the same classes as the official
+                      a custom module that has the same classes as ufoLib2 or
                       defcon to get instances of your own classes)
         designspace_module -- A Python module to use to build a Designspace
                               Document. Default is fontTools.designspaceLib.
@@ -690,11 +690,11 @@ class GlyphsBuilder(_LoggerMixin):
             if not hasattr(source, "font") or source.font is None:
                 if source.path:
                     # FIXME: (jany) consider not changing the caller's objects
-                    source.font = defcon.Font(source.path)
+                    source.font = ufoLib2.Font.open(source.path)
                 else:
                     dirname = os.path.dirname(designspace.path)
                     ufo_path = os.path.join(dirname, source.filename)
-                    source.font = defcon.Font(ufo_path)
+                    source.font = ufoLib2.Font.open(ufo_path)
             if source.location is None:
                 source.location = {}
             for name in ("familyName", "styleName"):
@@ -741,7 +741,7 @@ class GlyphsBuilder(_LoggerMixin):
                 if user_loc is not None:
                     design_loc = class_to_value(axis_def.tag, user_loc)
                     mapping.append((user_loc, design_loc))
-                    ufo_to_location[ufo][axis_def.name] = design_loc
+                    ufo_to_location[id(ufo)][axis_def.name] = design_loc
 
             mapping = sorted(set(mapping))
             if len(mapping) > 1:
@@ -760,7 +760,7 @@ class GlyphsBuilder(_LoggerMixin):
             source.styleName = ufo.info.styleName
             # source.name = '%s %s' % (source.familyName, source.styleName)
             source.path = ufo.path
-            source.location = ufo_to_location[ufo]
+            source.location = ufo_to_location[id(ufo)]
             designspace.addSource(source)
 
         # UFO-level skip list lib keys are usually ignored, except when we don't have a

--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -348,10 +348,6 @@ GLYPHS_UFO_CUSTOM_PARAMS_NO_SHORT_NAME = (
     "openTypeHeadFlags",
     "openTypeNameVersion",
     "openTypeNameUniqueID",
-    # TODO: (jany) look at
-    # https://forum.glyphsapp.com/t/name-table-entry-win-id4/3811/10
-    # Use Name Table Entry for the next param
-    "openTypeNameRecords",
     "openTypeOS2FamilyClass",
     "postscriptFontName",
     "postscriptFullName",
@@ -483,6 +479,24 @@ register(
         ufo_name="openTypeGaspRangeRecords",
         value_to_ufo=to_ufo_gasp_table,
         value_to_glyphs=to_glyphs_gasp_table,
+    )
+)
+
+# TODO: (jany) look at
+# https://forum.glyphsapp.com/t/name-table-entry-win-id4/3811/10
+# Use Name Table Entry for the next param
+
+
+def to_glyphs_opentype_name_records(value):
+    # In ufoLib2, font.info.openTypeNameRecords is a list of NameRecord objects,
+    # while in defcon it is a list of dicts; reduce both to dicts.
+    return [dict(r) for r in value]
+
+
+register(
+    ParamHandler(
+        glyphs_name="openTypeNameRecords",
+        value_to_glyphs=to_glyphs_opentype_name_records,
     )
 )
 

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -113,7 +113,6 @@ def _to_ufo_features(font, ufo=None, generate_GDEF=False, skip_export_glyphs=Non
             )
         gdef_str = _build_gdef(ufo, skip_export_glyphs)
 
-    # make sure feature text is a unicode string, for defcon
     full_text = (
         "\n\n".join(filter(None, [class_str, prefix_str, fea_str, gdef_str])) + "\n"
     )

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -15,8 +15,6 @@
 
 import logging
 
-from defcon import Color  # noqa
-
 import glyphsLib.glyphdata
 from .common import to_ufo_time, from_loose_ufo_time
 from .constants import GLYPHLIB_PREFIX, GLYPHS_COLORS, PUBLIC_PREFIX

--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -30,8 +30,6 @@ from .axes import (
 )
 from .custom_params import to_ufo_custom_params
 
-import ufoLib2
-
 EXPORT_KEY = GLYPHS_PREFIX + "export"
 WIDTH_KEY = GLYPHS_PREFIX + "width"
 WEIGHT_KEY = GLYPHS_PREFIX + "weight"
@@ -329,7 +327,7 @@ def set_width_class(ufo, designspace, instance):
     _set_class_from_instance(ufo, designspace, instance, "wdth")
 
 
-def apply_instance_data(designspace, include_filenames=None, Font=ufoLib2.Font):
+def apply_instance_data(designspace, include_filenames=None, Font=None):
     """Open UFO instances referenced by designspace, apply Glyphs instance
     data if present, re-save UFOs and return updated UFO Font objects.
 
@@ -339,12 +337,18 @@ def apply_instance_data(designspace, include_filenames=None, Font=ufoLib2.Font):
         include_filenames: optional set of instance filenames (relative to
             the designspace path) to be included. By default all instaces are
             processed.
-        Font: a defcon-like Font class used to load the UFO (default: ufoLib2.Font).
+        Font: a callable(path: str) -> Font, used to load a UFO, such as
+            defcon.Font class (default: ufoLib2.Font.open).
     Returns:
         List of opened and updated instance UFOs.
     """
     from fontTools.designspaceLib import DesignSpaceDocument
     from os.path import normcase, normpath
+
+    if Font is None:
+        import ufoLib2
+
+        Font = ufoLib2.Font.open
 
     if hasattr(designspace, "__fspath__"):
         designspace = designspace.__fspath__()
@@ -370,11 +374,7 @@ def apply_instance_data(designspace, include_filenames=None, Font=ufoLib2.Font):
         # fontmake <= 1.4.0 compares the ufo paths returned from this function
         # to the keys of a dict of designspace locations that have been passed
         # through normpath (but not normcase). We do the same.
-        ufo_path = normpath(os.path.join(basedir, fname))
-        try:
-            ufo = Font.open(ufo_path)  # ufoLib2
-        except AttributeError:
-            ufo = Font(ufo_path)  # defcon, fontParts, etc.
+        ufo = Font(normpath(os.path.join(basedir, fname)))
 
         apply_instance_data_to_ufo(ufo, designspace_instance, designspace)
 

--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -30,7 +30,7 @@ from .axes import (
 )
 from .custom_params import to_ufo_custom_params
 
-import defcon
+import ufoLib2
 
 EXPORT_KEY = GLYPHS_PREFIX + "export"
 WIDTH_KEY = GLYPHS_PREFIX + "width"
@@ -329,7 +329,7 @@ def set_width_class(ufo, designspace, instance):
     _set_class_from_instance(ufo, designspace, instance, "wdth")
 
 
-def apply_instance_data(designspace, include_filenames=None, Font=defcon.Font):
+def apply_instance_data(designspace, include_filenames=None, Font=ufoLib2.Font):
     """Open UFO instances referenced by designspace, apply Glyphs instance
     data if present, re-save UFOs and return updated UFO Font objects.
 
@@ -339,7 +339,7 @@ def apply_instance_data(designspace, include_filenames=None, Font=defcon.Font):
         include_filenames: optional set of instance filenames (relative to
             the designspace path) to be included. By default all instaces are
             processed.
-        Font: the class used to load the UFO (default: defcon.Font).
+        Font: a defcon-like Font class used to load the UFO (default: ufoLib2.Font).
     Returns:
         List of opened and updated instance UFOs.
     """
@@ -370,7 +370,11 @@ def apply_instance_data(designspace, include_filenames=None, Font=defcon.Font):
         # fontmake <= 1.4.0 compares the ufo paths returned from this function
         # to the keys of a dict of designspace locations that have been passed
         # through normpath (but not normcase). We do the same.
-        ufo = Font(normpath(os.path.join(basedir, fname)))
+        ufo_path = normpath(os.path.join(basedir, fname))
+        try:
+            ufo = Font.open(ufo_path)  # ufoLib2
+        except AttributeError:
+            ufo = Font(ufo_path)  # defcon, fontParts, etc.
 
         apply_instance_data_to_ufo(ufo, designspace_instance, designspace)
 

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -37,7 +37,6 @@ def to_ufo_layer(self, glyph, layer):
 
 
 def to_ufo_background_layer(self, ufo_glyph):
-    font = self.font
     if ufo_glyph.layer.name != "public.default":
         layer_name = ufo_glyph.layer.name + ".background"
     else:

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -36,17 +36,17 @@ def to_ufo_layer(self, glyph, layer):
     return ufo_layer
 
 
-def to_ufo_background_layer(self, ufo_glyph):
-    if ufo_glyph.layer.name != "public.default":
-        layer_name = ufo_glyph.layer.name + ".background"
-    else:
+def to_ufo_background_layer(self, layer):
+    ufo_font = self._sources[layer.associatedMasterId or layer.layerId].font
+    if layer.associatedMasterId == layer.layerId:
         layer_name = "public.background"
-    font = ufo_glyph.font
-    if layer_name not in font.layers:
-        ufo_layer = font.newLayer(layer_name)
     else:
-        ufo_layer = font.layers[layer_name]
-    return ufo_layer
+        layer_name = layer.name + ".background"
+    if layer_name not in ufo_font.layers:
+        background_layer = ufo_font.newLayer(layer_name)
+    else:
+        background_layer = ufo_font.layers[layer_name]
+    return background_layer
 
 
 def _layer_order_in_glyph(self, layer):

--- a/Lib/glyphsLib/cli.py
+++ b/Lib/glyphsLib/cli.py
@@ -58,6 +58,16 @@ def main(args=None):
             "file."
         ),
     )
+    parser_glyphs2ufo.add_argument(
+        "--ufo-module",
+        metavar="UFO_MODULE",
+        choices=("ufoLib2", "defcon"),
+        default="ufoLib2",
+        help=(
+            "Select the default library for writing UFOs. Choose between: %(choices)s "
+            "(default: %(default)s)"
+        ),
+    )
     group = parser_glyphs2ufo.add_argument_group(
         "Roundtripping between Glyphs and UFOs"
     )
@@ -197,6 +207,7 @@ def glyphs2ufo(options):
         generate_GDEF=options.generate_GDEF,
         store_editor_state=not options.no_store_editor_state,
         write_skipexportglyphs=options.write_public_skip_export_glyphs,
+        ufo_module=__import__(options.ufo_module),
     )
 
 

--- a/Lib/glyphsLib/cli.py
+++ b/Lib/glyphsLib/cli.py
@@ -210,7 +210,7 @@ def _glyphs2ufo_entry_point():
 def ufo2glyphs(options):
     """Convert one designspace file or one or more UFOs to a Glyphs.app source file."""
     import fontTools.designspaceLib
-    import defcon
+    import ufoLib2
 
     sources = options.designspace_file_or_UFOs
     designspace_file = None
@@ -224,7 +224,7 @@ def ufo2glyphs(options):
         designspace.read(designspace_file)
         object_to_read = designspace
     elif all(source.endswith(".ufo") and os.path.isdir(source) for source in sources):
-        ufos = [defcon.Font(source) for source in sources]
+        ufos = [ufoLib2.Font.open(source) for source in sources]
         ufos.sort(
             key=lambda ufo: [  # Order the masters by weight and width
                 ufo.info.openTypeOS2WeightClass or 400,

--- a/Lib/glyphsLib/util.py
+++ b/Lib/glyphsLib/util.py
@@ -33,6 +33,13 @@ def build_ufo_path(out_dir, family_name, style_name):
     )
 
 
+def open_ufo(path, font_class, **kwargs):
+    try:
+        return font_class.open(path, **kwargs)  # ufoLib2
+    except AttributeError:
+        return font_class(path, **kwargs)  # defcon, fontParts, etc.
+
+
 def write_ufo(ufo, out_dir):
     """Write a UFO."""
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,10 +14,10 @@ more-itertools==7.2.0     # via pytest, zipp
 packaging==19.2           # via pytest
 pluggy==0.13.0            # via pytest
 py==1.8.0                 # via pytest
-pyparsing==2.4.2          # via packaging
+pyparsing==2.4.4          # via packaging
 pytest-randomly==3.1.0
 pytest==5.2.2
-six==1.12.0               # via packaging, xmldiff
+six==1.13.0               # via packaging, xmldiff
 ufonormalizer==0.3.6
 wcwidth==0.1.7            # via pytest
 xmldiff==2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,14 @@
 #    pip-compile setup.py
 #
 appdirs==1.4.3            # via fs
+attrs==19.3.0             # via ufolib2
 defcon==0.6.0
-fonttools[ufo,unicode]==3.40.0
+fonttools[ufo,unicode]==4.0.2
 fs==2.4.11                # via fonttools
-pytz==2019.2              # via fs
-six==1.12.0               # via fs
+pytz==2019.3              # via fs
+six==1.13.0               # via fs
+ufolib2==0.5.0
+unicodedata2==12.1.0      # via fonttools
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via fs
+# setuptools==41.6.0        # via fs

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ setup_requires =
     setuptools_scm
     wheel
 install_requires =
+    ufoLib2 >= 0.5.0
     defcon >= 0.3.0
     fonttools[ufo] >= 3.24.0
     importlib_resources; python_version < '3.7'

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1458,7 +1458,7 @@ class GlyphOrderTestBase(object):
         self.ufo.newGlyph("f")
 
     def from_glyphs(self):
-        builder = UFOBuilder(self.font)
+        builder = UFOBuilder(self.font, ufo_module=self.ufo_module)
         return next(iter(builder.masters))
 
     def from_ufo(self):

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -22,7 +22,8 @@ import os
 import shutil
 
 import glyphsLib
-from defcon import Font
+import defcon
+import ufoLib2
 from fontTools.misc.loggingTools import CapturingLogHandler
 from glyphsLib import builder
 from glyphsLib.classes import (
@@ -37,7 +38,7 @@ from glyphsLib.classes import (
 )
 from glyphsLib.types import Point
 
-from glyphsLib.builder import to_ufos, to_glyphs, to_designspace
+from glyphsLib.builder import to_glyphs
 from glyphsLib.builder.builders import UFOBuilder, GlyphsBuilder
 from glyphsLib.builder.paths import to_ufo_paths
 from glyphsLib.builder.names import build_stylemap_names
@@ -55,6 +56,7 @@ from ..classes_test import (
     add_anchor,
     add_component,
 )
+from ..test_helpers import ParametrizedUfoModuleTestMixin
 
 
 class BuildStyleMapNamesTest(unittest.TestCase):
@@ -337,14 +339,14 @@ class ParseGlyphsFilterTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
-class ToUfosTest(unittest.TestCase):
+class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
     def test_minimal_data(self):
         """Test the minimal data that must be provided to generate UFOs, and in
         some cases that additional redundant data is not set."""
 
         font = generate_minimal_font()
         family_name = font.familyName
-        ufos = to_ufos(font)
+        ufos = self.to_ufos(font)
         self.assertEqual(len(ufos), 1)
 
         ufo = ufos[0]
@@ -363,7 +365,7 @@ class ToUfosTest(unittest.TestCase):
         font = generate_minimal_font()
         font.appVersion = "0"
         with CapturingLogHandler(builder.logger, "WARNING") as captor:
-            to_ufos(font)
+            self.to_ufos(font)
         self.assertEqual(
             len([r for r in captor.records if "outdated version" in r.msg]), 1
         )
@@ -396,7 +398,7 @@ class ToUfosTest(unittest.TestCase):
             )
         }
 
-        ufos = to_ufos(font)
+        ufos = self.to_ufos(font)
         ufo = ufos[0]
 
         self.assertEqual(ufo.kerning["public.kern1.A", "public.kern2.V"], -250)
@@ -424,7 +426,7 @@ class ToUfosTest(unittest.TestCase):
             for n, x, y in component_data:
                 add_component(font, name, n, (1, 0, 0, 1, x, y))
 
-        ufos = to_ufos(font)
+        ufos = self.to_ufos(font)
         ufo = ufos[0]
 
         glyph = ufo["dadDotbelow"]
@@ -465,12 +467,12 @@ class ToUfosTest(unittest.TestCase):
                 add_component(font, name, n, (1, 0, 0, 1, x, y))
 
         # We just want the call to `to_ufos` to not crash
-        assert to_ufos(font)
+        assert self.to_ufos(font)
 
     def test_postscript_name_from_data(self):
         font = generate_minimal_font()
         add_glyph(font, "foo")["production"] = "f_o_o.alt1"
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         postscriptNames = ufo.lib.get("public.postscriptNames")
         self.assertEqual(postscriptNames, {"foo": "f_o_o.alt1"})
 
@@ -482,7 +484,7 @@ class ToUfosTest(unittest.TestCase):
         add_glyph(font, "foobar")
         # in GlyphData with a 'production' name
         add_glyph(font, "C-fraktur")
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         postscriptNames = ufo.lib.get("public.postscriptNames")
         self.assertEqual(postscriptNames, {"C-fraktur": "uni212D"})
 
@@ -490,7 +492,7 @@ class ToUfosTest(unittest.TestCase):
         font = generate_minimal_font()
         add_glyph(font, "foo")["category"] = "Mark"
         add_glyph(font, "bar")
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         category_key = GLYPHLIB_PREFIX + "category"
         self.assertEqual(ufo["foo"].lib.get(category_key), "Mark")
         self.assertFalse(category_key in ufo["bar"].lib)
@@ -499,7 +501,7 @@ class ToUfosTest(unittest.TestCase):
         font = generate_minimal_font()
         add_glyph(font, "foo")["subCategory"] = "Nonspacing"
         add_glyph(font, "bar")
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         subCategory_key = GLYPHLIB_PREFIX + "subCategory"
         self.assertEqual(ufo["foo"].lib.get(subCategory_key), "Nonspacing")
         self.assertFalse(subCategory_key in ufo["bar"].lib)
@@ -519,7 +521,7 @@ class ToUfosTest(unittest.TestCase):
         bar.subCategory = "Nonspacing"
         bar.layers[0].width = 0
 
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
 
         originalWidth_key = GLYPHLIB_PREFIX + "originalWidth"
         self.assertEqual(ufo["dieresiscomb"].width, 0)
@@ -549,7 +551,7 @@ class ToUfosTest(unittest.TestCase):
         add_anchor(font, "t_e_s_t.alt", "caret_1", 200, 0)
         add_anchor(font, "t_e_s_t.alt", "caret_2", 400, 0)
         add_anchor(font, "t_e_s_t.alt", "caret_3", 600, 0)
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(
             ufo.features.text.splitlines(),
             [
@@ -570,30 +572,30 @@ class ToUfosTest(unittest.TestCase):
         font = generate_minimal_font()
         add_glyph(font, "A.alt")
         add_anchor(font, "A.alt", "top", 400, 1000)
-        self.assertIn("[A.alt], # Base", to_ufos(font)[0].features.text)
+        self.assertIn("[A.alt], # Base", self.to_ufos(font)[0].features.text)
 
     def test_GDEF_base_with_nonattaching_anchor(self):
         font = generate_minimal_font()
         add_glyph(font, "A.alt")
         add_anchor(font, "A.alt", "_top", 400, 1000)
-        self.assertEqual("", to_ufos(font)[0].features.text)
+        self.assertEqual("", self.to_ufos(font)[0].features.text)
 
     def test_GDEF_ligature_with_attaching_anchor(self):
         font = generate_minimal_font()
         add_glyph(font, "fi")
         add_anchor(font, "fi", "top", 400, 1000)
-        self.assertIn("[fi], # Liga", to_ufos(font)[0].features.text)
+        self.assertIn("[fi], # Liga", self.to_ufos(font)[0].features.text)
 
     def test_GDEF_ligature_with_nonattaching_anchor(self):
         font = generate_minimal_font()
         add_glyph(font, "fi")
         add_anchor(font, "fi", "_top", 400, 1000)
-        self.assertEqual("", to_ufos(font)[0].features.text)
+        self.assertEqual("", self.to_ufos(font)[0].features.text)
 
     def test_GDEF_mark(self):
         font = generate_minimal_font()
         add_glyph(font, "eeMatra-gurmukhi")
-        self.assertIn("[eeMatra-gurmukhi], # Mark", to_ufos(font)[0].features.text)
+        self.assertIn("[eeMatra-gurmukhi], # Mark", self.to_ufos(font)[0].features.text)
 
     def test_GDEF_fractional_caret_position(self):
         # Some Glyphs sources happen to contain fractional caret positions.
@@ -602,7 +604,7 @@ class ToUfosTest(unittest.TestCase):
         font = generate_minimal_font()
         add_glyph(font, "fi")
         add_anchor(font, "fi", "caret_1", 499.9876, 0)
-        self.assertIn("LigatureCaretByPos fi 500;", to_ufos(font)[0].features.text)
+        self.assertIn("LigatureCaretByPos fi 500;", self.to_ufos(font)[0].features.text)
 
     def test_GDEF_custom_category_subCategory(self):
         font = generate_minimal_font()
@@ -612,7 +614,7 @@ class ToUfosTest(unittest.TestCase):
         bar["category"], bar["subCategory"] = "Mark", "Nonspacing"
         baz = add_glyph(font, "baz")
         baz["category"], baz["subCategory"] = "Mark", "Spacing Combining"
-        features = to_ufos(font)[0].features.text
+        features = self.to_ufos(font)[0].features.text
         self.assertIn("[foo], # Liga", features)
         self.assertIn("[bar baz], # Mark", features)
 
@@ -631,7 +633,7 @@ class ToUfosTest(unittest.TestCase):
 
         font = generate_minimal_font()
         font.masters[0].alignmentZones = data_in
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
 
         self.assertEqual(ufo.info.postscriptBlueValues, expected_blue_values)
         self.assertEqual(ufo.info.postscriptOtherBlues, expected_other_blues)
@@ -639,7 +641,7 @@ class ToUfosTest(unittest.TestCase):
     def test_missing_date(self):
         font = generate_minimal_font()
         font.date = None
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertIsNone(ufo.info.openTypeHeadCreated)
 
     def test_variation_font_origin(self):
@@ -648,7 +650,7 @@ class ToUfosTest(unittest.TestCase):
         value = "Light"
         font.customParameters[name] = value
 
-        ufos, instances = to_ufos(font, include_instances=True)
+        ufos, instances = self.to_ufos(font, include_instances=True)
 
         key = FONT_CUSTOM_PARAM_PREFIX + name
         for ufo in ufos:
@@ -669,7 +671,7 @@ class ToUfosTest(unittest.TestCase):
         font.instances = [generate_instance_from_dict(i) for i in instances_list]
 
         # 'family_name' defaults to None
-        ufos, instance_data = to_ufos(font, include_instances=True)
+        ufos, instance_data = self.to_ufos(font, include_instances=True)
         instances = instance_data["data"]
 
         # all instances are included, both with/without 'familyName' parameter
@@ -696,7 +698,7 @@ class ToUfosTest(unittest.TestCase):
         font.instances = [generate_instance_from_dict(i) for i in instances_list]
         # 'MyFont' is the source family name, as returned from
         # 'generate_minimal_data'
-        ufos, instance_data = to_ufos(
+        ufos, instance_data = self.to_ufos(
             font, include_instances=True, family_name="MyFont"
         )
         instances = instance_data["data"]
@@ -721,7 +723,7 @@ class ToUfosTest(unittest.TestCase):
             },
         ]
         font.instances = [generate_instance_from_dict(i) for i in instances_list]
-        ufos, instance_data = to_ufos(
+        ufos, instance_data = self.to_ufos(
             font, include_instances=True, family_name="CustomFamily"
         )
         instances = instance_data["data"]
@@ -738,41 +740,41 @@ class ToUfosTest(unittest.TestCase):
 
     def test_lib_no_weight(self):
         font = generate_minimal_font()
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(ufo.lib[GLYPHS_PREFIX + "weight"], "Regular")
 
     def test_lib_weight(self):
         font = generate_minimal_font()
         font.masters[0].weight = "Bold"
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(ufo.lib[GLYPHS_PREFIX + "weight"], "Bold")
 
     def test_lib_no_width(self):
         font = generate_minimal_font()
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(ufo.lib[GLYPHS_PREFIX + "width"], "Regular")
 
     def test_lib_width(self):
         font = generate_minimal_font()
         font.masters[0].width = "Condensed"
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(ufo.lib[GLYPHS_PREFIX + "width"], "Condensed")
 
     def test_lib_no_custom(self):
         font = generate_minimal_font()
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertFalse(GLYPHS_PREFIX + "customName" in ufo.lib)
 
     def test_lib_custom(self):
         font = generate_minimal_font()
         font.masters[0].customName = "FooBar"
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(ufo.lib[GLYPHS_PREFIX + "customName"], "FooBar")
 
     def test_coerce_to_bool(self):
         font = generate_minimal_font()
         font.customParameters["Disable Last Change"] = "Truthy"
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(True, ufo.lib[FONT_CUSTOM_PARAM_PREFIX + "disablesLastChange"])
 
     def _run_guideline_test(self, data_in, expected):
@@ -791,8 +793,8 @@ class ToUfosTest(unittest.TestCase):
             guide.angle = guide_data["angle"]
             layer.guides.append(guide)
         glyph.layers.append(layer)
-        ufo = to_ufos(font)[0]
-        self.assertEqual(ufo["a"].guidelines, expected)
+        ufo = self.to_ufos(font)[0]
+        self.assertEqual([dict(g) for g in ufo["a"].guidelines], expected)
 
     def test_set_guidelines(self):
         """Test that guidelines are set correctly."""
@@ -824,7 +826,7 @@ class ToUfosTest(unittest.TestCase):
         sublayer.width = 0
         sublayer.name = "SubLayer"
         glyph.layers.append(sublayer)
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual([l.name for l in ufo.layers], ["public.default", "SubLayer"])
 
     def test_glyph_lib_Export(self):
@@ -832,8 +834,8 @@ class ToUfosTest(unittest.TestCase):
         glyph = add_glyph(font, "a")
         self.assertEqual(glyph.export, True)
 
-        ufo = to_ufos(font)[0]
-        ds = to_designspace(font)
+        ufo = self.to_ufos(font)[0]
+        ds = self.to_designspace(font)
 
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo["a"].lib)
         self.assertNotIn("public.skipExportGlyphs", ufo.lib)
@@ -845,8 +847,8 @@ class ToUfosTest(unittest.TestCase):
         font2.glyphs["a"].export = False
 
         # Test write_skipexportglyphs=True
-        ufo = to_ufos(font2, write_skipexportglyphs=True)[0]
-        ds = to_designspace(font2, write_skipexportglyphs=True)
+        ufo = self.to_ufos(font2, write_skipexportglyphs=True)[0]
+        ds = self.to_designspace(font2, write_skipexportglyphs=True)
 
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo["a"].lib)
         self.assertEqual(ufo.lib["public.skipExportGlyphs"], ["a"])
@@ -856,8 +858,8 @@ class ToUfosTest(unittest.TestCase):
         self.assertEqual(font3.glyphs["a"].export, False)
 
         # Test write_skipexportglyphs=False
-        ufo = to_ufos(font2, write_skipexportglyphs=False)[0]
-        ds = to_designspace(font2, write_skipexportglyphs=False)
+        ufo = self.to_ufos(font2, write_skipexportglyphs=False)[0]
+        ds = self.to_designspace(font2, write_skipexportglyphs=False)
 
         self.assertFalse(ufo["a"].lib[GLYPHLIB_PREFIX + "Export"])
         self.assertNotIn("public.skipExportGlyphs", ufo.lib)
@@ -872,7 +874,7 @@ class ToUfosTest(unittest.TestCase):
         add_glyph(font, "b")
         add_glyph(font, "c")
         add_glyph(font, "d")
-        ds = to_designspace(font, write_skipexportglyphs=True)
+        ds = self.to_designspace(font, write_skipexportglyphs=True)
         ufo = ds.sources[0].font
 
         ufo["a"].lib[GLYPHLIB_PREFIX + "Export"] = False
@@ -881,7 +883,7 @@ class ToUfosTest(unittest.TestCase):
 
         font2 = to_glyphs(ds)
 
-        ds2 = to_designspace(font2, write_skipexportglyphs=True)
+        ds2 = self.to_designspace(font2, write_skipexportglyphs=True)
         ufo2 = ds2.sources[0].font
 
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["a"].lib)
@@ -897,7 +899,7 @@ class ToUfosTest(unittest.TestCase):
         self.assertEqual(font3.glyphs["c"].export, False)
         self.assertEqual(font3.glyphs["d"].export, True)
 
-        ufos3 = to_ufos(font3, write_skipexportglyphs=True)
+        ufos3 = self.to_ufos(font3, write_skipexportglyphs=True)
         ufo3 = ufos3[0]
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo3["a"].lib)
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo3["b"].lib)
@@ -911,7 +913,7 @@ class ToUfosTest(unittest.TestCase):
         add_glyph(font, "b")
         add_glyph(font, "c")
         add_glyph(font, "d")
-        ds = to_designspace(font, write_skipexportglyphs=False)
+        ds = self.to_designspace(font, write_skipexportglyphs=False)
         ufo = ds.sources[0].font
 
         ufo["a"].lib[GLYPHLIB_PREFIX + "Export"] = False
@@ -920,7 +922,7 @@ class ToUfosTest(unittest.TestCase):
 
         font2 = to_glyphs(ds)
 
-        ds2 = to_designspace(font2, write_skipexportglyphs=False)
+        ds2 = self.to_designspace(font2, write_skipexportglyphs=False)
         ufo2 = ds2.sources[0].font
 
         self.assertFalse(ufo2["a"].lib[GLYPHLIB_PREFIX + "Export"])
@@ -936,7 +938,7 @@ class ToUfosTest(unittest.TestCase):
         self.assertEqual(font3.glyphs["c"].export, False)
         self.assertEqual(font3.glyphs["d"].export, True)
 
-        ufos3 = to_ufos(font3, write_skipexportglyphs=False)
+        ufos3 = self.to_ufos(font3, write_skipexportglyphs=False)
         ufo3 = ufos3[0]
         self.assertFalse(ufo3["a"].lib[GLYPHLIB_PREFIX + "Export"])
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo3["b"].lib)
@@ -956,14 +958,14 @@ class ToUfosTest(unittest.TestCase):
         add_glyph(font, "d")
         add_anchor(font, "d", "top", 100, 100)
 
-        ds = to_designspace(font, write_skipexportglyphs=True)
+        ds = self.to_designspace(font, write_skipexportglyphs=True)
         ufo = ds.sources[0].font
         self.assertIn(
             "GlyphClassDef[d]", ufo.features.text.replace("\n", "").replace(" ", "")
         )
 
         font.glyphs["d"].export = False
-        ds2 = to_designspace(font, write_skipexportglyphs=True)
+        ds2 = self.to_designspace(font, write_skipexportglyphs=True)
         ufo2 = ds2.sources[0].font
         self.assertEqual(ufo2.features.text, "")
 
@@ -978,12 +980,12 @@ class ToUfosTest(unittest.TestCase):
         font.masters.append(master)
         add_glyph(font, "a")
         add_glyph(font, "b")
-        ds = to_designspace(font, write_skipexportglyphs=True)
+        ds = self.to_designspace(font, write_skipexportglyphs=True)
 
         ufos = [source.font for source in ds.sources]
 
         font2 = to_glyphs(ufos)
-        ds2 = to_designspace(font2, write_skipexportglyphs=True)
+        ds2 = self.to_designspace(font2, write_skipexportglyphs=True)
         self.assertNotIn("public.skipExportGlyphs", ds2.lib)
 
         ufos[0].lib["public.skipExportGlyphs"] = ["a"]
@@ -1003,7 +1005,7 @@ class ToUfosTest(unittest.TestCase):
         glyph.rightMetricsKey = "z"
         assert glyph.widthMetricsKey is None
 
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
 
         self.assertEqual(ufo["x"].lib[GLYPHLIB_PREFIX + "glyph.leftMetricsKey"], "y")
         self.assertEqual(ufo["x"].lib[GLYPHLIB_PREFIX + "glyph.rightMetricsKey"], "z")
@@ -1023,7 +1025,7 @@ class ToUfosTest(unittest.TestCase):
         self.assertEqual(comp1.locked, False)
         self.assertEqual(comp1.smartComponentValues, {})
 
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
 
         # all components have deault values, no lib key is written
         self.assertNotIn(GLYPHS_PREFIX + "componentsAlignment", ufo["c"].lib)
@@ -1033,7 +1035,7 @@ class ToUfosTest(unittest.TestCase):
         comp2.alignment = -1
         comp1.locked = True
         comp1.smartComponentValues["height"] = 0
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
 
         # if any component has a non-default alignment/locked values, write
         # list of values for all of them
@@ -1060,7 +1062,7 @@ class ToUfosTest(unittest.TestCase):
         assert master.name == "Thin"
         assert master.weight == "Light"
 
-        ufo, = to_ufos(font)
+        ufo, = self.to_ufos(font)
         font_rt = to_glyphs([ufo])
         master_rt = font_rt.masters[0]
 
@@ -1082,20 +1084,20 @@ class ToUfosTest(unittest.TestCase):
 
     def test_italic_angle(self):
         font = generate_minimal_font()
-        ufo, = to_ufos(font)
+        ufo, = self.to_ufos(font)
 
         ufo.info.italicAngle = 1
-        ufo_rt, = to_ufos(to_glyphs([ufo]))
+        ufo_rt, = self.to_ufos(to_glyphs([ufo]))
         assert ufo_rt.info.italicAngle == 1
 
         ufo.info.italicAngle = 1.5
-        ufo_rt, = to_ufos(to_glyphs([ufo]))
+        ufo_rt, = self.to_ufos(to_glyphs([ufo]))
         assert ufo_rt.info.italicAngle == 1.5
 
         ufo.info.italicAngle = 0
         font_rt = to_glyphs([ufo])
         assert font_rt.masters[0].italicAngle == 0
-        ufo_rt, = to_ufos(font_rt)
+        ufo_rt, = self.to_ufos(font_rt)
         assert ufo_rt.info.italicAngle == 0
 
     def test_unique_masterid(self):
@@ -1106,7 +1108,7 @@ class ToUfosTest(unittest.TestCase):
         master2.descender = 0
         master2.xHeight = 0
         font.masters.append(master2)
-        ufos = to_ufos(font, minimize_glyphs_diffs=True)
+        ufos = self.to_ufos(font, minimize_glyphs_diffs=True)
 
         try:
             to_glyphs(ufos)
@@ -1119,6 +1121,14 @@ class ToUfosTest(unittest.TestCase):
 
         font_rt = to_glyphs(ufos)
         assert len({m.id for m in font_rt.masters}) == 2
+
+
+class ToUfosTestUfoLib2(ToUfosTestBase, unittest.TestCase):
+    ufo_module = ufoLib2
+
+
+class ToUfosTestDefcon(ToUfosTestBase, unittest.TestCase):
+    ufo_module = defcon
 
 
 class _PointDataPen:
@@ -1238,7 +1248,7 @@ class DrawPathsTest(unittest.TestCase):
         self.assertEqual(first_segment_type, "qcurve")
 
 
-class GlyphPropertiesTest(unittest.TestCase):
+class GlyphPropertiesTestBase(ParametrizedUfoModuleTestMixin):
     def test_glyph_color(self):
         font = generate_minimal_font()
         glyph = GSGlyph(name="a")
@@ -1265,7 +1275,7 @@ class GlyphPropertiesTest(unittest.TestCase):
         glyph2.layers.append(layer2)
         glyph3.layers.append(layer3)
         glyph4.layers.append(layer4)
-        ufo = to_ufos(font)[0]
+        ufo = self.to_ufos(font)[0]
         self.assertEqual(ufo["a"].lib.get("public.markColor"), "0.957,0,0.541,0.004")
         self.assertEqual(ufo["b"].lib.get("public.markColor"), "0.97,1,0,1")
         self.assertEqual(ufo["c"].lib.get("public.markColor"), None)
@@ -1286,7 +1296,7 @@ class GlyphPropertiesTest(unittest.TestCase):
             font.glyphs["circumflexcomb_tildecomb"].layers[0].components[1].anchor
         )
 
-        ds = to_designspace(font)
+        ds = self.to_designspace(font)
         ufo = ds.sources[0].font
         self.assertEqual(
             ufo["circumflexcomb_acutecomb"].lib[GLYPHLIB_PREFIX + "ComponentInfo"],
@@ -1314,7 +1324,15 @@ class GlyphPropertiesTest(unittest.TestCase):
         )
 
 
-class SkipDanglingAndNamelessLayers(unittest.TestCase):
+class GlyphPropertiesTestUfoLib2(GlyphPropertiesTestBase, unittest.TestCase):
+    ufo_module = ufoLib2
+
+
+class GlyphPropertiesTestDefcon(GlyphPropertiesTestBase, unittest.TestCase):
+    ufo_module = ufoLib2
+
+
+class SkipDanglingAndNamelessLayersTestBase(ParametrizedUfoModuleTestMixin):
     def setUp(self):
         self.font = generate_minimal_font()
         add_glyph(self.font, "a")
@@ -1322,7 +1340,7 @@ class SkipDanglingAndNamelessLayers(unittest.TestCase):
 
     def test_normal_layer(self):
         with CapturingLogHandler(self.logger, level="WARNING") as captor:
-            to_ufos(self.font)
+            self.to_ufos(self.font)
 
         # no warnings are emitted
         self.assertRaises(
@@ -1334,13 +1352,13 @@ class SkipDanglingAndNamelessLayers(unittest.TestCase):
         self.font.glyphs[0].layers[0].associatedMasterId = "xxx"
 
         with CapturingLogHandler(self.logger, level="WARNING") as captor:
-            to_ufos(self.font, minimize_glyphs_diffs=True)
+            self.to_ufos(self.font, minimize_glyphs_diffs=True)
 
         captor.assertRegex("layer without a name")
 
         # no warning if minimize_glyphs_diff=False
         with CapturingLogHandler(self.logger, level="WARNING") as captor:
-            to_ufos(self.font, minimize_glyphs_diffs=False)
+            self.to_ufos(self.font, minimize_glyphs_diffs=False)
 
         self.assertFalse(captor.records)
 
@@ -1349,12 +1367,24 @@ class SkipDanglingAndNamelessLayers(unittest.TestCase):
         self.font.glyphs[0].layers[0].associatedMasterId = "xxx"
 
         with CapturingLogHandler(self.logger, level="WARNING") as captor:
-            to_ufos(self.font, minimize_glyphs_diffs=True)
+            self.to_ufos(self.font, minimize_glyphs_diffs=True)
 
         captor.assertRegex("is dangling and will be skipped")
 
 
-class GlyphOrderTest(unittest.TestCase):
+class SkipDanglingAndNamelessLayersTestUfoLib2(
+    SkipDanglingAndNamelessLayersTestBase, unittest.TestCase
+):
+    ufo_module = ufoLib2
+
+
+class SkipDanglingAndNamelessLayersTestDefcon(
+    SkipDanglingAndNamelessLayersTestBase, unittest.TestCase
+):
+    ufo_module = defcon
+
+
+class GlyphOrderTestBase(object):
     """Check that the glyphOrder data is persisted correctly in all directions.
 
     Problem: Glyphs.app (tested 2.4.1 and 2.5.2) does not import and export a
@@ -1414,13 +1444,15 @@ class GlyphOrderTest(unittest.TestCase):
     that the resulting GSFont glyph order is ["c", "a", "f"].
     """
 
+    ufo_module = None  # subclasses must override this
+
     def setUp(self):
         self.font = GSFont()
         self.font.masters.append(GSFontMaster())
         self.font.glyphs.append(GSGlyph("a"))
         self.font.glyphs.append(GSGlyph("c"))
         self.font.glyphs.append(GSGlyph("f"))
-        self.ufo = Font()
+        self.ufo = self.ufo_module.Font()
         self.ufo.newGlyph("a")
         self.ufo.newGlyph("c")
         self.ufo.newGlyph("f")
@@ -1457,17 +1489,27 @@ class GlyphOrderTest(unittest.TestCase):
         self.assertEqual(["a", "c", "f"], [glyph.name for glyph in font.glyphs])
 
     def test_ufo_to_glyphs_only_pgO(self):
+        self.ufo.lib["public.glyphOrder"] = ["a", "c", "f"]
         font = self.from_ufo()
         self.assertEqual(["a", "c", "f"], font.customParameters["glyphOrder"])
         self.assertEqual(["a", "c", "f"], [glyph.name for glyph in font.glyphs])
 
     def test_ufo_to_glyphs_no_pgO(self):
-        del self.ufo.lib["public.glyphOrder"]
+        if "public.glyphOrder" in self.ufo.lib:
+            del self.ufo.lib["public.glyphOrder"]
         font = self.from_ufo()
         self.assertNotIn("glyphOrder", font.customParameters)
         self.assertEqual(
             [glyph.name for glyph in self.ufo], [glyph.name for glyph in font.glyphs]
         )
+
+
+class GlyphOrderTestUfoLib2(GlyphOrderTestBase, unittest.TestCase):
+    ufo_module = ufoLib2
+
+
+class GlyphOrderTestDefcon(GlyphOrderTestBase, unittest.TestCase):
+    ufo_module = defcon
 
 
 if __name__ == "__main__":

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -19,40 +19,39 @@ from xmldiff import main, formatting
 
 import itertools
 import pytest
-import defcon
 
 import glyphsLib
 from glyphsLib import to_designspace, to_glyphs
 
 
-def test_designspace_generation_regular_same_family_name(tmpdir):
-    ufo_Lt = defcon.Font()
+def test_designspace_generation_regular_same_family_name(tmpdir, ufo_module):
+    ufo_Lt = ufo_module.Font()
     ufo_Lt.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Lt.info.styleName = "Light"
     ufo_Lt.info.openTypeOS2WeightClass = 300
 
-    ufo_Rg = defcon.Font()
+    ufo_Rg = ufo_module.Font()
     ufo_Rg.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Rg.info.styleName = "Regular"
     ufo_Rg.info.openTypeOS2WeightClass = 400
 
-    ufo_Md = defcon.Font()
+    ufo_Md = ufo_module.Font()
     ufo_Md.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Md.info.styleName = "Medium"
     ufo_Md.info.openTypeOS2WeightClass = 500
 
-    ufo_Bd = defcon.Font()
+    ufo_Bd = ufo_module.Font()
     ufo_Bd.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Bd.info.styleName = "Bold"
     ufo_Bd.info.openTypeOS2WeightClass = 700
 
-    ufo_ExBd = defcon.Font()
+    ufo_ExBd = ufo_module.Font()
     ufo_ExBd.info.familyName = "CoolFoundry Examplary Serif"
     ufo_ExBd.info.styleName = "XBold"
     ufo_ExBd.info.openTypeOS2WeightClass = 800
 
     font = to_glyphs([ufo_Lt, ufo_Rg, ufo_Md, ufo_Bd, ufo_ExBd])
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     path = os.path.join(str(tmpdir), "actual.designspace")
     designspace.write(path)
@@ -67,39 +66,39 @@ def test_designspace_generation_regular_same_family_name(tmpdir):
     )
 
 
-def test_designspace_generation_italic_same_family_name(tmpdir):
-    ufo_Lt = defcon.Font()
+def test_designspace_generation_italic_same_family_name(tmpdir, ufo_module):
+    ufo_Lt = ufo_module.Font()
     ufo_Lt.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Lt.info.styleName = "Light Italic"
     ufo_Lt.info.openTypeOS2WeightClass = 300
     ufo_Lt.info.italicAngle = -11
 
-    ufo_Rg = defcon.Font()
+    ufo_Rg = ufo_module.Font()
     ufo_Rg.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Rg.info.styleName = "Regular Italic"
     ufo_Rg.info.openTypeOS2WeightClass = 400
     ufo_Rg.info.italicAngle = -11
 
-    ufo_Md = defcon.Font()
+    ufo_Md = ufo_module.Font()
     ufo_Md.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Md.info.styleName = "Medium Italic"
     ufo_Md.info.openTypeOS2WeightClass = 500
     ufo_Md.info.italicAngle = -11
 
-    ufo_Bd = defcon.Font()
+    ufo_Bd = ufo_module.Font()
     ufo_Bd.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Bd.info.styleName = "Bold Italic"
     ufo_Bd.info.openTypeOS2WeightClass = 700
     ufo_Bd.info.italicAngle = -11
 
-    ufo_ExBd = defcon.Font()
+    ufo_ExBd = ufo_module.Font()
     ufo_ExBd.info.familyName = "CoolFoundry Examplary Serif"
     ufo_ExBd.info.styleName = "XBold Italic"
     ufo_ExBd.info.openTypeOS2WeightClass = 800
     ufo_ExBd.info.italicAngle = -11
 
     font = to_glyphs([ufo_Lt, ufo_Rg, ufo_Md, ufo_Bd, ufo_ExBd])
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     path = os.path.join(str(tmpdir), "actual.designspace")
     designspace.write(path)
@@ -114,13 +113,13 @@ def test_designspace_generation_italic_same_family_name(tmpdir):
     )
 
 
-def test_designspace_generation_regular_different_family_names(tmpdir):
-    ufo_Lt = defcon.Font()
+def test_designspace_generation_regular_different_family_names(tmpdir, ufo_module):
+    ufo_Lt = ufo_module.Font()
     ufo_Lt.info.familyName = "CoolFoundry Examplary Serif Light"
     ufo_Lt.info.styleName = "Regular"
     ufo_Lt.info.openTypeOS2WeightClass = 300
 
-    ufo_Rg = defcon.Font()
+    ufo_Rg = ufo_module.Font()
     ufo_Rg.info.familyName = "CoolFoundry Examplary Serif"
     ufo_Rg.info.styleName = "Regular"
     ufo_Rg.info.openTypeOS2WeightClass = 400
@@ -131,31 +130,31 @@ def test_designspace_generation_regular_different_family_names(tmpdir):
         to_glyphs([ufo_Lt, ufo_Rg])
 
 
-def test_designspace_generation_same_weight_name(tmpdir):
-    ufo_Bd = defcon.Font()
+def test_designspace_generation_same_weight_name(tmpdir, ufo_module):
+    ufo_Bd = ufo_module.Font()
     ufo_Bd.info.familyName = "Test"
     ufo_Bd.info.styleName = "Bold"
 
-    ufo_ExBd = defcon.Font()
+    ufo_ExBd = ufo_module.Font()
     ufo_ExBd.info.familyName = "Test"
     ufo_ExBd.info.styleName = "Bold"
 
-    ufo_XExBd = defcon.Font()
+    ufo_XExBd = ufo_module.Font()
     ufo_XExBd.info.familyName = "Test"
     ufo_XExBd.info.styleName = "Bold"
 
     font = to_glyphs([ufo_Bd, ufo_ExBd, ufo_XExBd])
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     assert designspace.sources[0].filename != designspace.sources[1].filename
     assert designspace.sources[1].filename != designspace.sources[2].filename
     assert designspace.sources[0].filename != designspace.sources[2].filename
 
 
-def test_designspace_generation_brace_layers(datadir):
+def test_designspace_generation_brace_layers(datadir, ufo_module):
     with open(str(datadir.join("BraceTestFont.glyphs"))) as f:
         font = glyphsLib.load(f)
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     axes_order = [
         (a.name, a.minimum, a.default, a.maximum, a.map) for a in designspace.axes
@@ -187,10 +186,10 @@ def test_designspace_generation_brace_layers(datadir):
         masters[source.filename] = source.font
 
 
-def test_designspace_generation_instances(datadir):
+def test_designspace_generation_instances(datadir, ufo_module):
     with open(str(datadir.join("BraceTestFont.glyphs"))) as f:
         font = glyphsLib.load(f)
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     instances_order = [
         (i.name, i.styleMapStyleName, i.location) for i in designspace.instances
@@ -206,13 +205,17 @@ def test_designspace_generation_instances(datadir):
     ]
 
 
-def test_designspace_generation_on_disk(datadir, tmpdir):
+def test_designspace_generation_on_disk(datadir, tmpdir, ufo_module):
     glyphsLib.build_masters(str(datadir.join("BraceTestFont.glyphs")), str(tmpdir))
 
     ufo_paths = list(tmpdir.visit(fil="*.ufo"))
     assert len(ufo_paths) == 4  # Source layers should not be written to disk.
     for ufo_path in ufo_paths:
-        ufo = defcon.Font(str(ufo_path))
+        try:
+            ufo = ufo_module.Font.open(ufo_path)
+        except AttributeError:
+            ufo = ufo_module.Font(str(ufo_path))
+
         # Check that all glyphs have contours (brace layers are in "b" only, writing
         # the brace layer to disk would result in empty other glyphs).
         for layer in ufo.layers:
@@ -223,10 +226,10 @@ def test_designspace_generation_on_disk(datadir, tmpdir):
                     assert glyph
 
 
-def test_designspace_generation_bracket_roundtrip(datadir):
+def test_designspace_generation_bracket_roundtrip(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
         font = glyphsLib.load(f)
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     assert designspace.rules[0].name == "BRACKET.300.600"
     assert designspace.rules[0].conditionSets == [
@@ -282,7 +285,7 @@ def test_designspace_generation_bracket_roundtrip(datadir):
     assert "x.BRACKET.600" not in font_rt.glyphs
 
 
-def test_designspace_generation_bracket_roundtrip_no_layername(datadir):
+def test_designspace_generation_bracket_roundtrip_no_layername(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
         font = glyphsLib.load(f)
 
@@ -293,7 +296,7 @@ def test_designspace_generation_bracket_roundtrip_no_layername(datadir):
         for l in dl:
             g.layers.remove(l)
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
     for source in designspace.sources:
         source.font.newGlyph("b.BRACKET.100")
 
@@ -303,14 +306,14 @@ def test_designspace_generation_bracket_roundtrip_no_layername(datadir):
             assert layer.name == "[100]"
 
 
-def test_designspace_generation_bracket_unbalanced_brackets(datadir):
+def test_designspace_generation_bracket_unbalanced_brackets(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont2.glyphs"))) as f:
         font = glyphsLib.load(f)
 
     layer_names = {l.name for l in font.glyphs["C"].layers}
     assert layer_names == {"Regular", "Bold", "Bold [600]"}
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     for source in designspace.sources:
         assert "C.BRACKET.600" in source.font
@@ -323,7 +326,7 @@ def test_designspace_generation_bracket_unbalanced_brackets(datadir):
     assert "C.BRACKET.600" not in font_rt.glyphs
 
 
-def test_designspace_generation_bracket_composite_glyph(datadir):
+def test_designspace_generation_bracket_composite_glyph(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont2.glyphs"))) as f:
         font = glyphsLib.load(f)
 
@@ -331,7 +334,7 @@ def test_designspace_generation_bracket_composite_glyph(datadir):
     for layer in g.layers:
         assert layer.components[0].name == "A"
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     for source in designspace.sources:
         ufo = source.font
@@ -350,7 +353,7 @@ def test_designspace_generation_bracket_composite_glyph(datadir):
     assert "B.BRACKET.600" not in font_rt.glyphs
 
 
-def test_designspace_generation_reverse_bracket_roundtrip(datadir):
+def test_designspace_generation_reverse_bracket_roundtrip(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont2.glyphs"))) as f:
         font = glyphsLib.load(f)
 
@@ -358,7 +361,7 @@ def test_designspace_generation_reverse_bracket_roundtrip(datadir):
 
     assert {"Regular ]600]", "Bold ]600]"}.intersection(l.name for l in g.layers)
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
 
     assert designspace.rules[1].name == "BRACKET.400.600"
     assert designspace.rules[1].conditionSets == [
@@ -380,13 +383,15 @@ def test_designspace_generation_reverse_bracket_roundtrip(datadir):
     assert "D.REV_BRACKET.600" not in font_rt.glyphs
 
 
-def test_designspace_generation_bracket_no_export_glyph(datadir):
+def test_designspace_generation_bracket_no_export_glyph(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont2.glyphs"))) as f:
         font = glyphsLib.load(f)
 
     font.glyphs["E"].export = False
 
-    designspace = to_designspace(font, write_skipexportglyphs=True)
+    designspace = to_designspace(
+        font, write_skipexportglyphs=True, ufo_module=ufo_module
+    )
 
     assert "E" in designspace.lib.get("public.skipExportGlyphs")
 

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -22,6 +22,7 @@ import pytest
 
 import glyphsLib
 from glyphsLib import to_designspace, to_glyphs
+from glyphsLib.util import open_ufo
 
 
 def test_designspace_generation_regular_same_family_name(tmpdir, ufo_module):
@@ -211,10 +212,7 @@ def test_designspace_generation_on_disk(datadir, tmpdir, ufo_module):
     ufo_paths = list(tmpdir.visit(fil="*.ufo"))
     assert len(ufo_paths) == 4  # Source layers should not be written to disk.
     for ufo_path in ufo_paths:
-        try:
-            ufo = ufo_module.Font.open(ufo_path)
-        except AttributeError:
-            ufo = ufo_module.Font(str(ufo_path))
+        ufo = open_ufo(ufo_path, ufo_module.Font)
 
         # Check that all glyphs have contours (brace layers are in "b" only, writing
         # the brace layer to disk would result in empty other glyphs).

--- a/tests/builder/designspace_roundtrip_test.py
+++ b/tests/builder/designspace_roundtrip_test.py
@@ -14,26 +14,25 @@
 # limitations under the License.
 
 
-import defcon
 from fontTools import designspaceLib
 
 from glyphsLib import to_glyphs, to_designspace
 
 
-def test_default_master_roundtrips():
+def test_default_master_roundtrips(ufo_module):
     """This test comes from a common scenario while using glyphsLib to go
     back and forth several times with "minimize diffs" in both directions.
     In the end we get UFOs that have information as below, and there was
     a bug that turned "Regular" into "Normal" and changed the default axis
     value.
     """
-    thin = defcon.Font()
+    thin = ufo_module.Font()
     thin.info.familyName = "CustomFont"
     thin.info.styleName = "Thin"
     thin.lib["com.schriftgestaltung.customParameter.GSFont.Axes"] = [
         {"Name": "Weight", "Tag": "wght"}
     ]
-    regular = defcon.Font()
+    regular = ufo_module.Font()
     regular.info.familyName = "CustomFont"
     regular.info.styleName = "Regular"
     regular.lib["com.schriftgestaltung.customParameter.GSFont.Axes"] = [
@@ -68,7 +67,7 @@ def test_default_master_roundtrips():
     ds.addSource(regularSource)
 
     font = to_glyphs(ds, minimize_ufo_diffs=True)
-    doc = to_designspace(font, minimize_glyphs_diffs=True)
+    doc = to_designspace(font, minimize_glyphs_diffs=True, ufo_module=ufo_module)
 
     reg = doc.sources[1]
     assert reg.styleName == "Regular"

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -17,40 +17,32 @@
 import os
 from textwrap import dedent
 
-import defcon
-
 from glyphsLib import to_glyphs, to_ufos, classes
 
 import pytest
 
 
-def make_font(features):
-    ufo = defcon.Font()
-    ufo.features = dedent(features)
-    return ufo
-
-
-def roundtrip(ufo, tmpdir):
+def roundtrip(ufo, tmpdir, ufo_module):
     font = to_glyphs([ufo], minimize_ufo_diffs=True)
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    ufo, = to_ufos(font)
+    ufo, = to_ufos(font, ufo_module=ufo_module)
     return font, ufo
 
 
-def test_blank(tmpdir):
-    ufo = defcon.Font()
+def test_blank(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert not font.features
     assert not font.featurePrefixes
     assert not rtufo.features.text
 
 
-def test_comment(tmpdir):
-    ufo = defcon.Font()
+def test_comment(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     ufo.features.text = dedent(
         """\
         # Test
@@ -58,7 +50,7 @@ def test_comment(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert not font.features
     assert len(font.featurePrefixes) == 1
@@ -69,8 +61,8 @@ def test_comment(tmpdir):
     assert rtufo.features.text == ufo.features.text
 
 
-def test_languagesystems(tmpdir):
-    ufo = defcon.Font()
+def test_languagesystems(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     # The sample has messed-up spacing because there was a problem with that
     ufo.features.text = dedent(
         """\
@@ -81,7 +73,7 @@ def test_languagesystems(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert not font.features
     assert len(font.featurePrefixes) == 1
@@ -92,8 +84,8 @@ def test_languagesystems(tmpdir):
     assert rtufo.features.text == ufo.features.text
 
 
-def test_classes(tmpdir):
-    ufo = defcon.Font()
+def test_classes(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     # FIXME: (jany) no whitespace is preserved in this section
     ufo.features.text = dedent(
         """\
@@ -107,7 +99,7 @@ def test_classes(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert len(font.classes) == 4
     assert font.classes["lc"].code == "a b"
@@ -118,8 +110,8 @@ def test_classes(tmpdir):
     assert rtufo.features.text == ufo.features.text
 
 
-def test_class_synonym(tmpdir):
-    ufo = defcon.Font()
+def test_class_synonym(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     ufo.features.text = dedent(
         """\
         @lc = [ a b ];
@@ -128,7 +120,7 @@ def test_class_synonym(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert len(font.classes) == 2
     assert font.classes["lc"].code == "a b"
@@ -144,8 +136,8 @@ def test_class_synonym(tmpdir):
     )
 
 
-def test_include(tmpdir):
-    ufo = defcon.Font()
+def test_include(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     ufo.features.text = dedent(
         """\
         include(../family.fea);
@@ -154,7 +146,7 @@ def test_include(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert len(font.featurePrefixes) == 1
     assert font.featurePrefixes[0].code.strip() == ufo.features.text.strip()
@@ -162,15 +154,15 @@ def test_include(tmpdir):
     assert rtufo.features.text == ufo.features.text
 
 
-def test_include_no_semicolon(tmpdir):
-    ufo = defcon.Font()
+def test_include_no_semicolon(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     ufo.features.text = dedent(
         """\
         include(../family.fea)
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert len(font.featurePrefixes) == 1
     assert font.featurePrefixes[0].code.strip() == ufo.features.text.strip()
@@ -178,8 +170,8 @@ def test_include_no_semicolon(tmpdir):
     assert rtufo.features.text == ufo.features.text
 
 
-def test_standalone_lookup(tmpdir):
-    ufo = defcon.Font()
+def test_standalone_lookup(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     # FIXME: (jany) does not preserve whitespace before and after
     ufo.features.text = dedent(
         """\
@@ -191,7 +183,7 @@ def test_standalone_lookup(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert len(font.featurePrefixes) == 1
     assert font.featurePrefixes[0].code.strip() == ufo.features.text.strip()
@@ -199,8 +191,8 @@ def test_standalone_lookup(tmpdir):
     assert rtufo.features.text == ufo.features.text
 
 
-def test_feature(tmpdir):
-    ufo = defcon.Font()
+def test_feature(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     # This sample is straight from the documentation at
     # http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html
     # FIXME: (jany) does not preserve whitespace before and after
@@ -240,7 +232,7 @@ def test_feature(tmpdir):
     """
     )
 
-    font, rtufo = roundtrip(ufo, tmpdir)
+    font, rtufo = roundtrip(ufo, tmpdir, ufo_module)
 
     assert len(font.features) == 1
     # Strip "feature liga {} liga;"
@@ -250,7 +242,7 @@ def test_feature(tmpdir):
     assert rtufo.features.text.strip() == ufo.features.text.strip()
 
 
-def test_different_features_in_different_UFOS(tmpdir):
+def test_different_features_in_different_UFOS(tmpdir, ufo_module):
     # If the input UFOs have different features, Glyphs cannot model the
     # differences easily.
     #
@@ -263,13 +255,13 @@ def test_different_features_in_different_UFOS(tmpdir):
     # original text of each UFO's feature is stored in userData, and a single
     # GSFeaturePrefix is created just to warn the user that features were not
     # imported because of differences.
-    ufo1 = defcon.Font()
+    ufo1 = ufo_module.Font()
     ufo1.features.text = dedent(
         """\
         include('../family.fea');
     """
     )
-    ufo2 = defcon.Font()
+    ufo2 = ufo_module.Font()
     ufo2.features.text = dedent(
         """\
         include('../family.fea');
@@ -284,7 +276,7 @@ def test_different_features_in_different_UFOS(tmpdir):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    ufo1rt, ufo2rt = to_ufos(font)
+    ufo1rt, ufo2rt = to_ufos(font, ufo_module=ufo_module)
 
     assert len(font.features) == 0
     assert len(font.featurePrefixes) == 1
@@ -302,8 +294,8 @@ def test_different_features_in_different_UFOS(tmpdir):
     assert ufo2rt.features.text == ufo2.features.text
 
 
-def test_roundtrip_disabled_feature():
-    font = to_glyphs([defcon.Font()])
+def test_roundtrip_disabled_feature(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
     feature = classes.GSFeature(name="ccmp")
     feature.code = dedent(
         """\
@@ -315,7 +307,7 @@ def test_roundtrip_disabled_feature():
     feature.disabled = True
     font.features.append(feature)
 
-    ufo, = to_ufos(font)
+    ufo, = to_ufos(font, ufo_module=ufo_module)
     assert ufo.features.text == dedent(
         """\
         feature ccmp {
@@ -334,7 +326,7 @@ def test_roundtrip_disabled_feature():
     assert feature_r.code == feature.code
     assert feature_r.disabled is True
 
-    font_rr = to_glyphs(to_ufos(font_r))
+    font_rr = to_glyphs(to_ufos(font_r, ufo_module=ufo_module))
     assert len(font_rr.features) == 1
     feature_rr = font_rr.features[0]
     assert feature_rr.name == "ccmp"
@@ -342,14 +334,14 @@ def test_roundtrip_disabled_feature():
     assert feature_rr.disabled is True
 
 
-def test_roundtrip_automatic_feature():
-    font = to_glyphs([defcon.Font()])
+def test_roundtrip_automatic_feature(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
     feature = classes.GSFeature(name="ccmp")
     feature.code = "sub c by c.ss03;"
     feature.automatic = True
     font.features.append(feature)
 
-    ufo, = to_ufos(font)
+    ufo, = to_ufos(font, ufo_module=ufo_module)
     assert ufo.features.text == dedent(
         """\
         feature ccmp {
@@ -367,14 +359,14 @@ def test_roundtrip_automatic_feature():
     assert feature_r.automatic is True
 
 
-def test_roundtrip_feature_prefix_with_only_a_comment():
-    font = to_glyphs([defcon.Font()])
+def test_roundtrip_feature_prefix_with_only_a_comment(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
     prefix = classes.GSFeaturePrefix(name="include")
     # Contents: just a comment
     prefix.code = "#include(../family.fea)"
     font.featurePrefixes.append(prefix)
 
-    ufo, = to_ufos(font)
+    ufo, = to_ufos(font, ufo_module=ufo_module)
 
     assert ufo.features.text == dedent(
         """\
@@ -391,8 +383,8 @@ def test_roundtrip_feature_prefix_with_only_a_comment():
 
 
 @pytest.fixture
-def ufo_with_GDEF():
-    ufo = defcon.Font()
+def ufo_with_GDEF(ufo_module):
+    ufo = ufo_module.Font()
     gdef = dedent(
         """\
         table GDEF {
@@ -405,7 +397,7 @@ def ufo_with_GDEF():
         """
     )
     ufo.features.text = gdef
-    return ufo, gdef
+    return ufo, gdef, ufo_module
 
 
 def test_roundtrip_existing_GDEF(tmpdir, ufo_with_GDEF):
@@ -413,29 +405,29 @@ def test_roundtrip_existing_GDEF(tmpdir, ufo_with_GDEF):
     no extra GDEF table is generated upon roundtripping to UFO when
     `generate_GDEF` is False.
     """
-    ufo, gdef = ufo_with_GDEF
+    ufo, gdef, ufo_module = ufo_with_GDEF
     font = to_glyphs([ufo])
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    rtufo, = to_ufos(font, generate_GDEF=False)
+    rtufo, = to_ufos(font, generate_GDEF=False, ufo_module=ufo_module)
 
     assert rtufo.features.text == gdef
 
 
 def test_generate_GDEF_already_exists(tmpdir, ufo_with_GDEF):
-    ufo = ufo_with_GDEF[0]
+    ufo, _, ufo_module = ufo_with_GDEF
     font = to_glyphs([ufo])
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
 
     with pytest.raises(ValueError, match="features already contain a `table GDEF"):
-        to_ufos(font, generate_GDEF=True)
+        to_ufos(font, generate_GDEF=True, ufo_module=ufo_module)
 
 
-def test_groups_remain_at_top(tmpdir):
-    ufo = defcon.Font()
+def test_groups_remain_at_top(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     ufo.newGlyph("zero")
     ufo.newGlyph("zero.alt")
     fea_example = dedent(
@@ -458,20 +450,20 @@ def test_groups_remain_at_top(tmpdir):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    rtufo, = to_ufos(font)
+    rtufo, = to_ufos(font, ufo_module=ufo_module)
 
     fea_rt = rtufo.features.text
     assert fea_rt.index("@FIG_DFLT") < fea_rt.index("lookup") < fea_rt.index("feature")
 
 
-def test_roundtrip_empty_feature():
+def test_roundtrip_empty_feature(ufo_module):
     # https://github.com/googlefonts/glyphsLib/issues/562
-    font = to_glyphs([defcon.Font()])
+    font = to_glyphs([ufo_module.Font()])
     feature = classes.GSFeature(name="dlig")
     feature.code = ""
     font.features.append(feature)
 
-    ufo, = to_ufos(font)
+    ufo, = to_ufos(font, ufo_module=ufo_module)
     assert ufo.features.text == dedent(
         """\
         feature dlig {

--- a/tests/builder/instances_test.py
+++ b/tests/builder/instances_test.py
@@ -18,7 +18,6 @@ import os
 import glyphsLib
 from fontTools.designspaceLib import DesignSpaceDocument
 from glyphsLib.builder.instances import apply_instance_data
-import defcon
 
 import pytest
 import py.path
@@ -33,7 +32,7 @@ DATA = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
     [None, ["Extra Light"], ["Regular", "Bold"]],
     ids=["default", "include_1", "include_2"],
 )
-def test_apply_instance_data(tmpdir, instance_names):
+def test_apply_instance_data(tmpdir, instance_names, ufo_module):
     font = glyphsLib.GSFont(os.path.join(DATA, "GlyphsUnitTestSans.glyphs"))
     instance_dir = "instances"
     designspace = glyphsLib.to_designspace(font, instance_dir=instance_dir)
@@ -57,7 +56,7 @@ def test_apply_instance_data(tmpdir, instance_names):
     # interpolate.
     tmpdir.mkdir(instance_dir)
     for instance in test_instances:
-        ufo = defcon.Font()
+        ufo = ufo_module.Font()
         ufo.save(str(tmpdir / instance))
 
     ufos = apply_instance_data(designspace.path, include_filenames=test_instances)

--- a/tests/builder/interpolation_test.py
+++ b/tests/builder/interpolation_test.py
@@ -27,6 +27,7 @@ from glyphsLib.builder.constants import GLYPHS_PREFIX
 from glyphsLib.builder.instances import set_weight_class, set_width_class
 from glyphsLib.classes import GSFont, GSFontMaster, GSInstance
 from glyphsLib import to_designspace, to_glyphs
+import ufoLib2
 
 
 # Current limitation of glyphsLib for designspace to designspace round-trip:
@@ -399,9 +400,12 @@ WEIGHT_CLASS_KEY = GLYPHS_PREFIX + "weightClass"
 WIDTH_CLASS_KEY = GLYPHS_PREFIX + "widthClass"
 
 
-class SetWeightWidthClassesTest(unittest.TestCase):
+class SetWeightWidthClassesTestBase(object):
+
+    ufo_module = None  # subclasses must override this
+
     def test_no_weight_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         # name here says "Bold", however no explicit weightClass
         # is assigned
         doc, instance = makeInstanceDescriptor("Bold")
@@ -410,14 +414,14 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
 
     def test_weight_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         doc, data = makeInstanceDescriptor("Bold", weight=("Bold", None, 150))
 
         set_weight_class(ufo, doc, data)
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 700)
 
     def test_explicit_default_weight(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         doc, data = makeInstanceDescriptor("Regular", weight=("Regular", None, 100))
 
         set_weight_class(ufo, doc, data)
@@ -425,7 +429,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
 
     def test_no_width_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         # no explicit widthClass set, instance name doesn't matter
         doc, data = makeInstanceDescriptor("Normal")
         set_width_class(ufo, doc, data)
@@ -433,14 +437,14 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 5)
 
     def test_width_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         doc, data = makeInstanceDescriptor("Condensed", width=("Condensed", 3, 80))
 
         set_width_class(ufo, doc, data)
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 3)
 
     def test_explicit_default_width(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         doc, data = makeInstanceDescriptor("Regular", width=("Medium (normal)", 5, 100))
 
         set_width_class(ufo, doc, data)
@@ -448,7 +452,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 5)
 
     def test_weight_and_width_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         doc, data = makeInstanceDescriptor(
             "SemiCondensed ExtraBold",
             weight=("ExtraBold", None, 160),
@@ -462,7 +466,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 4)
 
     def test_unknown_ui_string_but_defined_weight_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         # "DemiLight" is not among the predefined weight classes listed in
         # Glyphs.app/Contents/Frameworks/GlyphsCore.framework/Versions/A/
         # Resources/weights.plist
@@ -480,7 +484,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         self.assertTrue(ufo.info.openTypeOS2WeightClass == 350)
 
     def test_unknown_weight_class(self):
-        ufo = defcon.Font()
+        ufo = self.ufo_module.Font()
         # "DemiLight" is not among the predefined weight classes listed in
         # Glyphs.app/Contents/Frameworks/GlyphsCore.framework/Versions/A/
         # Resources/weights.plist
@@ -495,6 +499,16 @@ class SetWeightWidthClassesTest(unittest.TestCase):
 
         # the default OS/2 weight class is set
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
+
+
+class SetWeightWidthClassesTestUfoLib2(
+    SetWeightWidthClassesTestBase, unittest.TestCase
+):
+    ufo_module = ufoLib2
+
+
+class SetWeightWidthClassesTestDefcon(SetWeightWidthClassesTestBase, unittest.TestCase):
+    ufo_module = defcon
 
 
 if __name__ == "__main__":

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -50,7 +50,7 @@ def test_designspace_lib_equivalent_to_font_user_data(tmpdir):
     assert designspace.lib["designspaceLibKey1"] == "designspaceLibValue1"
 
 
-def test_default_featureWriters_in_designspace_lib(tmpdir):
+def test_default_featureWriters_in_designspace_lib(tmpdir, ufo_module):
     """Test that the glyphsLib custom featureWriters settings (with mode="append")
     are exported to the designspace lib whenever a GSFont contains a manual 'kern'
     feature. And that they are not imported back to GSFont.userData if they are
@@ -61,7 +61,7 @@ def test_default_featureWriters_in_designspace_lib(tmpdir):
     kern = classes.GSFeature(name="kern", code="pos a b 100;")
     font.features.append(kern)
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
     path = str(tmpdir / "test.designspace")
     designspace.write(path)
     for source in designspace.sources:
@@ -72,13 +72,13 @@ def test_default_featureWriters_in_designspace_lib(tmpdir):
     assert UFO2FT_FEATURE_WRITERS_KEY in designspace2.lib
     assert designspace2.lib[UFO2FT_FEATURE_WRITERS_KEY] == DEFAULT_FEATURE_WRITERS
 
-    font2 = to_glyphs(designspace2)
+    font2 = to_glyphs(designspace2, ufo_module=ufo_module)
 
     assert not len(font2.userData)
     assert len([f for f in font2.features if f.name == "kern"]) == 1
 
 
-def test_custom_featureWriters_in_designpace_lib(tmpdir):
+def test_custom_featureWriters_in_designpace_lib(tmpdir, ufo_module):
     """Test that we can roundtrip custom user-defined ufo2ft featureWriters
     settings that are stored in the designspace lib or GSFont.userData.
     """
@@ -91,7 +91,7 @@ def test_custom_featureWriters_in_designpace_lib(tmpdir):
     ]
     font.userData[UFO2FT_FEATURE_WRITERS_KEY] = customFeatureWriters
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
     path = str(tmpdir / "test.designspace")
     designspace.write(path)
     for source in designspace.sources:
@@ -102,7 +102,7 @@ def test_custom_featureWriters_in_designpace_lib(tmpdir):
     assert UFO2FT_FEATURE_WRITERS_KEY in designspace2.lib
     assert designspace2.lib[UFO2FT_FEATURE_WRITERS_KEY] == customFeatureWriters
 
-    font2 = to_glyphs(designspace2)
+    font2 = to_glyphs(designspace2, ufo_module=ufo_module)
 
     assert len(font2.userData) == 1
     assert font2.userData[UFO2FT_FEATURE_WRITERS_KEY] == customFeatureWriters

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -16,7 +16,6 @@
 import os
 from collections import OrderedDict
 
-import defcon
 from fontTools.designspaceLib import DesignSpaceDocument
 from glyphsLib import classes
 from glyphsLib.types import BinaryData
@@ -132,10 +131,10 @@ def test_font_user_data_to_ufo_lib():
     assert font.userData["fontUserDataKey"] == "fontUserDataValue"
 
 
-def test_ufo_lib_equivalent_to_font_master_user_data():
-    ufo1 = defcon.Font()
+def test_ufo_lib_equivalent_to_font_master_user_data(ufo_module):
+    ufo1 = ufo_module.Font()
     ufo1.lib["ufoLibKey1"] = "ufoLibValue1"
-    ufo2 = defcon.Font()
+    ufo2 = ufo_module.Font()
     ufo2.lib["ufoLibKey2"] = "ufoLibValue2"
 
     font = to_glyphs([ufo1, ufo2])
@@ -151,10 +150,10 @@ def test_ufo_lib_equivalent_to_font_master_user_data():
     assert "ufoLibKey1" not in ufo2.lib
 
 
-def test_ufo_data_into_font_master_user_data(tmpdir):
+def test_ufo_data_into_font_master_user_data(tmpdir, ufo_module):
     filename = "org.customTool/ufoData.bin"
     data = b"\x00\x01\xFF"
-    ufo = defcon.Font()
+    ufo = ufo_module.Font()
     ufo.data[filename] = data
 
     font = to_glyphs([ufo])
@@ -174,8 +173,8 @@ def test_ufo_data_into_font_master_user_data(tmpdir):
     assert ufo.data[filename] == data
 
 
-def test_layer_lib_into_font_user_data():
-    ufo = defcon.Font()
+def test_layer_lib_into_font_user_data(ufo_module):
+    ufo = ufo_module.Font()
     ufo.layers["public.default"].lib["layerLibKey1"] = "layerLibValue1"
     layer = ufo.newLayer("sketches")
     layer.lib["layerLibKey2"] = "layerLibValue2"
@@ -220,8 +219,8 @@ def test_glyph_user_data_into_ufo_lib():
     assert font.glyphs["a"].userData["glyphUserDataKey"] == "glyphUserDataValue"
 
 
-def test_glif_lib_equivalent_to_layer_user_data():
-    ufo = defcon.Font()
+def test_glif_lib_equivalent_to_layer_user_data(ufo_module):
+    ufo = ufo_module.Font()
     # This glyph is in the `public.default` layer
     a = ufo.newGlyph("a")
     a.lib["glifLibKeyA"] = "glifLibValueA"
@@ -298,7 +297,7 @@ def test_node_user_data_into_glif_lib():
     assert path.nodes[4].userData["nodeUserDataKey2"] == "nodeUserDataValue2"
 
 
-def test_lib_data_types(tmpdir):
+def test_lib_data_types(tmpdir, ufo_module):
     # Test the roundtrip of a few basic types both at the top level and in a
     # nested object.
     data = OrderedDict(
@@ -311,7 +310,7 @@ def test_lib_data_types(tmpdir):
             "dict": {},
         }
     )
-    ufo = defcon.Font()
+    ufo = ufo_module.Font()
     a = ufo.newGlyph("a")
     for key, value in data.items():
         a.lib[key] = value

--- a/tests/builder/roundtrip_test.py
+++ b/tests/builder/roundtrip_test.py
@@ -24,7 +24,7 @@ from glyphsLib import classes
 from .. import test_helpers
 
 
-class UFORoundtripTest(unittest.TestCase, test_helpers.AssertUFORoundtrip):
+class UFORoundtripTest(test_helpers.AssertUFORoundtrip):
     def test_empty_font(self):
         empty_font = classes.GSFont()
         empty_font.masters.append(classes.GSFontMaster())

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -340,7 +340,7 @@ def test_designspace_source_locations(tmpdir, ufo_module):
     designspace = DesignSpaceDocument()
     designspace.read(designspace_path)
 
-    font = to_glyphs(designspace)
+    font = to_glyphs(designspace, ufo_module=ufo_module)
 
     assert len(font.masters) == 2
     assert font.masters[0].ascender == 30
@@ -368,7 +368,7 @@ def test_ufo_filename_is_kept_the_same(tmpdir, ufo_module):
     # First check: when going from UFOs -> Glyphs -> designspace
     font = to_glyphs([light, bold], minimize_ufo_diffs=True)
 
-    designspace = to_designspace(font)
+    designspace = to_designspace(font, ufo_module=ufo_module)
     assert designspace.sources[0].path == light_ufo_path
     assert designspace.sources[1].path == bold_ufo_path
 
@@ -515,7 +515,7 @@ def test_warn_diff_between_designspace_and_ufos(caplog, ufo_module):
         in caplog.text
     )
 
-    doc = to_designspace(font)
+    doc = to_designspace(font, ufo_module=ufo_module)
     source = doc.sources[0]
 
     # The UFO info will prevail

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -18,8 +18,6 @@ import pytest
 import datetime
 import os
 
-import defcon
-
 from glyphsLib.builder.constants import GLYPHS_COLORS, GLYPHLIB_PREFIX
 from glyphsLib import to_glyphs, to_ufos, to_designspace
 from glyphsLib import classes
@@ -31,8 +29,8 @@ from fontTools.designspaceLib import DesignSpaceDocument, AxisDescriptor
 
 
 @pytest.mark.skip
-def test_anchors_with_same_name_correct_order_rtl():
-    ufo = defcon.Font()
+def test_anchors_with_same_name_correct_order_rtl(ufo_module):
+    ufo = ufo_module.Font()
     g = ufo.newGlyph("laam_alif")
     # Append the anchors in the correct order
     g.appendAnchor(dict(x=50, y=600, name="top"))
@@ -51,8 +49,8 @@ def test_anchors_with_same_name_correct_order_rtl():
 
 
 @pytest.mark.skip
-def test_anchors_with_same_name_wrong_order_rtl():
-    ufo = defcon.Font()
+def test_anchors_with_same_name_wrong_order_rtl(ufo_module):
+    ufo = ufo_module.Font()
     g = ufo.newGlyph("laam_alif")
     # Append the anchors in the wrong order
     g.appendAnchor(dict(x=250, y=600, name="top"))
@@ -72,8 +70,8 @@ def test_anchors_with_same_name_wrong_order_rtl():
 
 
 @pytest.mark.skip
-def test_anchors_with_same_name_correct_order_ltr():
-    ufo = defcon.Font()
+def test_anchors_with_same_name_correct_order_ltr(ufo_module):
+    ufo = ufo_module.Font()
     g = ufo.newGlyph("laam_alif")
     # Append the anchors in the correct order
     g.appendAnchor(dict(x=50, y=600, name="top"))
@@ -93,8 +91,8 @@ def test_anchors_with_same_name_correct_order_ltr():
 
 
 @pytest.mark.skip
-def test_anchors_with_same_name_wrong_order_ltr():
-    ufo = defcon.Font()
+def test_anchors_with_same_name_wrong_order_ltr(ufo_module):
+    ufo = ufo_module.Font()
     g = ufo.newGlyph("laam_alif")
     # Append the anchors in the wrong order
     g.appendAnchor(dict(x=250, y=600, name="top"))
@@ -113,8 +111,8 @@ def test_anchors_with_same_name_wrong_order_ltr():
     assert top2.y == 600
 
 
-def test_groups():
-    ufo = defcon.Font()
+def test_groups(ufo_module):
+    ufo = ufo_module.Font()
     ufo.newGlyph("T")
     ufo.newGlyph("e")
     ufo.newGlyph("o")
@@ -183,8 +181,8 @@ def test_groups():
     assert dict(ufo.groups) == groups_dict
 
 
-def test_guidelines():
-    ufo = defcon.Font()
+def test_guidelines(ufo_module):
+    ufo = ufo_module.Font()
     a = ufo.newGlyph("a")
     for obj in [ufo, a]:
         # Complete guideline
@@ -194,14 +192,13 @@ def test_guidelines():
         # Don't crash if a guideline misses information
         obj.appendGuideline({"x": 10})
         obj.appendGuideline({"y": 20})
-        obj.appendGuideline({})
 
     font = to_glyphs([ufo])
 
     for gobj in [font.masters[0], font.glyphs["a"].layers[0]]:
-        assert len(gobj.guides) == 4
+        assert len(gobj.guides) == 3
 
-        angled, vertical, horizontal, empty = gobj.guides
+        angled, vertical, horizontal = gobj.guides
 
         assert angled.position.x == 10
         assert angled.position.y == 20
@@ -217,7 +214,7 @@ def test_guidelines():
     ufo, = to_ufos(font)
 
     for obj in [ufo, ufo["a"]]:
-        angled, vertical, horizontal, empty = obj.guidelines
+        angled, vertical, horizontal = obj.guidelines
 
         assert angled.x == 10
         assert angled.y == 20
@@ -235,8 +232,8 @@ def test_guidelines():
         assert horizontal.angle is None
 
 
-def test_glyph_color():
-    ufo = defcon.Font()
+def test_glyph_color(ufo_module):
+    ufo = ufo_module.Font()
     a = ufo.newGlyph("a")
     a.markColor = GLYPHS_COLORS[3]
     b = ufo.newGlyph("b")
@@ -255,8 +252,8 @@ def test_glyph_color():
     assert ufo["b"].markColor == b.markColor
 
 
-def test_bad_ufo_date_format_in_glyph_lib():
-    ufo = defcon.Font()
+def test_bad_ufo_date_format_in_glyph_lib(ufo_module):
+    ufo = ufo_module.Font()
     a = ufo.newGlyph("a")
     a.lib[GLYPHLIB_PREFIX + "lastChange"] = "2017-12-19 15:12:44 +0000"
 
@@ -266,23 +263,23 @@ def test_bad_ufo_date_format_in_glyph_lib():
     assert font.glyphs["a"].lastChange == datetime.datetime(2017, 12, 19, 15, 12, 44)
 
 
-def test_have_default_interpolation_values():
+def test_have_default_interpolation_values(ufo_module):
     """When no designspace is provided, make sure that the Glyphs file has some
     default "axis positions" for the masters.
     """
-    thin = defcon.Font()
+    thin = ufo_module.Font()
     thin.info.openTypeOS2WidthClass = 5
     thin.info.openTypeOS2WeightClass = 100
-    regular = defcon.Font()
+    regular = ufo_module.Font()
     regular.info.openTypeOS2WidthClass = 5
     regular.info.openTypeOS2WeightClass = 400
-    bold = defcon.Font()
+    bold = ufo_module.Font()
     bold.info.openTypeOS2WidthClass = 5
     bold.info.openTypeOS2WeightClass = 700
-    thin_expanded = defcon.Font()
+    thin_expanded = ufo_module.Font()
     thin_expanded.info.openTypeOS2WidthClass = 7
     thin_expanded.info.openTypeOS2WeightClass = 100
-    bold_ultra_cond = defcon.Font()
+    bold_ultra_cond = ufo_module.Font()
     bold_ultra_cond.info.openTypeOS2WidthClass = 1
     bold_ultra_cond.info.openTypeOS2WeightClass = 700
 
@@ -306,7 +303,7 @@ def test_have_default_interpolation_values():
     assert gbolducond.widthValue == 50
 
 
-def test_designspace_source_locations(tmpdir):
+def test_designspace_source_locations(tmpdir, ufo_module):
     """Check that opening UFOs from their source descriptor works with both
     the filename and the path attributes.
     """
@@ -332,11 +329,11 @@ def test_designspace_source_locations(tmpdir):
     designspace.addSource(bold_source)
     designspace.write(designspace_path)
 
-    light = defcon.Font()
+    light = ufo_module.Font()
     light.info.ascender = 30
     light.save(light_ufo_path)
 
-    bold = defcon.Font()
+    bold = ufo_module.Font()
     bold.info.ascender = 40
     bold.save(bold_ufo_path)
 
@@ -351,7 +348,7 @@ def test_designspace_source_locations(tmpdir):
 
 
 @pytest.mark.skip(reason="Should be better defined")
-def test_ufo_filename_is_kept_the_same(tmpdir):
+def test_ufo_filename_is_kept_the_same(tmpdir, ufo_module):
     """Check that the filenames of existing UFOs are correctly written to
     the designspace document when doing UFOs -> Glyphs -> designspace.
     This only works when the option "minimize_ufo_diffs" is given, because
@@ -360,11 +357,11 @@ def test_ufo_filename_is_kept_the_same(tmpdir):
     light_ufo_path = os.path.join(str(tmpdir), "light.ufo")
     bold_ufo_path = os.path.join(str(tmpdir), "subdir/bold.ufo")
 
-    light = defcon.Font()
+    light = ufo_module.Font()
     light.info.ascender = 30
     light.save(light_ufo_path)
 
-    bold = defcon.Font()
+    bold = ufo_module.Font()
     bold.info.ascender = 40
     bold.save(bold_ufo_path)
 
@@ -392,8 +389,8 @@ def test_ufo_filename_is_kept_the_same(tmpdir):
     assert designspace.sources[1].filename == "subdir/bold.ufo"
 
 
-def test_dont_copy_advance_to_the_background_unless_it_was_there(tmpdir):
-    ufo = defcon.Font()
+def test_dont_copy_advance_to_the_background_unless_it_was_there(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     bg = ufo.newLayer("public.background")
 
     fg_a = ufo.newGlyph("a")
@@ -431,8 +428,8 @@ def test_dont_zero_width_of_nonspacing_marks_if_it_was_not_zero():
     pass
 
 
-def test_double_unicodes(tmpdir):
-    ufo = defcon.Font()
+def test_double_unicodes(tmpdir, ufo_module):
+    ufo = ufo_module.Font()
     z = ufo.newGlyph("z")
     z.unicodes = [0x005A, 0x007A]
 
@@ -450,8 +447,8 @@ def test_double_unicodes(tmpdir):
         assert ufo["z"].unicodes == [0x005A, 0x007A]
 
 
-def test_open_contour():
-    ufo = defcon.Font()
+def test_open_contour(ufo_module):
+    ufo = ufo_module.Font()
     a = ufo.newGlyph("a")
     pen = a.getPen()
     pen.moveTo((10, 20))
@@ -472,8 +469,8 @@ def test_open_contour():
     ]
 
 
-def test_background_before_foreground():
-    ufo = defcon.Font()
+def test_background_before_foreground(ufo_module):
+    ufo = ufo_module.Font()
     ufo.newGlyph("a")
     background = ufo.newLayer("public.background")
     background.newGlyph("a")
@@ -484,8 +481,8 @@ def test_background_before_foreground():
     to_glyphs([ufo])
 
 
-def test_only_background():
-    ufo = defcon.Font()
+def test_only_background(ufo_module):
+    ufo = ufo_module.Font()
     background = ufo.newLayer("public.background")
     background.newGlyph("a")
 
@@ -493,8 +490,8 @@ def test_only_background():
     to_glyphs([ufo])
 
 
-def test_warn_diff_between_designspace_and_ufos(caplog):
-    ufo = defcon.Font()
+def test_warn_diff_between_designspace_and_ufos(caplog, ufo_module):
+    ufo = ufo_module.Font()
     ufo.info.familyName = "UFO Family Name"
     ufo.info.styleName = "UFO Style Name"
     # ufo.info.styleMapFamilyName = 'UFO Stylemap Family Name'
@@ -528,8 +525,8 @@ def test_warn_diff_between_designspace_and_ufos(caplog):
     assert source.font.info.styleName == "UFO Style Name"
 
 
-def test_custom_stylemap_style_name():
-    ufo = defcon.Font()
+def test_custom_stylemap_style_name(ufo_module):
+    ufo = ufo_module.Font()
     ufo.info.styleMapStyleName = "bold"  # Not "regular"
 
     font = to_glyphs([ufo], minimize_ufo_diffs=True)
@@ -538,7 +535,7 @@ def test_custom_stylemap_style_name():
     assert ufo.info.styleMapStyleName == "bold"
 
 
-def test_weird_kerning_roundtrip():
+def test_weird_kerning_roundtrip(ufo_module):
     groups = {
         "public.kern1.i": [
             "i",
@@ -581,7 +578,7 @@ def test_weird_kerning_roundtrip():
     }
     glyphs = sorted({g for glyphs in groups.values() for g in glyphs})
 
-    ufo = defcon.Font()
+    ufo = ufo_module.Font()
     for glyph in glyphs:
         ufo.newGlyph(glyph)
     for k, v in groups.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,8 @@ import pytest
 @pytest.fixture
 def datadir(request):
     return py.path.local(py.path.local(__file__).dirname).join("data")
+
+
+@pytest.fixture(scope="session", params=["defcon", "ufoLib2"])
+def ufo_module(request):
+    return pytest.importorskip(request.param)

--- a/tests/run_various_tests_on_various_files.py
+++ b/tests/run_various_tests_on_various_files.py
@@ -17,6 +17,9 @@ import os
 import unittest
 import pytest
 
+import defcon
+import ufoLib2
+
 import glyphsLib
 from fontTools.designspaceLib import DesignSpaceDocument
 import test_helpers
@@ -45,7 +48,7 @@ class GlyphsRT(unittest.TestCase, test_helpers.AssertParseWriteRoundtrip):
             setattr(cls, test_name, test_method)
 
 
-class GlyphsToDesignspaceRT(unittest.TestCase, test_helpers.AssertUFORoundtrip):
+class GlyphsToDesignspaceRT(test_helpers.AssertUFORoundtrip):
     """Test the whole chain from .glyphs to designspace + UFOs and back"""
 
     @classmethod
@@ -69,7 +72,15 @@ class GlyphsToDesignspaceRT(unittest.TestCase, test_helpers.AssertUFORoundtrip):
             setattr(cls, test_name, test_method)
 
 
-class DesignspaceToGlyphsRT(unittest.TestCase, test_helpers.AssertDesignspaceRoundtrip):
+class GlyphsToDesignspaceRTUfoLib2(unittest.TestCase, GlyphsToDesignspaceRT):
+    ufo_module = ufoLib2
+
+
+class GlyphsToDesignspaceRTDefcon(unittest.TestCase, GlyphsToDesignspaceRT):
+    ufo_module = defcon
+
+
+class DesignspaceToGlyphsRT(test_helpers.AssertDesignspaceRoundtrip):
     """Test the whole chain from designspace + UFOs to .glyphs and back"""
 
     @classmethod
@@ -91,12 +102,12 @@ class DesignspaceToGlyphsRT(unittest.TestCase, test_helpers.AssertDesignspaceRou
             print("adding test", test_name)
 
 
-class UFOsToGlyphsRT(unittest.TestCase):
-    """The the whole chain from a collection of UFOs to .glyphs and back"""
+class DesignspaceToGlyphsRTUfoLib2(unittest.TestCase, DesignspaceToGlyphsRT):
+    ufo_module = ufoLib2
 
-    @classmethod
-    def add_tests(cls, testable):
-        pass
+
+class DesignspaceToGlyphsRTDefcon(unittest.TestCase, DesignspaceToGlyphsRT):
+    ufo_module = defcon
 
 
 TESTABLES = [
@@ -105,48 +116,66 @@ TESTABLES = [
         "name": "noto_moyogo",  # dirname inside `downloaded/`
         "git_url": "https://github.com/moyogo/noto-source.git",
         "git_ref": "normalized-1071",
-        "classes": (GlyphsRT, GlyphsToDesignspaceRT),
+        "classes": (
+            GlyphsRT,
+            GlyphsToDesignspaceRTUfoLib2,
+            GlyphsToDesignspaceRTDefcon,
+        ),
     },
     {
         # https://github.com/googlefonts/glyphsLib/issues/238
         "name": "montserrat",
         "git_url": "https://github.com/JulietaUla/Montserrat",
         "git_ref": "master",
-        "classes": (GlyphsRT, GlyphsToDesignspaceRT),
+        "classes": (
+            GlyphsRT,
+            GlyphsToDesignspaceRTUfoLib2,
+            GlyphsToDesignspaceRTDefcon,
+        ),
     },
     {
         # https://github.com/googlefonts/glyphsLib/issues/282
         "name": "cantarell_madig",
         "git_url": "https://github.com/madig/cantarell-fonts/",
         "git_ref": "f17124d041e6ee370a9fcddcc084aa6cbf3d5500",
-        "classes": (GlyphsRT, GlyphsToDesignspaceRT),
+        "classes": (
+            GlyphsRT,
+            GlyphsToDesignspaceRTUfoLib2,
+            GlyphsToDesignspaceRTDefcon,
+        ),
     },
     # {
     #     # This one has truckloads of smart components
     #     'name': 'vt323',
     #     'git_url': 'https://github.com/phoikoi/VT323',
     #     'git_ref': 'master',
-    #     'classes': (GlyphsRT, GlyphsToDesignspaceRT),
+    #     'classes': (
+    #         GlyphsRT, GlyphsToDesignspaceRTUfoLib2, GlyphsToDesignspaceRTDefcon
+    #     ),
     # },
     {
         # This one has truckloads of smart components
         "name": "vt323_jany",
         "git_url": "https://github.com/belluzj/VT323",
         "git_ref": "glyphs-1089",
-        "classes": (GlyphsRT, GlyphsToDesignspaceRT),
+        "classes": (
+            GlyphsRT,
+            GlyphsToDesignspaceRTUfoLib2,
+            GlyphsToDesignspaceRTDefcon,
+        ),
     },
     # The following contain .designspace files
     {
         "name": "spectral",
         "git_url": "https://github.com/productiontype/Spectral",
         "git_ref": "master",
-        "classes": (DesignspaceToGlyphsRT, UFOsToGlyphsRT),
+        "classes": (DesignspaceToGlyphsRTUfoLib2, DesignspaceToGlyphsRTDefcon),
     },
     {
         "name": "amstelvar",
         "git_url": "https://github.com/TypeNetwork/fb-Amstelvar",
         "git_ref": "master",
-        "classes": (DesignspaceToGlyphsRT, UFOsToGlyphsRT),
+        "classes": (DesignspaceToGlyphsRTUfoLib2, DesignspaceToGlyphsRTDefcon),
     },
 ]
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import difflib
+import inspect
 import os.path
 import re
 import subprocess
@@ -27,10 +28,9 @@ from textwrap import dedent
 import glyphsLib
 from glyphsLib import classes
 from fontTools.designspaceLib import DesignSpaceDocument
-from glyphsLib.builder import to_glyphs, to_designspace
+from glyphsLib.builder import to_glyphs, to_designspace, to_ufos
 from glyphsLib.writer import Writer
 from ufonormalizer import normalizeUFO
-import defcon
 
 
 def write_to_lines(glyphs_object):
@@ -92,7 +92,20 @@ class AssertParseWriteRoundtrip(AssertLinesEqual):
         )
 
 
-class AssertUFORoundtrip(AssertLinesEqual):
+class ParametrizedUfoModuleTestMixin(object):
+
+    ufo_module = None  # subclasses must override this
+
+    def to_ufos(self, *args, **kwargs):
+        kwargs["ufo_module"] = self.ufo_module
+        return to_ufos(*args, **kwargs)
+
+    def to_designspace(self, *args, **kwargs):
+        kwargs["ufo_module"] = self.ufo_module
+        return to_designspace(*args, **kwargs)
+
+
+class AssertUFORoundtrip(AssertLinesEqual, ParametrizedUfoModuleTestMixin):
     """Check .glyphs -> UFOs + designspace -> .glyphs"""
 
     def _normalize(self, font):
@@ -122,7 +135,7 @@ class AssertUFORoundtrip(AssertLinesEqual):
         self._normalize(font)
         expected = write_to_lines(font)
         # Don't propagate anchors nor generate GDEF when intending to round-trip
-        designspace = to_designspace(
+        designspace = self.to_designspace(
             font,
             propagate_anchors=False,
             minimize_glyphs_diffs=True,
@@ -159,13 +172,21 @@ class AssertUFORoundtrip(AssertLinesEqual):
         )
 
 
+def _save_overwrite_ufo(font, path):
+    if "overwrite" in inspect.getfullargspec(font.save).args:
+        font.save(path, formatVersion=3, overwrite=True)  # ufoLib2
+    else:
+        font.save(path, formatVersion=3)  # defcon
+
+
 def write_designspace_and_UFOs(designspace, path):
     for source in designspace.sources:
         basename = os.path.basename(source.filename)
         ufo_path = os.path.join(os.path.dirname(path), basename)
         source.filename = basename
         source.path = ufo_path
-        source.font.save(ufo_path, formatVersion=3)
+        _save_overwrite_ufo(source.font, ufo_path)
+
     designspace.write(path)
 
 
@@ -191,20 +212,23 @@ def deboolize(lib):
         lib[key] = deboolized(value)
 
 
-def normalize_ufo_lib(path):
+def normalize_ufo_lib(path, ufo_module):
     """Go through each `lib` element recursively and transform `bools` into
     `int` because that's what's going to happen on round-trip with Glyphs.
     """
-    font = defcon.Font(path)
+    try:
+        font = ufo_module.Font.open(path)
+    except AttributeError:
+        font = ufo_module.Font(path)
     deboolize(font.lib)
     for layer in font.layers:
         deboolize(layer.lib)
         for glyph in layer:
             deboolize(glyph.lib)
-    font.save()
+    _save_overwrite_ufo(font, path)
 
 
-class AssertDesignspaceRoundtrip:
+class AssertDesignspaceRoundtrip(ParametrizedUfoModuleTestMixin):
     """Check UFOs + designspace -> .glyphs -> UFOs + designspace"""
 
     def assertDesignspacesEqual(self, expected, actual, message=""):
@@ -253,12 +277,12 @@ class AssertDesignspaceRoundtrip:
         font = to_glyphs(designspace, minimize_ufo_diffs=True)
 
         # Check that round-tripping in memory is the same as writing on disk
-        roundtrip_in_mem = to_designspace(font, propagate_anchors=False)
+        roundtrip_in_mem = self.to_designspace(font, propagate_anchors=False)
 
         tmpfont_path = os.path.join(directory, "font.glyphs")
         font.save(tmpfont_path)
         font_rt = classes.GSFont(tmpfont_path)
-        roundtrip = to_designspace(font_rt, propagate_anchors=False)
+        roundtrip = self.to_designspace(font_rt, propagate_anchors=False)
 
         font.save("intermediary.glyphs")
 


### PR DESCRIPTION
use ufoLib2 by default -- but still allow to use defcon (or a compatible UFO library) as the `ufo_module` in build_masters, to_designspace, to_ufos, etc.

glyphs2ufo also has a new `--ufo-module` option.