### PR TITLE
Improve brace layer name diagnostics

### DIFF
--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -160,12 +160,19 @@ def _to_designspace_source_layer(self):
     layers_to_insert = collections.defaultdict(list)
     for layer_name, master_ids in layer_name_to_master_ids.items():
         # Construct coordinates first...
-        brace_coordinates = [
-            int(c)
-            for c in layer_name[
-                layer_name.index("{") + 1 : layer_name.index("}")
-            ].split(",")
-        ]
+        try:
+            brace_coordinates = [
+                int(c)
+                for c in layer_name[
+                    layer_name.index("{") + 1 : layer_name.index("}")
+                ].split(",")
+            ]
+        except ValueError as e:
+            raise ValueError(
+                "{}: brace layers must be defined with an integer value, received {}".format(
+                    e, layer_name
+                )
+            )
 
         for master_id in master_ids:
             # ... as they may need to be filled up with the values of the associated

--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -169,9 +169,8 @@ def _to_designspace_source_layer(self):
             ]
         except ValueError as e:
             raise ValueError(
-                "{}: brace layers must be defined with an integer value, received {}".format(
-                    e, layer_name
-                )
+                "{}: brace layers must be defined with an "
+                "integer value, received {}".format(e, layer_name)
             )
 
         for master_id in master_ids:

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1541,5 +1541,36 @@ class GlyphOrderTestDefcon(GlyphOrderTestBase, unittest.TestCase):
     ufo_module = defcon
 
 
+class BraceLayerValidityTest(unittest.TestCase):
+    def test_brace_layers_integer(self):
+        font = generate_minimal_font()
+        glyph = GSGlyph(name="a")
+        font.glyphs.append(glyph)
+        layer = GSLayer()
+        layer.layerId = "test"
+        layer2 = GSLayer()
+        layer2.layerId = "test2"
+        layer2.name = "{14}"
+        glyph.layers.append(layer)
+        glyph.layers.append(layer2)
+        # should not raise ValueError with an int brace layer name
+        builder.to_designspace(font)
+
+    def test_brace_layers_float(self):
+        font = generate_minimal_font()
+        glyph = GSGlyph(name="a")
+        font.glyphs.append(glyph)
+        layer = GSLayer()
+        layer.layerId = "test"
+        layer2 = GSLayer()
+        layer2.layerId = "test2"
+        layer2.name = "{14.1}"
+        glyph.layers.append(layer)
+        glyph.layers.append(layer2)
+        # should raise a ValueError with a float brace layer name
+        with self.assertRaises(ValueError):
+            builder.to_designspace(font)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I've been tinkering with brace layers while we transition an optical size axis range and came across an exception when I attempted to define a brace layer with a float rather than an int value.  The error message was:

> ValueError: invalid literal for int() with base 10: '17.01'

which is a bit cryptic. 

This PR adds a try/except block around the int cast attempt and includes information about the requirement for int values in brace layers as part of the diagnostics.  It would be ideal to point to the affected glyph and brace layer name, but a unique glyph name does not appear to be accessible in this area of the code? 

Also adds a couple of unit tests for brace layer name validity testing (against an int definition and a float definition).

