### PR TITLE
features:_build_gdef: handle glyphs outside ufo.glyphOrder

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -178,8 +178,14 @@ def _build_gdef(ufo, skipExportGlyphs=None):
     if not any((bases, ligatures, marks, carets)):
         return None
 
-    def fmt(g):
-        return ("[%s]" % " ".join(sorted(g, key=ufo.glyphOrder.index))) if g else ""
+    def sortkey(glyph_name):
+        try:
+            return ufo.glyphOrder.index(glyph_name), glyph_name
+        except ValueError:
+            return len(ufo.glyphOrder), glyph_name
+
+    def fmt(glyphs):
+        return ("[%s]" % " ".join(sorted(glyphs, key=sortkey))) if glyphs else ""
 
     lines = [
         "table GDEF {",

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -18,6 +18,7 @@ import os
 from textwrap import dedent
 
 from glyphsLib import to_glyphs, to_ufos, classes
+from glyphsLib.builder.features import _build_gdef
 
 import pytest
 
@@ -477,3 +478,15 @@ def test_roundtrip_empty_feature(ufo_module):
     feature_r = font_r.features[0]
     assert feature_r.name == "dlig"
     assert feature_r.code == ""
+
+
+def test_build_GDEF_incomplete_glyphOrder():
+    import ufoLib2
+
+    font = ufoLib2.Font()
+    font.lib["public.glyphOrder"] = ["b", "c"]
+    for name in ("d", "c", "b", "a"):
+        glyph = font.newGlyph(name)
+        glyph.appendAnchor({"name": "top", "x": 0, "y": 0})
+
+    assert "[b c a d], # Base" in _build_gdef(font)


### PR DESCRIPTION
unlike defcon.Font, ufoLib2 doesn't auto append new glyphs to the glyphOrder. Thus, if the public.glyphOrder list is incomplete and some glyphs are not in that list, attempting to call `ufo.glyphOrder.index(glyph_name)` may fail with ValueError.
We need to handle this gracefully by sorting these glyphs-outside-glyphOrder alphabetically, after the explicitly ordered ones.