### PR TITLE
Rename glyph layers when duplicate

### DIFF
--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from .constants import GLYPHS_PREFIX
 
 LAYER_ID_KEY = GLYPHS_PREFIX + "layerId"
@@ -26,6 +25,22 @@ def to_ufo_layer(self, glyph, layer):
         ufo_layer = ufo_font.layers.defaultLayer
     elif layer.name not in ufo_font.layers:
         ufo_layer = ufo_font.newLayer(layer.name)
+    elif layer.name in ufo_font.layers and glyph.name in ufo_font.layers[layer.name]:
+        self.logger.warning(
+            "%s %s: Glyph %s, layer %s: Duplicate glyph layer name"
+            % (
+                ufo_font.info.familyName,
+                ufo_font.info.styleName,
+                glyph.name,
+                layer.name,
+            )
+        )
+        n = 1
+        new_layer_name = layer.name
+        while new_layer_name in ufo_font.layers:
+            new_layer_name = layer.name + " #" + repr(n)
+            n += 1
+        ufo_layer = ufo_font.newLayer(new_layer_name)
     else:
         ufo_layer = ufo_font.layers[layer.name]
     if self.minimize_glyphs_diffs:

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -829,6 +829,30 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
         ufo = self.to_ufos(font)[0]
         self.assertEqual([l.name for l in ufo.layers], ["public.default", "SubLayer"])
 
+    def test_duplicate_supplementary_layers(self):
+        """Test glyph layers with same name."""
+        font = generate_minimal_font()
+        glyph = GSGlyph(name="a")
+        font.glyphs.append(glyph)
+        layer = GSLayer()
+        layer.layerId = font.masters[0].id
+        layer.width = 0
+        glyph.layers.append(layer)
+        sublayer = GSLayer()
+        sublayer.associatedMasterId = font.masters[0].id
+        sublayer.width = 0
+        sublayer.name = "SubLayer"
+        glyph.layers.append(sublayer)
+        sublayer = GSLayer()
+        sublayer.associatedMasterId = font.masters[0].id
+        sublayer.width = 0
+        sublayer.name = "SubLayer"
+        glyph.layers.append(sublayer)
+        ufo = self.to_ufos(font)[0]
+        self.assertEqual(
+            [l.name for l in ufo.layers], ["public.default", "SubLayer", "SubLayer #1"]
+        )
+
     def test_glyph_lib_Export(self):
         font = generate_minimal_font()
         glyph = add_glyph(font, "a")


### PR DESCRIPTION
Glyph sub layers are sometimes duplicated in Glyhps.app source files.
For example if a user double-clicks on "Copy layer"  or for other reasons, a glyph "a" may have two glyph layers called "Dec 16 19, 12:00". Writing the UFO will fail when trying to write the glyph to "Dec 16 19, 12:00" twice.

This PR "solves" this by renaming the second layer, adding " #1", or " #n+1" .