### PR TITLE
Improve compatibility with Glyphs

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1612,11 +1612,13 @@ class GSNode(GSBase):
     )
     _parent = None
 
-    def __init__(self, position=(0, 0), nodetype=LINE, smooth=False, name=None):
+    def __init__(self, position=(0, 0), type=LINE, smooth=False, name=None, nodetype=None):
         self._userData = None
         self._position = Point(position[0], position[1])
         self.smooth = smooth
-        self.type = nodetype
+        self.type = type
+        if nodetype is not None: # for backward compatibility
+            self.type = nodetype
         # Optimization: Points can number in the 10000s, don't access the userDataProxy
         # through `name` unless needed.
         if name is not None:

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1603,7 +1603,7 @@ class GSFontMaster(GSBase):
 
 
 class GSNode(GSBase):
-    __slots__ = ("_userData", "position", "smooth", "type")
+    __slots__ = ("_userData", "_position", "smooth", "type")
 
     _PLIST_VALUE_RE = re.compile(
         r'"([-.e\d]+) ([-.e\d]+) (LINE|CURVE|QCURVE|OFFCURVE|n/a)'
@@ -1614,7 +1614,7 @@ class GSNode(GSBase):
 
     def __init__(self, position=(0, 0), nodetype=LINE, smooth=False, name=None):
         self._userData = None
-        self.position = Point(position[0], position[1])
+        self._position = Point(position[0], position[1])
         self.smooth = smooth
         self.type = nodetype
         # Optimization: Points can number in the 10000s, don't access the userDataProxy
@@ -1634,6 +1634,16 @@ class GSNode(GSBase):
         lambda self: UserDataProxy(self),
         lambda self, value: UserDataProxy(self).setter(value),
     )
+
+    @property
+    def position(self):
+        return self._position
+
+    @position.setter
+    def position(self, value):
+        if not isinstance(value, Point):
+            value = Point(value[0], value[1])
+        self._position = value
 
     @property
     def parent(self):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1527,6 +1527,13 @@ class GSPathFromFileTest(GSObjectsTestCase):
         del path.nodes[-1]
         self.assertEqual(amount, len(path.nodes))
 
+    def test_node_position(self):
+        n = GSNode()
+        n.position = Point("{10, 10}")
+        self.assertEqual(n.position.x, 10)
+        n.position = (20,20)
+        self.assertEqual(n.position.x, 20)
+
     # TODO: GSPath.closed
 
     # bezierPath?


### PR DESCRIPTION
When trying to run a Glyphs script on the command line, I noticed that I couldn't set a node's position. Glyphs allows `n.position = (x,y)`, but this creates a tuple when GSNode expects a `Point` object. But of course I can't use a `Point` object because then the script wouldn't work in Glyphs...

This PR allows setting `n.position = (x,y)` and automatically upcasting that to a `Point` object.