### PR TITLE
Use Proxy for GSFont.features/featurePrefixes

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -717,7 +717,13 @@ class FontClassesProxy(Proxy):
                 if klass.name == key:
                     del self.values()[index]
 
-    # FIXME: (jany) def __contains__
+    def __contains__(self, item):
+        if isinstance(item, str):
+            for klass in self.values():
+                if klass.name == item:
+                    return True
+            return False
+        return item in self.values()
 
     def append(self, item):
         self.values().append(item)

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1749,5 +1749,23 @@ class FontGlyphsProxyTest(unittest.TestCase):
             del self.font.glyphs[self.font]
 
 
+class FontClassesProxyTest(unittest.TestCase):
+    def setUp(self):
+        self.font = GSFont(TESTFILE_PATH)
+
+    def test_indxing_by_name(self):
+        assert "Languagesystems" in self.font.featurePrefixes
+        assert "c2sc_source" in self.font.classes
+        assert "aalt" in self.font.features
+
+        assert "XXXX" not in self.font.featurePrefixes
+        assert "XXXX" not in self.font.classes
+        assert "XXXX" not in self.font.features
+
+        assert self.font.featurePrefixes["Languagesystems"] in self.font.featurePrefixes
+        assert self.font.classes["c2sc_source"] in self.font.classes
+        assert self.font.features["aalt"] in self.font.features
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -87,7 +87,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         font.features.append(f1)
         # featurePrefixes
         fp1 = classes.GSFeaturePrefix()
-        fp1 = "FP1"
+        fp1.name = "FP1"
         font.featurePrefixes.append(fp1)
         # copyright
         font.copyright = "Copyright Bob"
@@ -173,7 +173,10 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             disablesNiceNames = 1;
             familyName = "Sans Rien";
             featurePrefixes = (
-            FP1
+            {
+            code = "";
+            name = FP1;
+            }
             );
             features = (
             {


### PR DESCRIPTION
Matches Glyphs App API and for consistency with the rather identical GSFont.classes.