### PR TITLE
Keep Axis axes

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -146,6 +146,19 @@ def to_designspace_axes(self):
         axis.name = axis_def.name
         # TODO add support for localised axis.labelNames when Glyphs.app does
 
+        # NOTE: The following is a hack because this entire method is.
+        # get_axis_definitions may or may not generate axes that are in the font,
+        # so the bottom `if` statement filters out axes that it guesses don't actually
+        # exist. This results in the edge case where you have a single master at the
+        # default location and end up with no axes. Therefore, we make sure here that
+        # if there is an Axes parameter, we actually really keep axes that are defined
+        # in there.
+        axis_wanted = False
+        if any(
+            a.get("Tag") == axis.tag for a in self.font.customParameters["Axes"] or []
+        ):
+            axis_wanted = True
+
         # See https://github.com/googlefonts/glyphsLib/issues/280
         if font_uses_new_axes(self.font):
             # Build the mapping from the "Axis Location" of the masters
@@ -206,6 +219,7 @@ def to_designspace_axes(self):
             minimum < maximum
             or minimum != axis_def.default_user_loc
             or not is_identity_map
+            or axis_wanted
         ):
             if not is_identity_map:
                 axis.map = sorted(mapping.items())

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -146,13 +146,11 @@ def to_designspace_axes(self):
         axis.name = axis_def.name
         # TODO add support for localised axis.labelNames when Glyphs.app does
 
-        # NOTE: The following is a hack because this entire method is.
-        # get_axis_definitions may or may not generate axes that are in the font,
-        # so the bottom `if` statement filters out axes that it guesses don't actually
-        # exist. This results in the edge case where you have a single master at the
-        # default location and end up with no axes. Therefore, we make sure here that
-        # if there is an Axes parameter, we actually really keep axes that are defined
-        # in there.
+        # Make sure here that if there is an Axes parameter, we actually really
+        # keep axes that are defined in it, even if they do nothing. This
+        # prevents an edge case where you have a single master at the default
+        # location that ends in with a Designspace with no axes, as they were
+        # all filtered out by the `if` statement at the bottom.
         axis_wanted = False
         if any(
             a.get("Tag") == axis.tag for a in self.font.customParameters["Axes"] or []

--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -271,3 +271,15 @@ def test_custom_parameter_vfo_not_set():
     assert font.customParameters["Variation Font Origin"] is None
     default_master = get_regular_master(font)
     assert default_master.name == "Regular Text"
+
+
+def test_wheres_ma_axis(datadir):
+    font1 = GSFont(datadir.join("AxesWdth.glyphs"))
+    doc1 = to_designspace(font1)
+    assert [a.tag for a in doc1.axes] == ["wdth"]
+
+
+def test_wheres_ma_axis2(datadir):
+    font2 = GSFont(datadir.join("AxesWdthWght.glyphs"))
+    doc2 = to_designspace(font2)
+    assert [a.tag for a in doc2.axes] == ["wdth", "wght"]

--- a/tests/data/AxesWdth.glyphs
+++ b/tests/data/AxesWdth.glyphs
@@ -1,0 +1,30 @@
+{
+.appVersion = "1286";
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Width;
+Tag = wdth;
+}
+);
+}
+);
+date = "2020-02-14 13:24:41 +0000";
+familyName = "Neue Schrift";
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "35BEE313-1FD1-491B-9B8D-FF684D71037F";
+xHeight = 500;
+}
+);
+glyphs = (
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/data/AxesWdthWght.glyphs
+++ b/tests/data/AxesWdthWght.glyphs
@@ -1,0 +1,34 @@
+{
+.appVersion = "1286";
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Width;
+Tag = wdth;
+},
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2020-02-14 13:24:41 +0000";
+familyName = "Neue Schrift";
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "35BEE313-1FD1-491B-9B8D-FF684D71037F";
+xHeight = 500;
+}
+);
+glyphs = (
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Add yet another heuristic to prevent a glyphs2ufo edge case where you have a single master at the default location and end up with a Designspace with no axes. If you have an Axes parameter, try to put the axes mentioned in there into the Designspace.