### PR TITLE
Implement GSFont.axes

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -21,7 +21,7 @@ import re
 import uuid
 from collections import OrderedDict
 from io import StringIO
-from typing import Dict, List
+from typing import Dict, List, Union, Tuple
 
 import glyphsLib
 from glyphsLib.affine import Affine
@@ -1507,6 +1507,21 @@ class GSFontMaster(GSBase):
             # Only write out the name if we can't make it by joining the parts
             return self._name != self.name
         return super().shouldWriteValueForKey(key)
+
+    @property
+    def axes(self) -> Tuple[Union[int, float], ...]:
+        axis_num = len(self.font.axes)
+        return tuple(
+            getattr(self, attr)
+            for attr in (
+                "weightValue",
+                "widthValue",
+                "customValue",
+                "customValue1",
+                "customValue2",
+                "customValue3",
+            )[:axis_num]
+        )
 
     @property
     def name(self):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -183,6 +183,76 @@ class GSFontTest(unittest.TestCase):
         font.masters.append(master)
         self.assertEqual(master.font, font)
 
+    def test_axes_default(self):
+        font = GSFont()
+        self.assertEqual(font.axes, [{"Name": "Weight", "Tag": "wght"}])
+
+    def test_axes_more_axes(self):
+        font = GSFont()
+        master = GSFontMaster()
+        font.masters.append(master)
+        master2 = GSFontMaster()
+        font.masters.append(master2)
+        self.assertEqual(font.axes, [{"Name": "Weight", "Tag": "wght"}])
+
+        master2.widthValue = 1
+        self.assertEqual(
+            font.axes,
+            [{"Name": "Weight", "Tag": "wght"}, {"Name": "Width", "Tag": "wdth"}],
+        )
+
+        master.customValue3 = 1
+        self.assertEqual(
+            font.axes,
+            [
+                {"Name": "Weight", "Tag": "wght"},
+                {"Name": "Width", "Tag": "wdth"},
+                {"Name": "Custom", "Tag": "CUS1"},
+                {"Name": "Custom2", "Tag": "CUS2"},
+                {"Name": "Custom3", "Tag": "CUS3"},
+                {"Name": "Custom4", "Tag": "CUS4"},
+            ],
+        )
+
+        font.customParameters["Axes"] = []
+        self.assertEqual(
+            font.axes,
+            [
+                {"Name": "Weight", "Tag": "wght"},
+                {"Name": "Width", "Tag": "wdth"},
+                {"Name": "Custom", "Tag": "CUS1"},
+                {"Name": "Custom2", "Tag": "CUS2"},
+                {"Name": "Custom3", "Tag": "CUS3"},
+                {"Name": "Custom4", "Tag": "CUS4"},
+            ],
+        )
+
+    def test_axes_parameter(self):
+        font = GSFont()
+        # The following entries are the default strings if you repeatedly add
+        # axes in Glyphs' "Axes" dialog but don't change them.
+        font.customParameters["Axes"] = [
+            {"Name": "Weight", "Tag": "wght"},
+            {"Name": "Empty Name", "Tag": "EMPT"},
+            {"Name": "Empty Name", "Tag": "EMPT"},
+            {"Name": "Empty Name", "Tag": "EMPT"},
+            {"Name": "Empty Name", "Tag": "EMPT"},
+            {"Name": "Empty Name", "Tag": "EMPT"},
+            {"Name": "Empty Name", "Tag": "EMPT"},
+        ]
+        self.assertEqual(
+            font.axes,
+            [
+                {"Name": "Weight", "Tag": "wght"},
+                {"Name": "Empty Name", "Tag": "EMPT"},
+                {"Name": "Empty Name", "Tag": "EMPT"},
+                {"Name": "Empty Name", "Tag": "EMPT"},
+                {"Name": "Empty Name", "Tag": "EMPT"},
+                {"Name": "Empty Name", "Tag": "EMPT"},
+                {"Name": "Empty Name", "Tag": "EMPT"},
+            ],
+        )
+
 
 class GSObjectsTestCase(unittest.TestCase):
     def setUp(self):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -194,12 +194,15 @@ class GSFontTest(unittest.TestCase):
         master2 = GSFontMaster()
         font.masters.append(master2)
         self.assertEqual(font.axes, [{"Name": "Weight", "Tag": "wght"}])
+        self.assertEqual(master.axes, (100,))
+        self.assertEqual(master2.axes, (100,))
 
         master2.widthValue = 1
         self.assertEqual(
             font.axes,
             [{"Name": "Weight", "Tag": "wght"}, {"Name": "Width", "Tag": "wdth"}],
         )
+        self.assertEqual(master2.axes, (100, 1))
 
         master.customValue3 = 1
         self.assertEqual(
@@ -213,6 +216,8 @@ class GSFontTest(unittest.TestCase):
                 {"Name": "Custom4", "Tag": "CUS4"},
             ],
         )
+        self.assertEqual(master.axes, (100, 100, 0, 0, 0, 1))
+        self.assertEqual(master2.axes, (100, 1, 0, 0, 0, 0))
 
         font.customParameters["Axes"] = []
         self.assertEqual(
@@ -226,6 +231,8 @@ class GSFontTest(unittest.TestCase):
                 {"Name": "Custom4", "Tag": "CUS4"},
             ],
         )
+        self.assertEqual(master.axes, (100, 100, 0, 0, 0, 1))
+        self.assertEqual(master2.axes, (100, 1, 0, 0, 0, 0))
 
     def test_axes_parameter(self):
         font = GSFont()


### PR DESCRIPTION
This PR goes towards supporting the Axes font-level parameter (https://github.com/googlefonts/glyphsLib/issues/585). I want to use it later for determining what axes to write to the Designspace.