### PR TITLE
Fix import statement in unit test

### DIFF
--- a/tests/run_various_tests_on_various_files.py
+++ b/tests/run_various_tests_on_various_files.py
@@ -22,7 +22,7 @@ import ufoLib2
 
 import glyphsLib
 from fontTools.designspaceLib import DesignSpaceDocument
-import test_helpers
+from . import test_helpers
 
 
 # Kinds of tests that can be run


### PR DESCRIPTION
Changed to a relative import, which it actually is. Before this change,
Python setuptools was unable to run glyphsLib unit tests on Alpine Linux.
(Alpine seems to be more strict on Python import paths?) After this change,
the unit tests get executed. They still fail, but that is another problem.

Here’s the traceback of the error before this change:

```
run_various_tests_on_various_files (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: run_various_tests_on_various_files (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: run_various_tests_on_various_files
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/builder/aports/testing/py3-glyphslib/src/glyphsLib-5.1.7/tests/run_various_tests_on_various_files.py", line 25, in <module>
    import test_helpers
ModuleNotFoundError: No module named 'test_helpers'
```