### PR TITLE
Support 'Axis Mappings' customParameter

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -296,7 +296,7 @@ def to_glyphs_axes(self):
     if axes_parameter and not _is_subset_of_default_axes(axes_parameter):
         self.font.customParameters["Axes"] = axes_parameter
 
-    if self.minimize_ufo_diffs:
+    if any(a.map for a in self.designspace.axes):
         mapping = {
             axis.tag: {str(k): v for k, v in axis.map} for axis in self.designspace.axes
         }

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -141,7 +141,13 @@ def to_designspace_axes(self):
     assert isinstance(regular_master, classes.GSFontMaster)
 
     custom_mapping = self.font.customParameters["Axis Mappings"]
-
+    if not custom_mapping:
+        logger.warning(
+            "Recommended 'Axis Mappings' customParameter not set. This parameter "
+            "allows developers define an explicit mapping, otherwise the mapping "
+            "is calculated by using the 'Axis Locations' customParameters or by "
+            "using values from the instances and masters."
+        )
     for axis_def in get_axis_definitions(self.font):
         axis = self.designspace.newAxisDescriptor()
         axis.tag = axis_def.tag
@@ -171,7 +177,7 @@ def to_designspace_axes(self):
             else:
                 logger.debug(
                     f"Skipping {axis.tag} since it hasn't been defined "
-                    "in the Axis Mapping"
+                    "in the Axis Mapping."
                 )
                 continue
         # See https://github.com/googlefonts/glyphsLib/issues/280
@@ -191,7 +197,7 @@ def to_designspace_axes(self):
             regularDesignLoc = axis_def.get_design_loc(regular_master)
             regularUserLoc = axis_def.get_user_loc(regular_master)
         else:
-            # Build the mapping from the isntances because they have both
+            # Build the mapping from the instances because they have both
             # a user location and a design location.
             instance_mapping = {}
             for instance in self.font.instances:

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -175,7 +175,7 @@ def to_designspace_axes(self):
                 )
                 continue
         # See https://github.com/googlefonts/glyphsLib/issues/280
-        elif font_uses_new_axes(self.font):
+        elif font_uses_axis_locations(self.font):
             # Build the mapping from the "Axis Location" of the masters
             # TODO: (jany) use Virtual Masters as well?
             mapping = {}
@@ -259,7 +259,7 @@ def to_designspace_axes(self):
         )
 
 
-def font_uses_new_axes(font):
+def font_uses_axis_locations(font):
     # It's possible for fonts to have the 'Axes' parameter but to NOT specify
     # the master locations using 'Axis Location', in which case we have to
     # resort to using instances or other old tricks to get the mapping.

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -170,7 +170,7 @@ def to_designspace_axes(self):
                 else:
                     regularUserLoc = min(mapping)
             else:
-                logger.warning(
+                logger.debug(
                     f"Skipping {axis.tag} since it hasn't been defined "
                     "in the Axis Mapping"
                 )

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -170,8 +170,6 @@ def to_designspace_axes(self):
             if axis.tag in custom_mapping:
                 mapping = {float(k): v for k, v in custom_mapping[axis.tag].items()}
                 regularDesignLoc = axis_def.get_design_loc(regular_master)
-                # Glyphs masters don't have a user location, so we compute it by
-                # looking at the axis mapping in reverse.
                 reverse_mapping = [(dl, ul) for ul, dl in sorted(mapping.items())]
                 regularUserLoc = interp(reverse_mapping, regularDesignLoc)
             else:

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -164,11 +164,10 @@ def to_designspace_axes(self):
             if axis.tag in custom_mapping:
                 mapping = {float(k): v for k, v in custom_mapping[axis.tag].items()}
                 regularDesignLoc = axis_def.get_design_loc(regular_master)
-                reverse_mapping = {v: k for k, v in mapping.items()}
-                if regularDesignLoc in reverse_mapping:
-                    regularUserLoc = reverse_mapping[regularDesignLoc]
-                else:
-                    regularUserLoc = min(mapping)
+                # Glyphs masters don't have a user location, so we compute it by
+                # looking at the axis mapping in reverse.
+                reverse_mapping = [(dl, ul) for ul, dl in sorted(mapping.items())]
+                regularUserLoc = interp(reverse_mapping, regularDesignLoc)
             else:
                 logger.debug(
                     f"Skipping {axis.tag} since it hasn't been defined "

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -141,13 +141,7 @@ def to_designspace_axes(self):
     assert isinstance(regular_master, classes.GSFontMaster)
 
     custom_mapping = self.font.customParameters["Axis Mappings"]
-    if not custom_mapping:
-        logger.warning(
-            "Recommended 'Axis Mappings' customParameter not set. This parameter "
-            "allows developers define an explicit mapping, otherwise the mapping "
-            "is calculated by using the 'Axis Locations' customParameters or by "
-            "using values from the instances and masters."
-        )
+
     for axis_def in get_axis_definitions(self.font):
         axis = self.designspace.newAxisDescriptor()
         axis.tag = axis_def.tag

--- a/Lib/glyphsLib/builder/masters.py
+++ b/Lib/glyphsLib/builder/masters.py
@@ -15,7 +15,7 @@
 
 import os
 
-from .axes import font_uses_new_axes, get_axis_definitions
+from .axes import font_uses_axis_locations, get_axis_definitions
 from .constants import GLYPHS_PREFIX, GLYPHLIB_PREFIX, UFO_FILENAME_CUSTOM_PARAM
 
 MASTER_ID_LIB_KEY = GLYPHS_PREFIX + "fontMasterID"
@@ -63,7 +63,7 @@ def to_ufo_master_attributes(self, source, master):
         if custom_value:
             ufo.lib[GLYPHS_PREFIX + "customValue" + number] = custom_value
 
-    if font_uses_new_axes(self.font):
+    if font_uses_axis_locations(self.font):
         # Set the OS/2 weightClass and widthClas according the this master's
         # user location ("Axis Location" parameter)
         for axis in get_axis_definitions(self.font):

--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -21,7 +21,12 @@ import fontTools.designspaceLib
 from glyphsLib.util import build_ufo_path
 
 from .masters import UFO_FILENAME_KEY
-from .axes import get_axis_definitions, get_regular_master, font_uses_new_axes, interp
+from .axes import (
+    get_axis_definitions,
+    get_regular_master,
+    font_uses_axis_locations,
+    interp,
+)
 from .constants import UFO_FILENAME_CUSTOM_PARAM
 
 
@@ -227,7 +232,7 @@ def _to_glyphs_source(self, master):
             continue
 
         axis_def.set_design_loc(master, design_location)
-        if font_uses_new_axes(self.font):
+        if font_uses_axis_locations(self.font):
             # The user location can be found by reading the mapping backwards
             mapping = []
             for axis in self.designspace.axes:

--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -334,11 +334,13 @@ def test_axis_mapping(ufo_module):
 
     assert doc.axes[0].name == "Weight"
     assert doc.axes[0].minimum == 100
+    assert doc.axes[0].default == 100
     assert doc.axes[0].maximum == 900
     assert doc.axes[0].map == wght_mapping
 
     assert doc.axes[1].name == "Width"
     assert doc.axes[1].minimum == 75
+    assert doc.axes[0].default == 100
     assert doc.axes[1].maximum == 100
     # No axis map needed for Width because user and design coords are identical
     assert doc.axes[1].map != wdth_mapping

--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -325,11 +325,13 @@ def test_axis_mapping(ufo_module):
     wdth_mapping = [(75, 75), (100, 100)]
 
     axis_mappings = {
-        "wght": {k: v for k, v in wght_mapping},
-        "wdth": {k: v for k, v in wdth_mapping},
+        "wght": {str(float(k)): v for k, v in wght_mapping},
+        "wdth": {str(float(k)): v for k, v in wdth_mapping},
     }
 
     font.customParameters["Axis Mappings"] = axis_mappings
+    # When we convert to a designspace, the wdth mapping is removed because
+    # it isn't needed.
     doc = to_designspace(font, ufo_module=ufo_module)
 
     assert doc.axes[0].name == "Weight"
@@ -342,9 +344,11 @@ def test_axis_mapping(ufo_module):
     assert doc.axes[1].minimum == 75
     assert doc.axes[0].default == 100
     assert doc.axes[1].maximum == 100
-    # No axis map needed for Width because user and design coords are identical
     assert doc.axes[1].map != wdth_mapping
     assert doc.axes[1].map == []
 
+    # When we convert back to glyphs, the wdth mapping isn't present because
+    # it was removed during the designspace conversion.
     font = to_glyphs(doc)
+    axis_mappings["wdth"] = {}
     assert font.customParameters["Axis Mappings"] == axis_mappings


### PR DESCRIPTION
Support the 'Axis Mappings' customParameter.

If this customParameter has been defined, it takes precedence over all our other methods to assemble the designspace axes.


Todo:
- Possibly add a more informative comment
- regularDesignLoc and regularUserLoc are copy pasta. We may want to refactor this.