### PR TITLE
Do not require wheel for all setuptools operations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ include_package_data = True
 python_requires = >=3.6
 setup_requires =
     setuptools_scm
-    wheel
 install_requires =
     # Synchronize with requirements.in until
     # https://github.com/jazzband/pip-tools/issues/1047 is implemented.


### PR DESCRIPTION
Fixes #701

When using setuptools (commonly still used for distro packages because no other
solution supports installing to bare packaging directory yet) to build a project
it is not necessary or desired to have *wheel* in the loop. It is needed for
releasing the project upstream of course, but not for installing it locally.