### PR TITLE
UFO default layer with custom name

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -259,12 +259,12 @@ class UFOBuilder(_LoggerMixin):
 
         for master_id, source in self._sources.items():
             ufo = source.font
+            master = self.font.masters[master_id]
             if self.propagate_anchors:
                 self.to_ufo_propagate_font_anchors(ufo)
-            for layer in ufo.layers:
-                self.to_ufo_layer_lib(layer)
+            for layer in list(ufo.layers):
+                self.to_ufo_layer_lib(master, ufo, layer)
 
-            master = self.font.masters[master_id]
             # to_ufo_custom_params may apply "Replace Features" or "Replace Prefix"
             # parameters so it requires UFOs have their features set first; at the
             # same time, to generate a GDEF table we first need to have defined the

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -736,7 +736,7 @@ class GlyphsBuilder(_LoggerMixin):
                         del layer[glyph_name]
 
             for layer in _sorted_backgrounds_last(source.font.layers):
-                self.to_glyphs_layer_lib(layer)
+                self.to_glyphs_layer_lib(layer, master)
                 for glyph in layer:
                     self.to_glyphs_glyph(glyph, layer, master)
 

--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -100,3 +100,5 @@ DEFAULT_FEATURE_WRITERS = [
     {"class": "KernFeatureWriter", "options": {"mode": "append"}},
     {"class": "MarkFeatureWriter", "options": {"mode": "skip"}},
 ]
+
+DEFAULT_LAYER_NAME = PUBLIC_PREFIX + "default"

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -71,7 +71,7 @@ def _layer_order_in_glyph(self, layer):
 
 
 def to_glyphs_layer(self, ufo_layer, glyph, master):
-    if ufo_layer.name == self._sources[master.id].font.layers.defaultLayer.name:
+    if ufo_layer is self._sources[master.id].font.layers.defaultLayer:
         layer = _get_or_make_foreground(self, glyph, master)
     elif ufo_layer.name == "public.background":
         master_layer = _get_or_make_foreground(self, glyph, master)

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -71,7 +71,7 @@ def _layer_order_in_glyph(self, layer):
 
 
 def to_glyphs_layer(self, ufo_layer, glyph, master):
-    if ufo_layer.name == "public.default":  # TODO: (jany) constant
+    if ufo_layer.name == self._sources[master.id].font.layers.defaultLayer.name:
         layer = _get_or_make_foreground(self, glyph, master)
     elif ufo_layer.name == "public.background":
         master_layer = _get_or_make_foreground(self, glyph, master)

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -77,10 +77,21 @@ def to_ufo_glyph_user_data(self, ufo, glyph):
         ufo.lib[key] = dict(glyph.userData)
 
 
-def to_ufo_layer_lib(self, ufo_layer):
+def to_ufo_layer_lib(self, master, ufo, ufo_layer):
     key = LAYER_LIB_KEY + "." + ufo_layer.name
+    # glyphsLib v5.3.2 and previous versions stored the layer lib in
+    # the GSFont useData under a key named after the layer.
+    # When different original UFOs each had a layer with the same layer name,
+    # only the layer lib of the last one was stored and was exported to UFOs
     if key in self.font.userData.keys():
-        ufo_layer.lib = self.font.userData[key]
+        self.logger.warning(
+            f"Layer '{ufo_layer.name}' lib is stored once in GSFont userData "
+            "instead of in each GSFontMaster but may have been different in "
+            "previous UFOs."
+        )
+        ufo_layer.lib.update(self.font.userData[key])
+    if key in master.userData.keys():
+        ufo_layer.lib.update(master.userData[key])
 
 
 def to_ufo_layer_user_data(self, ufo_glyph, layer):

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -146,11 +146,19 @@ def to_glyphs_glyph_user_data(self, ufo, glyph):
         glyph.userData = ufo.lib[key]
 
 
-def to_glyphs_layer_lib(self, ufo_layer):
+def to_glyphs_layer_lib(self, ufo_layer, master):
     user_data = {}
     for key, value in ufo_layer.lib.items():
         if _user_data_has_no_special_meaning(key):
             user_data[key] = value
+
+    # the default layer may have a custom name
+    if (
+        ufo_layer.name == self._sources[master.id].font.layers.defaultLayer.name
+        and ufo_layer.name != "public.default"
+    ):
+        key = UFO_DATA_KEY + ".layerName"
+        user_data[key] = ufo_layer.name
 
     if user_data:
         key = LAYER_LIB_KEY + "." + ufo_layer.name

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -86,11 +86,6 @@ def to_ufo_layer_lib(self, master, ufo, ufo_layer):
     # When different original UFOs each had a layer with the same layer name,
     # only the layer lib of the last one was stored and was exported to UFOs
     if key in self.font.userData.keys():
-        self.logger.warning(
-            f"Layer '{ufo_layer.name}' lib is stored once in GSFont userData "
-            "instead of in each GSFontMaster but may have been different in "
-            "previous UFOs."
-        )
         ufo_layer.lib.update(self.font.userData[key])
     if key in master.userData.keys():
         ufo_layer.lib.update(master.userData[key])
@@ -176,7 +171,7 @@ def to_glyphs_layer_lib(self, ufo_layer, master):
     # the default layer may have a custom name
     layer_name = ufo_layer.name
     if (
-        layer_name == self._sources[master.id].font.layers.defaultLayer.name
+        ufo_layer is self._sources[master.id].font.layers.defaultLayer
         and layer_name != DEFAULT_LAYER_NAME
     ):
         user_data[LAYER_NAME_KEY] = ufo_layer.name

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -15,10 +15,8 @@
 
 import os
 from collections import OrderedDict
-import logging
 
 from fontTools.designspaceLib import DesignSpaceDocument
-from fontTools.misc.loggingTools import CapturingLogHandler
 from glyphsLib import classes
 from glyphsLib.types import BinaryData
 from glyphsLib.builder.constants import (
@@ -245,7 +243,6 @@ def test_layer_lib_into_master_user_data(ufo_module):
 
 
 def test_layer_lib_in_font_user_data(ufo_module):
-    logger = logging.getLogger("glyphsLib.builder.builders.UFOBuilder")
     font = classes.GSFont()
     font.masters.append(classes.GSFontMaster())
     font.masters.append(classes.GSFontMaster())
@@ -264,14 +261,11 @@ def test_layer_lib_in_font_user_data(ufo_module):
         "layerLibKey": "layerLibValue"
     }
 
-    with CapturingLogHandler(logger, level="WARNING") as captor:
-        ufo1, ufo2 = to_ufos(font)
+    ufo1, ufo2 = to_ufos(font)
     assert "layerLibKey" in ufo1.layers["public.default"].lib
     assert ufo1.layers["public.default"].lib["layerLibKey"] == "layerLibValue"
     assert "layerLibKey" in ufo2.layers["public.default"].lib
     assert ufo2.layers["public.default"].lib["layerLibKey"] == "layerLibValue"
-
-    assert len([r for r in captor.records if "in GSFont userData" in r.msg]) == 2
 
 
 def test_glyph_user_data_into_ufo_lib():

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -15,8 +15,10 @@
 
 import os
 from collections import OrderedDict
+import logging
 
 from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.misc.loggingTools import CapturingLogHandler
 from glyphsLib import classes
 from glyphsLib.types import BinaryData
 from glyphsLib.builder.constants import (
@@ -198,29 +200,78 @@ def test_ufo_data_into_font_master_user_data(tmpdir, ufo_module):
     assert ufo.data[filename] == data
 
 
-def test_layer_lib_into_font_user_data(ufo_module):
-    ufo = ufo_module.Font()
-    ufo.layers["public.default"].lib["layerLibKey1"] = "layerLibValue1"
-    layer = ufo.newLayer("sketches")
-    layer.lib["layerLibKey2"] = "layerLibValue2"
+def test_layer_lib_into_master_user_data(ufo_module):
+    ufo1 = ufo_module.Font()
+    ufo1.layers["public.default"].lib["layerLibKey1"] = "ufo1 layerLibValue1"
+    layer = ufo1.newLayer("sketches")
+    layer.lib["layerLibKey2"] = "ufo1 layerLibValue2"
     # layers won't roundtrip if they contain no glyph, except for the default
     layer.newGlyph("bob")
+    ufo2 = ufo_module.Font()
+    ufo2.layers["public.default"].lib["layerLibKey1"] = "ufo2 layerLibValue1"
+    layer = ufo2.newLayer("sketches")
+    layer.lib["layerLibKey2"] = "ufo2 layerLibValue2"
+    layer.newGlyph("bob")
 
-    font = to_glyphs([ufo])
+    font = to_glyphs([ufo1, ufo2])
 
-    assert font.userData[GLYPHLIB_PREFIX + "layerLib.public.default"] == {
-        "layerLibKey1": "layerLibValue1"
+    default_layer_key = GLYPHLIB_PREFIX + "layerLib.public.default"
+    sketches_layer_key = GLYPHLIB_PREFIX + "layerLib.sketches"
+    assert default_layer_key not in font.userData
+    assert sketches_layer_key not in font.userData
+    assert font.masters[0].userData[default_layer_key] == {
+        "layerLibKey1": "ufo1 layerLibValue1"
     }
-    assert font.userData[GLYPHLIB_PREFIX + "layerLib.sketches"] == {
-        "layerLibKey2": "layerLibValue2"
+    assert font.masters[0].userData[sketches_layer_key] == {
+        "layerLibKey2": "ufo1 layerLibValue2"
+    }
+    assert font.masters[1].userData[default_layer_key] == {
+        "layerLibKey1": "ufo2 layerLibValue1"
+    }
+    assert font.masters[1].userData[sketches_layer_key] == {
+        "layerLibKey2": "ufo2 layerLibValue2"
     }
 
-    (ufo,) = to_ufos(font)
+    (ufo1, ufo2) = to_ufos(font)
 
-    assert ufo.layers["public.default"].lib["layerLibKey1"] == "layerLibValue1"
-    assert "layerLibKey1" not in ufo.layers["sketches"].lib
-    assert ufo.layers["sketches"].lib["layerLibKey2"] == "layerLibValue2"
-    assert "layerLibKey2" not in ufo.layers["public.default"].lib
+    assert ufo1.layers["public.default"].lib["layerLibKey1"] == "ufo1 layerLibValue1"
+    assert "layerLibKey1" not in ufo1.layers["sketches"].lib
+    assert ufo1.layers["sketches"].lib["layerLibKey2"] == "ufo1 layerLibValue2"
+    assert "layerLibKey2" not in ufo1.layers["public.default"].lib
+    assert ufo2.layers["public.default"].lib["layerLibKey1"] == "ufo2 layerLibValue1"
+    assert "layerLibKey1" not in ufo2.layers["sketches"].lib
+    assert ufo2.layers["sketches"].lib["layerLibKey2"] == "ufo2 layerLibValue2"
+    assert "layerLibKey2" not in ufo2.layers["public.default"].lib
+
+
+def test_layer_lib_in_font_user_data(ufo_module):
+    logger = logging.getLogger("glyphsLib.builder.builders.UFOBuilder")
+    font = classes.GSFont()
+    font.masters.append(classes.GSFontMaster())
+    font.masters.append(classes.GSFontMaster())
+    glyph = classes.GSGlyph(name="a")
+    font.glyphs.append(glyph)
+    layer = classes.GSLayer()
+    layer.layerId = font.masters[0].id
+    layer.width = 0
+    glyph.layers.append(layer)
+    layer = classes.GSLayer()
+    layer.layerId = font.masters[1].id
+    layer.width = 0
+    glyph.layers.append(layer)
+
+    font.userData[GLYPHLIB_PREFIX + "layerLib.public.default"] = {
+        "layerLibKey": "layerLibValue"
+    }
+
+    with CapturingLogHandler(logger, level="WARNING") as captor:
+        ufo1, ufo2 = to_ufos(font)
+    assert "layerLibKey" in ufo1.layers["public.default"].lib
+    assert ufo1.layers["public.default"].lib["layerLibKey"] == "layerLibValue"
+    assert "layerLibKey" in ufo2.layers["public.default"].lib
+    assert ufo2.layers["public.default"].lib["layerLibKey"] == "layerLibValue"
+
+    assert len([r for r in captor.records if "in GSFont userData" in r.msg]) == 2
 
 
 def test_glyph_user_data_into_ufo_lib():

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -585,6 +585,23 @@ def test_custom_stylemap_style_name(ufo_module):
     assert ufo.info.styleMapStyleName == "bold"
 
 
+def test_custom_default_layer_name(ufo_module):
+    ufo1 = ufo_module.Font()
+    ufo2 = ufo_module.Font()
+    if hasattr(ufo1, "renameLayer") and callable(ufo1.renameLayer):
+        ufo1.renameLayer("public.default", "custom default")
+        ufo2.renameLayer("public.default", "other default")
+    else:
+        ufo1.layers.defaultLayer.name = "custom default"
+        ufo2.layers.defaultLayer.name = "other default"
+
+    font = to_glyphs([ufo1, ufo2])
+    (ufo1, ufo2) = to_ufos(font)
+
+    assert ufo1.layers.defaultLayer.name == "custom default"
+    assert ufo2.layers.defaultLayer.name == "other default"
+
+
 def test_weird_kerning_roundtrip(ufo_module):
     groups = {
         "public.kern1.i": [


### PR DESCRIPTION
The layer name [`public.default`](https://unifiedfontobject.org/versions/ufo3/layercontents.plist/#publicdefault) *indicates that the default layer has no user defined name*.
glyphsLib should store the user defined default layer name and round-trip it to UFOs.

The layer lib is now stored in the master userData instead of the font userData.
When several UFOs each have a layer with the same name, their lib may be different and cannot be stored in the font userData under the same key.

This now uses `master.userData["com.schriftgestaltung.Glyphs.layerLib.<layer.name>"]["com.schriftgestaltung.Glyphs.layerName"]`, one per layer, instead of `font.userData["com.schriftgestaltung.Glyphs.layerLib.<layer.name>"]["com.schriftgestaltung.Glyphs.layerName"]`, one for all layers with the same name across UFOs.