### PR TITLE
Copy glyphOrder lib key/custom parameter verbatim

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -617,21 +617,15 @@ class GlyphOrderParamHandler(AbstractParamHandler):
 
     def to_glyphs(self, glyphs, ufo):
         if glyphs.is_font():
-            glyphs_glyphOrder = ufo.get_lib_value(GLYPHS_PREFIX + "glyphOrder")
-            if isinstance(glyphs_glyphOrder, list):
-                glyphs.set_custom_value("glyphOrder", glyphs_glyphOrder)
-            elif glyphs_glyphOrder is None:
-                ufo_glyphOrder = ufo.get_lib_value(PUBLIC_PREFIX + "glyphOrder")
-                if ufo_glyphOrder:
-                    glyphs.set_custom_value("glyphOrder", ufo_glyphOrder)
+            ufo_glyphOrder = ufo.get_lib_value(PUBLIC_PREFIX + "glyphOrder")
+            if ufo_glyphOrder:
+                glyphs.set_custom_value("glyphOrder", ufo_glyphOrder)
 
     def to_ufo(self, builder, glyphs, ufo):
         if glyphs.is_font():
             glyphs_glyphOrder = glyphs.get_custom_value("glyphOrder")
             if glyphs_glyphOrder:
                 ufo.set_lib_value(PUBLIC_PREFIX + "glyphOrder", glyphs_glyphOrder)
-            else:
-                ufo.set_lib_value(GLYPHS_PREFIX + "glyphOrder", False)
 
 
 register(GlyphOrderParamHandler())

--- a/Lib/glyphsLib/builder/font.py
+++ b/Lib/glyphsLib/builder/font.py
@@ -75,6 +75,9 @@ def to_ufo_font_attributes(self, family_name):
         if manufacturer_url:
             ufo.info.openTypeNameManufacturerURL = manufacturer_url
 
+        # NOTE: glyphs2ufo will *always* set a UFO public.glyphOrder equal to the
+        # order of glyphs in the glyphs file, which can optionally be overwritten
+        # by a glyphOrder custom parameter below in `to_ufo_custom_params`.
         ufo.glyphOrder = glyph_order
 
         self.to_ufo_names(ufo, master, family_name)

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1426,61 +1426,38 @@ class SkipDanglingAndNamelessLayersTestDefcon(
 class GlyphOrderTestBase(object):
     """Check that the glyphOrder data is persisted correctly in all directions.
 
-    Problem: Glyphs.app (tested 2.4.1 and 2.5.2) does not import and export a
-    UFO's public.glyphOrder lib key verbatim. To prevent the glyph order from
-    changing when exporting to UFO from within Glyphs.app, working on the UFO
-    and re-opening it in Glyphs.app, it will:
+    When Glyphs 2.6.1 opens a UFO with a public.glyphOrder key and...
 
-    1. if a glyphOrder parameter is present, write it verbatim to the
-       `com.schriftgestaltung.glyphOrder` as a list and write a
-       cleaned-up version of it (e.g. only existing glyphs plus ones not covered
-       in it but present in the font) to `public.glyphOrder`.
-    2. if a glyphOrder parameter is not present, write the implicit order of the
-       font to `public.glyphOrder` and write the
-       `com.schriftgestaltung.glyphOrder` lib key with the value `False`.
+    1. ... no com.schriftgestaltung.glyphOrder key, it will copy
+       public.glyphOrder verbatim to the font's custom parameter glyphOrder,
+       including non-existant glyphs. It will sort the glyphs ("Predefined
+       Sorting") as specified by the font's custom parameter glyphOrder.
+    2. ... a com.schriftgestaltung.glyphOrder key set to a list of glyph names,
+       it will copy com.schriftgestaltung.glyphOrder verbatim to the font's custom
+       parameter glyphOrder, including non-existant glyphs. It will not reorder
+       the glyphs and instead display them as specified in public.glyphOrder. If
+       the glyphs aren't grouped by category, it may make repeated category groups
+       (e.g. Separator: .notdef, Punctuation: period, Separator: nbspace).
+    3. ... a com.schriftgestaltung.glyphOrder key set to False, it will not
+       copy public.glyphOrder at all and there is no font custom parameter
+       glyphOrder. It will also not sort the glyphs and instead display them as
+       specified in public.glyphOrder. Round-tripping back will therefore
+       overwrite public.glyphOrder with the order of the .glyphs file.
 
-    On reading a UFO, Glyphs.app will:
+    When Glyphs 2.6.1 opens a UFO _without_ a public.glyphOrder key and...
 
-    1. if a `com.schriftgestaltung.glyphOrder` lib key is present and holds a
-       list, copy it to the `glyphOrder` parameter.
-    2. if a `com.schriftgestaltung.glyphOrder` lib key is present and holds the
-       value `False`, not set a `glyphOrder` parameter and use its own ordering
-       instead. Side-note: Glyphs.app will get confused if the
-       `public.glyphOrder` now contains non-existant glyphs and may crash on
-       saving.
-    3. if no `com.schriftgestaltung.glyphOrder` lib key is present, copy
-       `public.glyphOrder` to the `glyphOrder` parameter.
-    4. if no `public.glyphOrder` exist, maybe get confused and crash.
+    1. ... no com.schriftgestaltung.glyphOrder key, it will sort the glyphs in
+       the typical Glyphs way and not create a font custom parameter glyphOrder.
+    2. ... a com.schriftgestaltung.glyphOrder key set to a list of glyph names,
+       it will copy com.schriftgestaltung.glyphOrder verbatim to the font's custom
+       parameter glyphOrder, including non-existant glyphs and will sort the
+       glyphs ("Predefined Sorting") as specified by the font's custom parameter
+       glyphOrder.
+    3. ... a com.schriftgestaltung.glyphOrder key set to False, it will sort
+       the glyphs in the typical Glyphs way and not create a font custom parameter
+       glyphOrder.
 
-    To work with this instead of against it and reduce Git diff noise on
-    round-tripping, do the following:
-
-    1. Glyphs to UFO: If a .glyphs file has...
-        1. no `glyphOrder` parameter set, the implicit order of glyphs becomes
-           the `public.glyphOrder` lib key and the
-           `com.schriftgestaltung.glyphOrder` lib key is set to `False`.
-        2. a `glyphOrder` parameter set, it gets copied to the
-           `public.glyphOrder` lib key, the `com.schriftgestaltung.glyphOrder`
-           lib key is not written.
-    2. UFO to Glyphs: If a UFO has...
-        1. a `com.schriftgestaltung.glyphOrder` lib key holding a list, it gets
-           copied to the `glyphOrder` parameter.
-        2. a `com.schriftgestaltung.glyphOrder` lib key holding the value
-           `False`, do not set a `glyphOrder` parameter.
-        3. a `public.glyphOrder` and no `com.schriftgestaltung.glyphOrder` key,
-           copy `public.glyphOrder` to the `glyphOrder` parameter.
-        4. no `public.glyphOrder` lib key, do not set the `glyphOrder`
-           parameter.
-
-    This covers the case of using Glyphs' UFO exporting mechanism and using
-    glyphslib to turn it into a Glyphs file again, as well as using glyphsLib to
-    produce UFOs from a .glyphs file and opening them in Glyphs.app again. It
-    also preserves existing public.glyphOrder from other tools.
-
-    TODO: these test cases do not exhaustively check for the glyph order in
-    GSFont objects, because we don't know Glyphs.app's ordering rules. E.g. a
-    test should set a UFOs `public.glyphOrder` to ["d", "c", "b", "a"] and check
-    that the resulting GSFont glyph order is ["c", "a", "f"].
+    For simplicity, we always write the glyphOrder both ways if it exists.
     """
 
     ufo_module = None  # subclasses must override this
@@ -1488,13 +1465,15 @@ class GlyphOrderTestBase(object):
     def setUp(self):
         self.font = GSFont()
         self.font.masters.append(GSFontMaster())
-        self.font.glyphs.append(GSGlyph("a"))
         self.font.glyphs.append(GSGlyph("c"))
+        self.font.glyphs.append(GSGlyph("a"))
         self.font.glyphs.append(GSGlyph("f"))
         self.ufo = self.ufo_module.Font()
-        self.ufo.newGlyph("a")
         self.ufo.newGlyph("c")
+        self.ufo.newGlyph("a")
         self.ufo.newGlyph("f")
+        # NOTE: defcon always creates a public.glyphOrder, do it here for ufoLib2.
+        self.ufo.lib["public.glyphOrder"] = ["c", "a", "f"]
 
     def from_glyphs(self):
         builder = UFOBuilder(self.font, ufo_module=self.ufo_module)
@@ -1506,37 +1485,38 @@ class GlyphOrderTestBase(object):
 
     def test_glyphs_to_ufo_no_glyphOrder(self):
         ufo = self.from_glyphs()
-        self.assertEqual(["a", "c", "f"], ufo.glyphOrder)
-        self.assertFalse(ufo.lib[GLYPHS_PREFIX + "glyphOrder"])
+        self.assertEqual(["c", "a", "f"], ufo.glyphOrder)
+        self.assertIsNone(ufo.lib.get(GLYPHS_PREFIX + "glyphOrder"))
 
     def test_glyphs_to_ufo_with_glyphOrder(self):
         self.font.customParameters["glyphOrder"] = ["a", "b", "c", "d"]
         ufo = self.from_glyphs()
         self.assertEqual(["a", "b", "c", "d"], ufo.glyphOrder)
-        self.assertNotIn(GLYPHS_PREFIX + "glyphOrder", ufo.lib)
+        self.assertIsNone(ufo.lib.get(GLYPHS_PREFIX + "glyphOrder"))
 
     def test_ufo_to_glyphs_with_csgO_list(self):
         self.ufo.lib[GLYPHS_PREFIX + "glyphOrder"] = ["a", "b", "c", "d"]
         font = self.from_ufo()
-        self.assertEqual(["a", "b", "c", "d"], font.customParameters["glyphOrder"])
-        self.assertEqual(["a", "c", "f"], [glyph.name for glyph in font.glyphs])
+        self.assertEqual(["c", "a", "f"], font.customParameters["glyphOrder"])
+        self.assertEqual(["c", "a", "f"], [glyph.name for glyph in font.glyphs])
 
     def test_ufo_to_glyphs_with_csgO_false(self):
         self.ufo.lib[GLYPHS_PREFIX + "glyphOrder"] = False
         font = self.from_ufo()
-        self.assertNotIn("glyphOrder", font.customParameters)
-        self.assertEqual(["a", "c", "f"], [glyph.name for glyph in font.glyphs])
+        self.assertEqual(["c", "a", "f"], font.customParameters["glyphOrder"])
+        self.assertEqual(["c", "a", "f"], [glyph.name for glyph in font.glyphs])
 
     def test_ufo_to_glyphs_only_pgO(self):
-        self.ufo.lib["public.glyphOrder"] = ["a", "c", "f"]
+        self.ufo.lib["public.glyphOrder"] = ["c", "x", "f"]
         font = self.from_ufo()
-        self.assertEqual(["a", "c", "f"], font.customParameters["glyphOrder"])
-        self.assertEqual(["a", "c", "f"], [glyph.name for glyph in font.glyphs])
+        self.assertEqual(["c", "x", "f"], font.customParameters["glyphOrder"])
+        self.assertEqual(["c", "f", "a"], [glyph.name for glyph in font.glyphs])
 
     def test_ufo_to_glyphs_no_pgO(self):
         if "public.glyphOrder" in self.ufo.lib:
             del self.ufo.lib["public.glyphOrder"]
         font = self.from_ufo()
+        assert "public.glyphOrder" not in self.ufo.lib
         self.assertNotIn("glyphOrder", font.customParameters)
         self.assertEqual(
             [glyph.name for glyph in self.ufo], [glyph.name for glyph in font.glyphs]


### PR DESCRIPTION
Closes https://github.com/googlefonts/glyphsLib/issues/560.

The idea is to not be smart and copy `public.GlyphOrder` to the Font's custom parameters verbatim and back if it exists.