### PR TITLE
Fix converting gasp table from version 3 fonts

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -517,6 +517,15 @@ register(
     )
 )
 
+register(
+    ParamHandler(
+        glyphs_name="gasp Table",
+        ufo_name="openTypeGaspRangeRecords",
+        value_to_ufo=to_ufo_gasp_table,
+        value_to_glyphs=to_glyphs_gasp_table,
+    )
+)
+
 # TODO: (jany) look at
 # https://forum.glyphsapp.com/t/name-table-entry-win-id4/3811/10
 # Use Name Table Entry for the next param


### PR DESCRIPTION
In Glyphs 3 the custom parameter is “gasp Table” instead of “GASP table”. I’m not sure how to register custom parameter handler based on
format version, so I simply duplicated the handler with the new name even though that means both would be active for any format version (I’m personally fine with that).