### PR TITLE
Profile guided performance optimization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 19.3b0
+  rev: 19.10b0
   hooks:
   - id: black
     language_version: python3
     language: python_venv
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.3.0
+  rev: v1.4.0
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==19.3b0]
+    additional_dependencies: [black==19.10b0]
     language: python_venv
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.22.1
+  rev: v1.25.3
   hooks:
   - id: pyupgrade
     language: python_venv
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v2.4.0
   hooks:
   - id: trailing-whitespace
     language: python_venv

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -136,7 +136,7 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):
     self.to_ufo_glyph_anchors(ufo_glyph, layer.anchors)
 
 
-def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):
+def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):  # noqa: C901
     """Add UFO glif metadata, paths, components, and anchors to a GSGlyph.
     If the matching GSGlyph does not exist, then it is created,
     else it is updated with the new data.

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -36,9 +36,13 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):
     if note is not None:
         ufo_glyph.note = note
 
-    last_change = glyph.lastChange
-    if last_change is not None:
-        ufo_glyph.lib[GLYPHLIB_PREFIX + "lastChange"] = to_ufo_time(last_change)
+    # Optimization: profiling glyphs2ufo of NotoSans-MM.glyphs (6000 glyphs) on a Mac
+    # mini late 2014, Python 3.6.8, revealed that a whopping 17% of the time was spent
+    # converting lastChange to UFO timestamps. I could not reproduce this on a Windows
+    # 10/Python 3.7 setup, so this might be a platform thing. If-guarding anyway
+    # because these timestamps are useless in a UFO scenario if you use Git.
+    if self.minimize_glyphs_diffs and glyph.lastChange is not None:
+        ufo_glyph.lib[GLYPHLIB_PREFIX + "lastChange"] = to_ufo_time(glyph.lastChange)
 
     color_index = glyph.color
     if color_index is not None:

--- a/Lib/glyphsLib/builder/paths.py
+++ b/Lib/glyphsLib/builder/paths.py
@@ -49,7 +49,9 @@ def to_ufo_paths(self, ufo_glyph, layer):
 
 
 def to_glyphs_paths(self, ufo_glyph, layer):
-    for contour in ufo_glyph:
+    # Keep track of path and node numbers, otherwise to_glyphs_node_user_data must
+    # call _indices on every single GSNode, which is a huge performance drain.
+    for contour_index, contour in enumerate(ufo_glyph):
         path = self.glyphs_module.GSPath()
         for point in contour:
             node = self.glyphs_module.GSNode()
@@ -63,8 +65,8 @@ def to_glyphs_paths(self, ufo_glyph, layer):
             path.nodes.append(path.nodes.pop(0))
         layer.paths.append(path)
 
-        for node in path.nodes:
-            self.to_glyphs_node_user_data(ufo_glyph, node)
+        for node_index, node in enumerate(path.nodes):
+            self.to_glyphs_node_user_data(ufo_glyph, node, contour_index, node_index)
 
 
 def _to_ufo_node_type(node_type):

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -165,8 +165,7 @@ def to_glyphs_layer_user_data(self, ufo_glyph, layer):
             user_data[key] = value
 
 
-def to_glyphs_node_user_data(self, ufo_glyph, node):
-    path_index, node_index = node._indices()
+def to_glyphs_node_user_data(self, ufo_glyph, node, path_index, node_index):
     key = f"{NODE_USER_DATA_KEY}.{path_index}.{node_index}"
     if key in ufo_glyph.lib:
         node.userData = ufo_glyph.lib[key]

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import copy
 import logging
 import math
 import os
@@ -1332,11 +1333,11 @@ class GSGuideLine(GSBase):
 
     def __init__(self):
         self.alignment = ""
-        self.angle = 0
+        self.angle = self._defaultsForName["angle"]
         self.filter = ""
         self.locked = False
         self.name = ""
-        self.position = Point(0, 0)
+        self.position = copy.deepcopy(self._defaultsForName["position"])
         self.showMeasurement = False
 
     def __repr__(self):
@@ -1463,27 +1464,27 @@ class GSFontMaster(GSBase):
         self._name = None
         self._userData = None
         self.alignmentZones = []
-        self.ascender = 800
-        self.capHeight = 700
+        self.ascender = self._defaultsForName["ascender"]
+        self.capHeight = self._defaultsForName["capHeight"]
         self.customName = ""
-        self.customValue = 0
-        self.customValue1 = 0
-        self.customValue2 = 0
-        self.customValue3 = 0
-        self.descender = -200
+        self.customValue = self._defaultsForName["customValue"]
+        self.customValue1 = self._defaultsForName["customValue1"]
+        self.customValue2 = self._defaultsForName["customValue2"]
+        self.customValue3 = self._defaultsForName["customValue3"]
+        self.descender = self._defaultsForName["descender"]
         self.font = None
         self.guides = []
         self.horizontalStems = 0
         self.iconName = ""
         self.id = str(uuid.uuid4()).upper()
-        self.italicAngle = 0
+        self.italicAngle = self._defaultsForName["italicAngle"]
         self.verticalStems = 0
         self.visible = False
-        self.weight = "Regular"
-        self.weightValue = 100
-        self.width = "Regular"
-        self.widthValue = 100
-        self.xHeight = 500
+        self.weight = self._defaultsForName["weight"]
+        self.weightValue = self._defaultsForName["weightValue"]
+        self.width = self._defaultsForName["width"]
+        self.widthValue = self._defaultsForName["widthValue"]
+        self.xHeight = self._defaultsForName["xHeight"]
 
     def __repr__(self):
         return '<GSFontMaster "{}" width {} weight {}>'.format(
@@ -1774,7 +1775,7 @@ class GSPath(GSBase):
     _parent = None
 
     def __init__(self):
-        self.closed = True
+        self.closed = self._defaultsForName["closed"]
         self.nodes = []
 
     @property
@@ -2082,7 +2083,7 @@ class GSComponent(GSBase):
                 dx, dy = offset
                 self.transform = Transform(xx, 0, 0, yy, dx, dy)
             else:
-                self.transform = Transform(1, 0, 0, 1, 0, 0)
+                self.transform = copy.deepcopy(self._defaultsForName["transform"])
         else:
             self.transform = transform
 
@@ -2229,10 +2230,10 @@ class GSSmartComponentAxis(GSBase):
 
     def __init__(self):
         self.bottomName = ""
-        self.bottomValue = 0
+        self.bottomValue = self._defaultsForName["bottomValue"]
         self.name = ""
         self.topName = ""
-        self.topValue = 0
+        self.topValue = self._defaultsForName["topValue"]
 
     def shouldWriteValueForKey(self, key):
         if key in ("bottomValue", "topValue"):
@@ -2249,7 +2250,10 @@ class GSAnchor(GSBase):
 
     def __init__(self, name=None, position=None):
         self.name = "" if name is None else name
-        self.position = Point(0, 0) if position is None else position
+        if position is None:
+            self.position = copy.deepcopy(self._defaultsForName["position"])
+        else:
+            self.position = position
 
     def __repr__(self):
         return '<{} "{}" x={:.1f} y={:.1f}>'.format(
@@ -2325,21 +2329,16 @@ class GSHint(GSBase):
     )
 
     def __init__(self):
-        self._origin = None
-        self._originNode = None
-        self._other1 = None
-        self._other2 = None
-        self._otherNode1 = None
-        self._otherNode2 = None
-        self._target = None
-        self._targetNode = None
         self.horizontal = False
         self.name = ""
         self.options = 0
-        self.place = None
-        self.scale = None
+        self.origin = self._defaultsForName["origin"]
+        self.other1 = self._defaultsForName["other1"]
+        self.other2 = self._defaultsForName["other2"]
+        self.place = self._defaultsForName["place"]
+        self.scale = self._defaultsForName["scale"]
         self.settings = {}
-        self.stem = -2
+        self.stem = self._defaultsForName["stem"]
         self.type = ""
 
     def shouldWriteValueForKey(self, key):
@@ -2563,11 +2562,11 @@ class GSAnnotation(GSBase):
     _parent = None
 
     def __init__(self):
-        self.angle = 0
-        self.position = Point(0, 0)
-        self.text = None
-        self.type = 0
-        self.width = 100
+        self.angle = self._defaultsForName["angle"]
+        self.position = copy.deepcopy(self._defaultsForName["position"])
+        self.text = self._defaultsForName["text"]
+        self.type = self._defaultsForName["type"]
+        self.width = self._defaultsForName["width"]
 
     @property
     def parent(self):
@@ -2660,23 +2659,25 @@ class GSInstance(GSBase):
 
     def __init__(self):
         self._customParameters = []
-        self.active = True
+        self.active = self._defaultsForName["active"]
         self.custom = None
-        self.customValue = 0
-        self.customValue1 = 0
-        self.customValue2 = 0
-        self.customValue3 = 0
-        self.instanceInterpolations = {}
+        self.customValue = self._defaultsForName["interpolationCustom"]
+        self.customValue1 = self._defaultsForName["interpolationCustom1"]
+        self.customValue2 = self._defaultsForName["interpolationCustom2"]
+        self.customValue3 = self._defaultsForName["interpolationCustom3"]
+        self.instanceInterpolations = copy.deepcopy(
+            self._defaultsForName["instanceInterpolations"]
+        )
         self.isBold = False
         self.isItalic = False
         self.linkStyle = ""
         self.manualInterpolation = False
         self.name = "Regular"
         self.visible = True
-        self.weight = "Regular"
-        self.weightValue = 100
-        self.width = "Medium (normal)"
-        self.widthValue = 100
+        self.weight = self._defaultsForName["weightClass"]
+        self.weightValue = self._defaultsForName["interpolationWeight"]
+        self.width = self._defaultsForName["widthClass"]
+        self.widthValue = self._defaultsForName["interpolationWidth"]
 
     customParameters = property(
         lambda self: CustomParametersProxy(self),
@@ -2803,13 +2804,13 @@ class GSBackgroundImage(GSBase):
 
     def __init__(self, path=None):
         self._R = 0.0
-        self._alpha = 50
         self._sX = 1.0
         self._sY = 1.0
+        self.alpha = self._defaultsForName["alpha"]
         self.crop = Rect()
         self.imagePath = path
         self.locked = False
-        self.transform = Transform(1, 0, 0, 1, 0, 0)
+        self.transform = copy.deepcopy(self._defaultsForName["transform"])
 
     def __repr__(self):
         return "<GSBackgroundImage '%s'>" % self.imagePath
@@ -2985,14 +2986,14 @@ class GSLayer(GSBase):
         self.associatedMasterId = ""
         self.backgroundImage = None
         self.color = None
-        self.leftMetricsKey = None
+        self.leftMetricsKey = self._defaultsForName["leftMetricsKey"]
         self.parent = None
-        self.rightMetricsKey = None
-        self.vertOrigin = 0
-        self.vertWidth = 0
+        self.rightMetricsKey = self._defaultsForName["rightMetricsKey"]
+        self.vertOrigin = self._defaultsForName["vertOrigin"]
+        self.vertWidth = self._defaultsForName["vertWidth"]
         self.visible = False
-        self.width = 600
-        self.widthMetricsKey = None
+        self.width = self._defaultsForName["width"]
+        self.widthMetricsKey = self._defaultsForName["widthMetricsKey"]
 
     def __repr__(self):
         name = self.name
@@ -3321,31 +3322,31 @@ class GSGlyph(GSBase):
     def __init__(self, name=None):
         self._layers = OrderedDict()
         self._unicodes = []
-        self._userData = None
         self.bottomKerningGroup = ""
         self.bottomMetricsKey = ""
-        self.category = None
-        self.color = None
-        self.export = True
-        self.lastChange = None
-        self.leftKerningGroup = None
+        self.category = self._defaultsForName["category"]
+        self.color = self._defaultsForName["color"]
+        self.export = self._defaultsForName["export"]
+        self.lastChange = self._defaultsForName["lastChange"]
+        self.leftKerningGroup = self._defaultsForName["leftKerningGroup"]
         self.leftKerningKey = ""
-        self.leftMetricsKey = None
+        self.leftMetricsKey = self._defaultsForName["leftMetricsKey"]
         self.name = name
-        self.note = None
+        self.note = self._defaultsForName["note"]
         self.parent = None
         self.partsSettings = []
         self.production = ""
-        self.rightKerningGroup = None
+        self.rightKerningGroup = self._defaultsForName["rightKerningGroup"]
         self.rightKerningKey = ""
-        self.rightMetricsKey = None
-        self.script = None
+        self.rightMetricsKey = self._defaultsForName["rightMetricsKey"]
+        self.script = self._defaultsForName["script"]
         self.selected = False
-        self.subCategory = None
+        self.subCategory = self._defaultsForName["subCategory"]
         self.topKerningGroup = ""
         self.topMetricsKey = ""
+        self.userData = self._defaultsForName["userData"]
         self.vertWidthMetricsKey = ""
-        self.widthMetricsKey = None
+        self.widthMetricsKey = self._defaultsForName["widthMetricsKey"]
 
     def __repr__(self):
         return '<GSGlyph "{}" with {} layers>'.format(self.name, len(self.layers))
@@ -3513,32 +3514,34 @@ class GSFont(GSBase):
 
     def __init__(self, path=None):
         self.DisplayStrings = ""
-        self._classes = []
-        self._customParameters = []
         self._features = []
         self._glyphs = []
         self._instances = []
-        self._kerning = OrderedDict()
         self._masters = []
         self._userData = None
         self._versionMinor = 0
         self.appVersion = "895"  # minimum required version
+        self.classes = copy.deepcopy(self._defaultsForName["classes"])
         self.copyright = ""
+        self.customParameters = copy.deepcopy(self._defaultsForName["customParameters"])
         self.date = None
         self.designer = ""
         self.designerURL = ""
-        self.disablesAutomaticAlignment = False
-        self.disablesNiceNames = False
+        self.disablesAutomaticAlignment = self._defaultsForName[
+            "disablesAutomaticAlignment"
+        ]
+        self.disablesNiceNames = self._defaultsForName["disablesNiceNames"]
         self.familyName = "Unnamed font"
         self.featurePrefixes = []
         self.filepath = None
-        self.grid = 1
-        self.gridSubDivisions = 1
+        self.grid = self._defaultsForName["gridLength"]
+        self.gridSubDivisions = self._defaultsForName["gridSubDivision"]
         self.keepAlternatesTogether = False
-        self.keyboardIncrement = 1
+        self.kerning = copy.deepcopy(self._defaultsForName["kerning"])
+        self.keyboardIncrement = self._defaultsForName["keyboardIncrement"]
         self.manufacturer = ""
         self.manufacturerURL = ""
-        self.upm = 1000
+        self.upm = self._defaultsForName["unitsPerEm"]
         self.versionMajor = 1
 
         if path:

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1595,6 +1595,20 @@ class GSNode(GSBase):
         )
 
     def read(self, line):
+        """Parse a Glyphs node string into a GSNode.
+
+        The format of a Glyphs node string (`line`) is:
+
+            "X Y (LINE|CURVE|QCURVE|OFFCURVE)"
+            "X Y (LINE|CURVE|QCURVE|OFFCURVE) SMOOTH"
+            "X Y (LINE|CURVE|QCURVE|OFFCURVE) SMOOTH {dictionary}"
+            "X Y (LINE|CURVE|QCURVE|OFFCURVE) {dictionary}"
+
+        X and Y can be integers or floats, positive or negative.
+
+        WARNING: This method is HOT. It is called for every single node and can
+        account for a significant portion of the file parsing time.
+        """
         m = self._PLIST_VALUE_RE.match(line).groups()
         self.position = Point(parse_float_or_int(m[0]), parse_float_or_int(m[1]))
         self.type = m[2].lower()

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-import copy
-import inspect
 import logging
 import math
 import os

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -68,6 +68,7 @@ __all__ = [
     "MOVE",
     "LINE",
     "CURVE",
+    "QCURVE",
     "OFFCURVE",
     "GSMOVE",
     "GSLINE",
@@ -132,6 +133,7 @@ MOVE = "move"
 LINE = "line"
 CURVE = "curve"
 OFFCURVE = "offcurve"
+QCURVE = "qcurve"
 
 TAG = -2
 TOPGHOST = -1
@@ -1546,11 +1548,6 @@ class GSNode(GSBase):
         r'(?: (SMOOTH))?(?: ({.*}))?"',
         re.DOTALL,
     )
-    MOVE = "move"
-    LINE = "line"
-    CURVE = "curve"
-    OFFCURVE = "offcurve"
-    QCURVE = "qcurve"
     _parent = None
 
     def __init__(self, position=(0, 0), nodetype=LINE, smooth=False, name=None):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -286,6 +286,8 @@ def transformStructToScaleAndRotation(transform):
 
 
 class GSApplication:
+    __slots__ = "font", "fonts"
+
     def __init__(self):
         self.font = None
         self.fonts = []
@@ -373,6 +375,8 @@ class GSBase:
 
 
 class Proxy:
+    __slots__ = "_owner"
+
     def __init__(self, owner):
         self._owner = owner
 
@@ -428,6 +432,8 @@ class Proxy:
 
 
 class LayersIterator:
+    __slots__ = "curInd", "_owner", "_orderedLayers"
+
     def __init__(self, owner):
         self.curInd = 0
         self._owner = owner
@@ -1126,6 +1132,8 @@ class UserDataProxy(Proxy):
 
 
 class GSCustomParameter(GSBase):
+    __slots__ = ("name", "_value")
+
     _classesForName = {"name": str, "value": None}
 
     _CUSTOM_INT_PARAMS = frozenset(
@@ -1274,6 +1282,8 @@ class GSCustomParameter(GSBase):
 
 
 class GSAlignmentZone(GSBase):
+    __slots__ = ("position", "size")
+
     def __init__(self, pos=0, size=20):
         self.position = pos
         self.size = size
@@ -1300,6 +1310,16 @@ class GSAlignmentZone(GSBase):
 
 
 class GSGuideLine(GSBase):
+    __slots__ = (
+        "alignment",
+        "angle",
+        "filter",
+        "locked",
+        "name",
+        "position",
+        "showMeasurement",
+    )
+
     _classesForName = {
         "alignment": str,
         "angle": parse_float_or_int,
@@ -1336,6 +1356,34 @@ MASTER_NAME_WIDTHS = ("Condensed", "SemiCondensed", "Extended", "SemiExtended")
 
 
 class GSFontMaster(GSBase):
+    __slots__ = (
+        "_customParameters",
+        "_name",
+        "_userData",
+        "alignmentZones",
+        "ascender",
+        "capHeight",
+        "customName",
+        "customValue",
+        "customValue1",
+        "customValue2",
+        "customValue3",
+        "descender",
+        "font",
+        "guides",
+        "horizontalStems",
+        "iconName",
+        "id",
+        "italicAngle",
+        "verticalStems",
+        "visible",
+        "weight",
+        "weightValue",
+        "width",
+        "widthValue",
+        "xHeight",
+    )
+
     _classesForName = {
         "alignmentZones": GSAlignmentZone,
         "ascender": parse_float_or_int,
@@ -1543,6 +1591,8 @@ class GSFontMaster(GSBase):
 
 
 class GSNode(GSBase):
+    __slots__ = ("_userData", "position", "smooth", "type")
+
     _PLIST_VALUE_RE = re.compile(
         r'"([-.e\d]+) ([-.e\d]+) (LINE|CURVE|QCURVE|OFFCURVE|n/a)'
         r'(?: (SMOOTH))?(?: ({.*}))?"',
@@ -1719,6 +1769,8 @@ class GSNode(GSBase):
 
 
 class GSPath(GSBase):
+    __slots__ = ("closed", "_nodes")
+
     _classesForName = {"nodes": GSNode, "closed": bool}
     _defaultsForName = {"closed": True}
     _parent = None
@@ -1875,6 +1927,8 @@ class GSPath(GSBase):
 
 
 class segment(list):
+    __slots__ = ("nodes", "parent", "index")
+
     def appendNode(self, node):
         if not hasattr(
             self, "nodes"
@@ -1990,6 +2044,15 @@ class segment(list):
 
 
 class GSComponent(GSBase):
+    __slots__ = (
+        "alignment",
+        "anchor",
+        "locked",
+        "name",
+        "smartComponentValues",
+        "transform",
+    )
+
     _classesForName = {
         "alignment": int,
         "anchor": str,
@@ -2148,6 +2211,14 @@ class GSComponent(GSBase):
 
 
 class GSSmartComponentAxis(GSBase):
+    __slots__ = (
+        "bottomName",
+        "bottomValue",
+        "name",
+        "topName",
+        "topValue",
+    )
+
     _classesForName = {
         "name": str,
         "bottomName": str,
@@ -2172,6 +2243,8 @@ class GSSmartComponentAxis(GSBase):
 
 
 class GSAnchor(GSBase):
+    __slots__ = ("position", "name")
+
     _classesForName = {"name": str, "position": Point}
     _parent = None
     _defaultsForName = {"position": Point(0, 0)}
@@ -2196,6 +2269,25 @@ class GSAnchor(GSBase):
 
 
 class GSHint(GSBase):
+    __slots__ = (
+        "_origin",
+        "_originNode",
+        "_other1",
+        "_other2",
+        "_otherNode1",
+        "_otherNode2",
+        "_target",
+        "_targetNode",
+        "horizontal",
+        "name",
+        "options",
+        "place",
+        "scale",
+        "settings",
+        "stem",
+        "type",
+    )
+
     _classesForName = {
         "horizontal": bool,
         "options": int,  # bitfield
@@ -2391,6 +2483,8 @@ class GSHint(GSBase):
 
 
 class GSFeature(GSBase):
+    __slots__ = ("automatic", "_code", "disabled", "name", "notes")
+
     _classesForName = {
         "automatic": bool,
         "code": str,
@@ -2446,6 +2540,14 @@ class GSFeaturePrefix(GSFeature):
 
 
 class GSAnnotation(GSBase):
+    __slots__ = (
+        "angle",
+        "position",
+        "text",
+        "type",
+        "width",
+    )
+
     _classesForName = {
         "angle": parse_float_or_int,
         "position": Point,
@@ -2475,6 +2577,27 @@ class GSAnnotation(GSBase):
 
 
 class GSInstance(GSBase):
+    __slots__ = (
+        "_customParameters",
+        "active",
+        "custom",
+        "customValue",
+        "customValue1",
+        "customValue2",
+        "customValue3",
+        "instanceInterpolations",
+        "isBold",
+        "isItalic",
+        "linkStyle",
+        "manualInterpolation",
+        "name",
+        "visible",
+        "weight",
+        "weightValue",
+        "width",
+        "widthValue",
+    )
+
     _classesForName = {
         "customParameters": GSCustomParameter,
         "active": bool,
@@ -2659,6 +2782,17 @@ class GSInstance(GSBase):
 
 
 class GSBackgroundImage(GSBase):
+    __slots__ = (
+        "_R",
+        "_alpha",
+        "_sX",
+        "_sY",
+        "crop",
+        "imagePath",
+        "locked",
+        "transform",
+    )
+
     _classesForName = {
         "crop": Rect,
         "imagePath": str,
@@ -2758,6 +2892,31 @@ class GSBackgroundImage(GSBase):
 
 
 class GSLayer(GSBase):
+    __slots__ = (
+        "_anchors",
+        "_annotations",
+        "_background",
+        "_components",
+        "_guides",
+        "_hints",
+        "_layerId",
+        "_name",
+        "_paths",
+        "_selection",
+        "_userData",
+        "associatedMasterId",
+        "backgroundImage",
+        "color",
+        "leftMetricsKey",
+        "parent",
+        "rightMetricsKey",
+        "vertOrigin",
+        "vertWidth",
+        "visible",
+        "width",
+        "widthMetricsKey",
+    )
+
     _classesForName = {
         "anchors": GSAnchor,
         "annotations": GSAnnotation,
@@ -3057,6 +3216,36 @@ GSLayer._classesForName["background"] = GSBackgroundLayer
 
 
 class GSGlyph(GSBase):
+    __slots__ = (
+        "_layers",
+        "_unicodes",
+        "_userData",
+        "bottomKerningGroup",
+        "bottomMetricsKey",
+        "category",
+        "color",
+        "export",
+        "lastChange",
+        "leftKerningGroup",
+        "leftKerningKey",
+        "leftMetricsKey",
+        "name",
+        "note",
+        "parent",
+        "partsSettings",
+        "production",
+        "rightKerningGroup",
+        "rightKerningKey",
+        "rightMetricsKey",
+        "script",
+        "selected",
+        "subCategory",
+        "topKerningGroup",
+        "topMetricsKey",
+        "vertWidthMetricsKey",
+        "widthMetricsKey",
+    )
+
     _classesForName = {
         "bottomKerningGroup": str,
         "bottomMetricsKey": str,
@@ -3245,6 +3434,37 @@ class GSGlyph(GSBase):
 
 
 class GSFont(GSBase):
+    __slots__ = (
+        "DisplayStrings",
+        "_classes",
+        "_customParameters",
+        "_features",
+        "_glyphs",
+        "_instances",
+        "_kerning",
+        "_masters",
+        "_userData",
+        "_versionMinor",
+        "appVersion",
+        "copyright",
+        "date",
+        "designer",
+        "designerURL",
+        "disablesAutomaticAlignment",
+        "disablesNiceNames",
+        "familyName",
+        "featurePrefixes",
+        "filepath",
+        "grid",
+        "gridSubDivisions",
+        "keepAlternatesTogether",
+        "keyboardIncrement",
+        "manufacturer",
+        "manufacturerURL",
+        "upm",
+        "versionMajor",
+    )
+
     _classesForName = {
         ".appVersion": str,
         "DisplayStrings": str,

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -27,7 +27,7 @@ from glyphsLib.types import (
     Rect,
     parse_datetime,
     parse_color,
-    floatToString,
+    floatToString5,
     readIntlist,
     UnicodesList,
     parse_float_or_int,
@@ -1296,7 +1296,7 @@ class GSAlignmentZone(GSBase):
 
     def plistValue(self):
         return '"{{{}, {}}}"'.format(
-            floatToString(self.position), floatToString(self.size)
+            floatToString5(self.position), floatToString5(self.size)
         )
 
 
@@ -1572,7 +1572,7 @@ class GSNode(GSBase):
             content += " "
             content += self._encode_dict_as_string(string.getvalue())
         return '"{} {} {}"'.format(
-            floatToString(self.position[0]), floatToString(self.position[1]), content
+            floatToString5(self.position[0]), floatToString5(self.position[1]), content
         )
 
     def read(self, line):

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -15,7 +15,6 @@
 
 import re
 import datetime
-import math
 import copy
 import binascii
 
@@ -27,7 +26,8 @@ __all__ = [
     "ValueType",
     "parse_datetime",
     "parse_color",
-    "floatToString",
+    "floatToString3",
+    "floatToString5",
     "readIntlist",
     "UnicodesList",
     "BinaryData",
@@ -97,7 +97,7 @@ def Vector(dim):
 
         def plistValue(self):
             assert isinstance(self.value, list) and len(self.value) == self.dimension
-            return '"{%s}"' % (", ".join(floatToString(v, 3) for v in self.value))
+            return '"{%s}"' % (", ".join(floatToString3(v) for v in self.value))
 
         def __getitem__(self, key):
             assert isinstance(self.value, list) and len(self.value) == self.dimension
@@ -202,7 +202,7 @@ class Rect(Vector(4)):
 
     def plistValue(self):
         assert isinstance(self.value, list) and len(self.value) == self.dimension
-        return '"{{%s, %s}, {%s, %s}}"' % tuple(floatToString(v, 3) for v in self.value)
+        return '"{{%s, %s}, {%s, %s}}"' % tuple(floatToString3(v) for v in self.value)
 
     def __repr__(self):
         return "<rect origin={} size={}>".format(str(self.origin), str(self.size))
@@ -247,7 +247,7 @@ class Transform(Vector(6)):
 
     def plistValue(self):
         assert isinstance(self.value, list) and len(self.value) == self.dimension
-        return '"{%s}"' % (", ".join(floatToString(v, 5) for v in self.value))
+        return '"{%s}"' % (", ".join(floatToString5(v) for v in self.value))
 
 
 UTC_OFFSET_RE = re.compile(r".* (?P<sign>[+-])(?P<hours>\d\d)(?P<minutes>\d\d)$")
@@ -350,37 +350,22 @@ def writeIntlist(val):
     return _mutate_list(str, val)
 
 
-def actualPrecition(Float):
-    ActualPrecition = 5
-    Integer = round(Float * 100000.0)
-    while ActualPrecition >= 0:
-        if Integer != round(Integer / 10.0) * 10:
-            return ActualPrecition
+def floatToString3(f: float) -> str:
+    """Return float f as a string with three decimal places without trailing zeros
+    and dot.
 
-        Integer = round(Integer / 10.0)
-        ActualPrecition -= 1
-
-    if ActualPrecition < 0:
-        ActualPrecition = 0
-    return ActualPrecition
+    Intended for places where three decimals are enough, e.g. node positions.
+    """
+    return f"{f:.3f}".rstrip("0").rstrip(".")
 
 
-def floatToString(Float, precision=3):
-    ActualPrecition = actualPrecition(Float)
-    precision = min(precision, ActualPrecition)
-    fractional = math.modf(math.fabs(Float))[0]
-    if precision >= 5 and 0.000005 <= fractional <= 0.999995:
-        return "%.5f" % Float
-    elif precision >= 4 and 0.00005 <= fractional <= 0.99995:
-        return "%.4f" % Float
-    elif precision >= 3 and 0.0005 <= fractional <= 0.9995:
-        return "%.3f" % Float
-    elif precision >= 2 and 0.005 <= fractional <= 0.995:
-        return "%.2f" % Float
-    elif precision >= 1 and 0.05 <= fractional <= 0.95:
-        return "%.1f" % Float
-    else:
-        return "%.0f" % Float
+def floatToString5(f: float) -> str:
+    """Return float f as a string with five decimal places without trailing zeros
+    and dot.
+
+    Intended for places where five decimals are needed, e.g. transformations.
+    """
+    return f"{f:.5f}".rstrip("0").rstrip(".")
 
 
 class UnicodesList(list):

--- a/Lib/glyphsLib/util.py
+++ b/Lib/glyphsLib/util.py
@@ -35,7 +35,7 @@ def build_ufo_path(out_dir, family_name, style_name):
 
 def open_ufo(path, font_class, **kwargs):
     try:
-        return font_class.open(path, **kwargs)  # ufoLib2
+        return font_class.open(path, lazy=False, **kwargs)  # ufoLib2
     except AttributeError:
         return font_class(path, **kwargs)  # defcon, fontParts, etc.
 

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -14,7 +14,7 @@
 
 
 import glyphsLib.classes
-from glyphsLib.types import floatToString
+from glyphsLib.types import floatToString5
 import logging
 import datetime
 from collections import OrderedDict
@@ -128,7 +128,7 @@ class Writer:
         elif isinstance(value, (dict, OrderedDict, glyphsLib.classes.GSBase)):
             self.writeDict(value)
         elif type(value) == float:
-            self.file.write(floatToString(value, 5))
+            self.file.write(floatToString5(value))
         elif type(value) == int:
             self.file.write(str(value))
         elif type(value) == bool:

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1062,7 +1062,7 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
         assert master.name == "Thin"
         assert master.weight == "Light"
 
-        ufo, = self.to_ufos(font)
+        (ufo,) = self.to_ufos(font)
         font_rt = to_glyphs([ufo])
         master_rt = font_rt.masters[0]
 
@@ -1084,20 +1084,20 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
 
     def test_italic_angle(self):
         font = generate_minimal_font()
-        ufo, = self.to_ufos(font)
+        (ufo,) = self.to_ufos(font)
 
         ufo.info.italicAngle = 1
-        ufo_rt, = self.to_ufos(to_glyphs([ufo]))
+        (ufo_rt,) = self.to_ufos(to_glyphs([ufo]))
         assert ufo_rt.info.italicAngle == 1
 
         ufo.info.italicAngle = 1.5
-        ufo_rt, = self.to_ufos(to_glyphs([ufo]))
+        (ufo_rt,) = self.to_ufos(to_glyphs([ufo]))
         assert ufo_rt.info.italicAngle == 1.5
 
         ufo.info.italicAngle = 0
         font_rt = to_glyphs([ufo])
         assert font_rt.masters[0].italicAngle == 0
-        ufo_rt, = self.to_ufos(font_rt)
+        (ufo_rt,) = self.to_ufos(font_rt)
         assert ufo_rt.info.italicAngle == 0
 
     def test_unique_masterid(self):

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -28,7 +28,7 @@ def roundtrip(ufo, tmpdir, ufo_module):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
     return font, ufo
 
 
@@ -308,7 +308,7 @@ def test_roundtrip_disabled_feature(ufo_module):
     feature.disabled = True
     font.features.append(feature)
 
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
     assert ufo.features.text == dedent(
         """\
         feature ccmp {
@@ -342,7 +342,7 @@ def test_roundtrip_automatic_feature(ufo_module):
     feature.automatic = True
     font.features.append(feature)
 
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
     assert ufo.features.text == dedent(
         """\
         feature ccmp {
@@ -367,7 +367,7 @@ def test_roundtrip_feature_prefix_with_only_a_comment(ufo_module):
     prefix.code = "#include(../family.fea)"
     font.featurePrefixes.append(prefix)
 
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
 
     assert ufo.features.text == dedent(
         """\
@@ -411,7 +411,7 @@ def test_roundtrip_existing_GDEF(tmpdir, ufo_with_GDEF):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    rtufo, = to_ufos(font, generate_GDEF=False, ufo_module=ufo_module)
+    (rtufo,) = to_ufos(font, generate_GDEF=False, ufo_module=ufo_module)
 
     assert rtufo.features.text == gdef
 
@@ -451,7 +451,7 @@ def test_groups_remain_at_top(tmpdir, ufo_module):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    rtufo, = to_ufos(font, ufo_module=ufo_module)
+    (rtufo,) = to_ufos(font, ufo_module=ufo_module)
 
     fea_rt = rtufo.features.text
     assert fea_rt.index("@FIG_DFLT") < fea_rt.index("lookup") < fea_rt.index("feature")
@@ -464,7 +464,7 @@ def test_roundtrip_empty_feature(ufo_module):
     feature.code = ""
     font.features.append(feature)
 
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
     assert ufo.features.text == dedent(
         """\
         feature dlig {

--- a/tests/builder/fontinfo_test.py
+++ b/tests/builder/fontinfo_test.py
@@ -440,7 +440,7 @@ def test_info(fields, tmpdir, ufo_module):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
 
     for field in fields:
         assert getattr(ufo.info, field.name) == field.test_value
@@ -459,7 +459,7 @@ def test_info_gasp_ranges(tmpdir, ufo_module):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
 
     assert [dict(r) for r in ufo.info.openTypeGaspRangeRecords] == gasp_ranges
 
@@ -490,7 +490,7 @@ def test_info_name_records(tmpdir, ufo_module):
     filename = os.path.join(str(tmpdir), "font.glyphs")
     font.save(filename)
     font = classes.GSFont(filename)
-    ufo, = to_ufos(font, ufo_module=ufo_module)
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
 
     print(ufo.info.openTypeNameRecords)
     assert [dict(r) for r in ufo.info.openTypeNameRecords] == name_records

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -168,7 +168,7 @@ def test_ufo_data_into_font_master_user_data(tmpdir, ufo_module):
         "org.customTool/ufoData.bin": BinaryData(data)
     }
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert ufo.data[filename] == data
 
@@ -190,7 +190,7 @@ def test_layer_lib_into_font_user_data(ufo_module):
         "layerLibKey2": "layerLibValue2"
     }
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert ufo.layers["public.default"].lib["layerLibKey1"] == "layerLibValue1"
     assert "layerLibKey1" not in ufo.layers["sketches"].lib
@@ -208,7 +208,7 @@ def test_glyph_user_data_into_ufo_lib():
     layer.layerId = font.masters[0].id
     glyph.layers.append(layer)
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert ufo.lib[GLYPHLIB_PREFIX + "glyphUserData.a"] == {
         "glyphUserDataKey": "glyphUserDataValue"
@@ -251,7 +251,7 @@ def test_glif_lib_equivalent_to_layer_user_data(ufo_module):
     assert "glifLibKeyB" not in default_layer.userData.keys()
     assert middleground.userData["glifLibKeyB"] == "glifLibValueB"
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert ufo["a"].lib["glifLibKeyA"] == "glifLibValueA"
     assert "glifLibKeyA" not in ufo.layers["middleground"]["a"]
@@ -281,7 +281,7 @@ def test_node_user_data_into_glif_lib():
     path.nodes.append(classes.GSNode())
     path.nodes.append(node2)
 
-    ufo, = to_ufos(font, minimize_glyphs_diffs=True)
+    (ufo,) = to_ufos(font, minimize_glyphs_diffs=True)
 
     assert ufo["a"].lib[GLYPHLIB_PREFIX + "nodeUserData.0.1"] == {
         "nodeUserDataKey1": "nodeUserDataValue1"
@@ -327,7 +327,7 @@ def test_lib_data_types(tmpdir, ufo_module):
     # font.save(filename)
     # font = classes.GSFont(filename)
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     for index, (key, value) in enumerate(data.items()):
         assert value == ufo["a"].lib[key]

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -161,7 +161,7 @@ def test_groups(ufo_module):
     # somehow, but we don't care how, that fact will be better tested by the
     # roundtrip test a few lines below
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     # Check that nothing has changed
     assert dict(ufo.groups) == groups_dict
@@ -176,7 +176,7 @@ def test_groups(ufo_module):
     groups_dict["public.kern1.halfInFont"].remove("o")
     groups_dict["public.kern1.onItsOwnO"] = ["o"]
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert dict(ufo.groups) == groups_dict
 
@@ -211,7 +211,7 @@ def test_guidelines(ufo_module):
         assert horizontal.position.y == 20
         assert horizontal.angle == 0
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     for obj in [ufo, ufo["a"]]:
         angled, vertical, horizontal = obj.guidelines
@@ -246,7 +246,7 @@ def test_glyph_color(ufo_module):
     rt_b_color = font.glyphs["b"].color
     assert rt_b_color == [4, 128, 0, 255] and all(type(x) is int for x in rt_b_color)
 
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert ufo["a"].markColor == GLYPHS_COLORS[3]
     assert ufo["b"].markColor == b.markColor
@@ -413,7 +413,7 @@ def test_dont_copy_advance_to_the_background_unless_it_was_there(tmpdir, ufo_mod
     saved_font = classes.GSFont(path)
 
     for font in [font, saved_font]:
-        ufo, = to_ufos(font)
+        (ufo,) = to_ufos(font)
 
         assert ufo["a"].width == 100
         assert ufo.layers["public.background"]["a"].width == 0
@@ -442,7 +442,7 @@ def test_double_unicodes(tmpdir, ufo_module):
         assert font.glyphs["z"].unicode == "005A"
         assert font.glyphs["z"].unicodes == ["005A", "007A"]
 
-        ufo, = to_ufos(font)
+        (ufo,) = to_ufos(font)
 
         assert ufo["z"].unicodes == [0x005A, 0x007A]
 
@@ -462,7 +462,7 @@ def test_open_contour(ufo_module):
     assert len(path.nodes) == 2
     assert path.nodes[0].type == classes.LINE
 
-    ufo_rt, = to_ufos(font)
+    (ufo_rt,) = to_ufos(font)
 
     assert [(p.segmentType, p.x, p.y) for p in a[0]] == [
         (p.segmentType, p.x, p.y) for p in ufo_rt["a"][0]
@@ -530,7 +530,7 @@ def test_custom_stylemap_style_name(ufo_module):
     ufo.info.styleMapStyleName = "bold"  # Not "regular"
 
     font = to_glyphs([ufo], minimize_ufo_diffs=True)
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     assert ufo.info.styleMapStyleName == "bold"
 
@@ -587,7 +587,7 @@ def test_weird_kerning_roundtrip(ufo_module):
         ufo.kerning[k] = v
 
     font = to_glyphs([ufo])
-    ufo, = to_ufos(font)
+    (ufo,) = to_ufos(font)
 
     # The kerning and groups should round-trip untouched
     for name, glyphs in groups.items():

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -47,6 +47,9 @@ from glyphsLib.classes import (
     CIRCLE,
     PLUS,
     MINUS,
+    LINE,
+    CURVE,
+    OFFCURVE,
 )
 from glyphsLib.types import Point, Transform, Rect
 
@@ -1562,7 +1565,7 @@ class GSNodeFromFileTest(GSObjectsTestCase):
         self.assertIsInstance(self.node.position, Point)
 
     def test_type(self):
-        self.assertTrue(self.node.type in [GSNode.LINE, GSNode.CURVE, GSNode.OFFCURVE])
+        self.assertTrue(self.node.type in [LINE, CURVE, OFFCURVE])
 
     def test_smooth(self):
         self.assertBool(self.node.smooth)

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -986,7 +986,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         )
 
     def test_write_node(self):
-        node = classes.GSNode(Point(10, 30), classes.GSNode.CURVE)
+        node = classes.GSNode(Point(10, 30), classes.CURVE)
         # http://docu.glyphsapp.com/#gsnode
         # position: already set
         # #type: already set
@@ -1006,7 +1006,7 @@ rememberToDownloadARealRemindersApp = 1;}"',
         )
 
         # Write floating point coordinates
-        node = classes.GSNode(Point(499.99, 512.01), classes.GSNode.OFFCURVE)
+        node = classes.GSNode(Point(499.99, 512.01), classes.OFFCURVE)
         self.assertWritesValue(node, '"499.99 512.01 OFFCURVE"')
 
         # Write userData with special characters
@@ -1015,7 +1015,7 @@ rememberToDownloadARealRemindersApp = 1;}"',
             ";": ";\n",
             "escapeception": "\\\"\\'\\n\\\\n",
         }
-        node = classes.GSNode(Point(130, 431), classes.GSNode.LINE)
+        node = classes.GSNode(Point(130, 431), classes.LINE)
         for key, value in test_user_data.items():
             node.userData[key] = value
         # This is the output of Glyphs 1089


### PR DESCRIPTION
I discovered https://github.com/nvdv/vprof and used it to run this script (Cantarell from https://gitlab.gnome.org/GNOME/cantarell-fonts/tree/dd36d229a2c304d17052dd62ad959f4e210c3c75/src):

```Python
import glyphsLib.cli

glyphsLib.cli.main(["ufo2glyphs", "Cantarell.designspace"])
```

Fedora 31 x64, Python 3.7.5, Ryzen 1700, all data in /tmp, which is a RAM-based tmpfs.

![init](https://user-images.githubusercontent.com/380829/70389807-665ae380-19bc-11ea-87e0-d0042b4f4349.png)

I tackled `GSNode._indices()` and `floatToString`.

After not calling `_indices()` on every node:

![second](https://user-images.githubusercontent.com/380829/70389844-ca7da780-19bc-11ea-9b6d-234a00aa37a0.png)

After simplifying `floatToString`:

![third](https://user-images.githubusercontent.com/380829/70389853-de290e00-19bc-11ea-9098-2098bcc5cb5d.png)

That shaved off roughly 1 second, so it's a ~25% speed up :)
