### PR TITLE
Further improve vertical typesetting

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -168,6 +168,9 @@ class UFOBuilder(_LoggerMixin):
             self._do_filter_instances_by_family = True
 
     def _is_vertical(self):
+        for feature in self.font.features:
+            if feature.name in ["vert", "vrt2", "vkna"]:
+                return True
         master_ids = {m.id for m in self.font.masters}
         for glyph in self.font.glyphs:
             for layer in glyph.layers:

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -270,6 +270,8 @@ def to_ufo_glyph_height_and_vertical_origin(self, ufo_glyph, layer):
 
     if layer.vertWidth:
         ufo_glyph.height = layer.vertWidth
+    elif "rotat" in ufo_glyph.name:
+        ufo_glyph.height = ufo_font[ufo_glyph.name.replace(".rotat", "")].width
     else:
         ufo_glyph.height = ascender - descender
 


### PR DESCRIPTION
Currently the _is_vertical function checks if vertWidth or vertOrigin are not `None` in the font to decide if the font is intended for vertical use. However, in many cases, I see those fields are not set, but GSUB features like `vert`, `vrt2`, or `vkna` are set in the font, indicating that the author intended the font to be used in vertical typesetting scenarios. This PR adds a check for any of those three GSUB features. 

Additionally, at current, without any values set in vertWidth or vertOrigin, the code sets the advancedWidth to be `ascender-descender` automatically. For rotated forms, indicated by the suffix `.rotat`, this is not workable—rather they should be set to the width of the non-rotated form. So `A.rotat` should have a height equal to the width of `A`. This PR adds that as a secondary check, in case the value is not set explicitly. 