### PR TITLE
Fix converting sampleText from version 3 fonts

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -360,7 +360,7 @@ GLYPHS_UFO_CUSTOM_PARAMS_GLYPHS3_PROPERTIES = (
     ("licenseURL", "openTypeNameLicenseURL", "licenseURL"),
     ("trademark", "trademark", "trademarks"),
     ("description", "openTypeNameDescription", "descriptions"),
-    ("sampleText", "openTypeNameSampleText", "sampleText"),
+    ("sampleText", "openTypeNameSampleText", "sampleTexts"),
     ("postscriptFontName", "postscriptFontName", "postscriptFontName"),
     ("postscriptFullName", "postscriptFullName", "postscriptFullName"),
     ("WWSFamilyName", "openTypeNameWWSFamilyName", "WWSFamilyName"),


### PR DESCRIPTION
The property name is plural, `sampleTexts`, not singular.