### PR TITLE
Don’t re-draw glyph if no overlap was removed

### DIFF
--- a/Lib/glyphsLib/filters/eraseOpenCorners.py
+++ b/Lib/glyphsLib/filters/eraseOpenCorners.py
@@ -1,6 +1,7 @@
 import logging
 
 from fontTools.pens.basePen import BasePen
+from fontTools.pens.recordingPen import RecordingPen
 from fontTools.misc.bezierTools import (
     segmentSegmentIntersections,
     _split_segment_at_t,
@@ -105,9 +106,11 @@ class EraseOpenCornersFilter(BaseFilter):
             return False
 
         contours = list(glyph)
-        glyph.clearContours()
-        outpen = glyph.getPen()
+        outpen = RecordingPen()
         p = EraseOpenCornersPen(outpen)
         for contour in contours:
             contour.draw(p)
+        if p.affected:
+            glyph.clearContours()
+            outpen.replay(glyph.getPen())
         return p.affected

--- a/tests/eraseOpenCorners_test.py
+++ b/tests/eraseOpenCorners_test.py
@@ -124,6 +124,18 @@ from glyphsLib.filters.eraseOpenCorners import EraseOpenCornersFilter
                         ("closePath", ()),
                     ],
                 },
+                {
+                    "name": "dotabove-ar",
+                    "width": 116,
+                    "outline": [
+                        ("moveTo", ((58, -58),)),
+                        ("curveTo", ((90, -58), (116, -32), (116, 0))),
+                        ("curveTo", ((116, 32), (90, 58), (58, 58))),
+                        ("curveTo", ((26, 58), (0, 32), (0, 0))),
+                        ("curveTo", ((0, -32), (26, -58), (58, -58))),
+                        ("closePath", ()),
+                    ],
+                },
             ]
         }
     ]
@@ -255,3 +267,14 @@ def test_square_plus_curve_corner(font):
 
     philter = EraseOpenCornersFilter(include={"squarePlusCurveCorner.reversed"})
     assert not philter(font)
+
+
+def test_circle_no_overlap(font):
+    oldcontour = font["dotabove-ar"][0]
+    assert len(oldcontour) == 12
+
+    philter = EraseOpenCornersFilter(include={"dotabove-ar"})
+    assert not philter(font)
+    newcontour = font["dotabove-ar"][0]
+    assert len(newcontour) == 12
+    assert oldcontour == newcontour


### PR DESCRIPTION
This is more of a bandaid, but it seems more hygienic to not re-draw a glyph we claim is not modified by the filter.

Fixes https://github.com/googlefonts/glyphsLib/issues/710