### PR TITLE
Add insert feature marker when Glyphs' Automatic Code Start/End is present

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -24,6 +24,7 @@ from .constants import GLYPHLIB_PREFIX
 
 ANONYMOUS_FEATURE_PREFIX_NAME = "<anonymous>"
 ORIGINAL_FEATURE_CODE_KEY = GLYPHLIB_PREFIX + "originalFeatureCode"
+GLYPHSAPP_INSERT_CODE = ("# Automatic Code Start", "# Automatic Code End")
 
 
 def autostr(automatic):
@@ -95,6 +96,11 @@ def _to_ufo_features(font, ufo=None, generate_GDEF=False, skip_export_glyphs=Non
             lines.append("# disabled")
             lines.extend("#" + line for line in code.splitlines())
         else:
+            insert_code = GLYPHSAPP_INSERT_CODE
+            for ic in insert_code:
+                if ic in code.split("\n"):
+                    lines = ["### INSERT %s" % feature.name, ""] + lines
+                    break
             lines.append(code)
         lines.append("} %s;" % feature.name)
         feature_defs.append("\n".join(lines))

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -383,6 +383,43 @@ def test_roundtrip_feature_prefix_with_only_a_comment(ufo_module):
     assert prefix_r.code == "#include(../family.fea)"
 
 
+def test_roundtrip_automatic_code_insert_feature(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
+    feature = classes.GSFeature(name="kern")
+    feature.code = dedent(
+        """
+        # Automatic Code Start
+        pos L apostrophe' -20 a;
+    """
+    )
+    font.features.append(feature)
+
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
+    assert ufo.features.text == dedent(
+        """\
+        ### INSERT kern
+
+        feature kern {
+
+        # Automatic Code Start
+        pos L apostrophe' -20 a;
+
+        } kern;
+    """
+    )
+
+    font_r = to_glyphs([ufo])
+    assert len(font_r.features) == 1
+    feature_r = font_r.features[0]
+    assert feature_r.name == "kern"
+    assert feature.code == dedent(
+        """
+        # Automatic Code Start
+        pos L apostrophe' -20 a;
+    """
+    )
+
+
 @pytest.fixture
 def ufo_with_GDEF(ufo_module):
     ufo = ufo_module.Font()


### PR DESCRIPTION
This adds the insert feature marker used in https://github.com/googlefonts/ufo2ft/pull/352 and discussed in https://github.com/googlefonts/ufo2ft/issues/351.