### PR TITLE
glyphdata: Handle ligatures with suffix

### DIFF
--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -187,6 +187,12 @@ def _construct_category(glyph_name, data):
     # Detect ligatures.
     if "_" in base_name:
         base_names = base_name.split("_")
+        # The last name has a suffix, add it to all the names.
+        if "-" in base_names[-1]:
+            _, s = base_names[-1].rsplit("-", 1)
+            base_names = [
+                (n if n.endswith(f"-{s}") else f"{n}-{s}") for n in base_names
+            ]
         base_names_attributes = [_lookup_attributes(name, data) for name in base_names]
         first_attribute = base_names_attributes[0]
 

--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -136,6 +136,8 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(cat("O_nbspace"), ("Letter", "Uppercase"))
         self.assertEqual(cat("_a"), (None, None))
         self.assertEqual(cat("_aaa"), (None, None))
+        self.assertEqual(cat("dal_alef-ar"), ("Letter", "Ligature"))
+        self.assertEqual(cat("dal_lam-ar.dlig"), ("Letter", "Ligature"))
 
     def test_bug232(self):
         # https://github.com/googlefonts/glyphsLib/issues/232


### PR DESCRIPTION
GlyphsLib fails to detect the category of glyphs like `dal_alef-ar` that GlyphsApp correctly classifies as Letter, Ligature.