### PR TITLE
Fix commented class issue

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -78,7 +78,7 @@ def _to_ufo_features(font, ufo=None, generate_GDEF=False, skip_export_glyphs=Non
         prefix = "@" if not class_.name.startswith("@") else ""
         name = prefix + class_.name
         class_defs.append(
-            "{}{} = [ {} ];".format(autostr(class_.automatic), name, class_.code)
+            "{}{} = [ {}\n];".format(autostr(class_.automatic), name, class_.code)
         )
     class_str = "\n\n".join(class_defs)
 

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -498,14 +498,13 @@ def test_build_GDEF_incomplete_glyphOrder():
 
     assert "[b c a d], # Base" in _build_gdef(font)
 
+
 def test_comments_in_classes(ufo_module):
-    filename = os.path.join(
-        os.path.dirname(__file__), "../data/CommentedClass.glyphs"
-    )
+    filename = os.path.join(os.path.dirname(__file__), "../data/CommentedClass.glyphs")
     font = classes.GSFont(filename)
-    (ufo, ) = to_ufos(font)
+    (ufo,) = to_ufos(font)
     assert ufo.features.text == dedent(
-            """\
+        """\
             @Test = [ A
             # B
             ];

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -90,13 +90,17 @@ def test_classes(tmpdir, ufo_module):
     # FIXME: (jany) no whitespace is preserved in this section
     ufo.features.text = dedent(
         """\
-        @lc = [ a b ];
+        @lc = [ a b
+        ];
 
-        @UC = [ A B ];
+        @UC = [ A B
+        ];
 
-        @all = [ @lc @UC zero one ];
+        @all = [ @lc @UC zero one
+        ];
 
-        @more = [ dot @UC colon @lc paren ];
+        @more = [ dot @UC colon @lc paren
+        ];
     """
     )
 
@@ -115,7 +119,8 @@ def test_class_synonym(tmpdir, ufo_module):
     ufo = ufo_module.Font()
     ufo.features.text = dedent(
         """\
-        @lc = [ a b ];
+        @lc = [ a b
+        ];
 
         @lower = @lc;
     """
@@ -130,9 +135,11 @@ def test_class_synonym(tmpdir, ufo_module):
     # FIXME: (jany) should roundtrip
     assert rtufo.features.text == dedent(
         """\
-        @lc = [ a b ];
+        @lc = [ a b
+        ];
 
-        @lower = [ @lc ];
+        @lower = [ @lc
+        ];
     """
     )
 
@@ -490,3 +497,17 @@ def test_build_GDEF_incomplete_glyphOrder():
         glyph.appendAnchor({"name": "top", "x": 0, "y": 0})
 
     assert "[b c a d], # Base" in _build_gdef(font)
+
+def test_comments_in_classes(ufo_module):
+    filename = os.path.join(
+        os.path.dirname(__file__), "../data/CommentedClass.glyphs"
+    )
+    font = classes.GSFont(filename)
+    (ufo, ) = to_ufos(font)
+    assert ufo.features.text == dedent(
+            """\
+            @Test = [ A
+            # B
+            ];
+"""
+    )

--- a/tests/data/CommentedClass.glyphs
+++ b/tests/data/CommentedClass.glyphs
@@ -1,0 +1,52 @@
+{
+.appVersion = "3039";
+classes = (
+{
+code = "A\012# B";
+name = Test;
+}
+);
+date = "2021-01-28 14:39:49 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+alignmentZones = (
+"{800, 16}",
+"{700, 16}",
+"{500, 16}",
+"{0, -16}",
+"{-200, -16}"
+);
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = m01;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = B;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 0042;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
This adds a newline to before the closing bracket of a class definition. Why do we want to do this? Well, there's an obscure corner case I just hit today.

Glyphs allows comments in glyph classes like so:

<img width="604" alt="Screenshot 2021-01-28 at 14 40 25" src="https://user-images.githubusercontent.com/106728/106153730-c4292c80-6176-11eb-8fc5-2737fdec4700.png">

If the last entry in a glyph class is commented out, glyphsLib writes a UFO feature file like so:

```
@Test = [ A
# B ];
```

The closing bracket of the class is commented out, causing a syntax error.

This PR writes the feature as

```
@Test = [ A
# B
];
```

instead.