### PR TITLE
Revert "Ignore main branch for now"

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,10 +17,9 @@ jobs:
     # Check out a *known good* version
     # For now I am assuming 'main' is known good
     - uses: actions/checkout@v2
-      # XXX: UNCOMMENT ONCE MERGED
-      # with:
-      #   repository: googlefonts/glyphsLib
-      #   ref: main
+      with:
+        repository: googlefonts/glyphsLib
+        ref: main
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This reverts commit 6bccbff8426c45ceb1a73bc5a654e4d81c42e14a.

Now that the new code and scripts have landed, we can use main as a point of reference.