### PR TITLE
Accept FL7 trailing semicolons

### DIFF
--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -48,15 +48,9 @@ class Parser:
         This method removes the semicolon before passing the string to the parser."""
         # see https://github.com/googlefonts/fontmake/issues/806
         if isinstance(d, str):
-            if d.endswith(";"):
-                d = d.rstrip(";")
-            elif d.endswith(";\n"):
-                d = d.rstrip(";\n")
+            d = d.rstrip(";\n")
         elif isinstance(d, bytes):
-            if d.endswith(b";"):
-                d = d.rstrip(b";")
-            elif d.endswith(b";\n"):
-                d = d.rstrip(b";\n")
+            d = d.rstrip(b";\n")
         return d
 
     def _parse(self, d, new_type=None):

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -33,13 +33,31 @@ class Parser:
     def parse(self, d):
         try:
             if isinstance(d, str):
+                d = self._fl7_format_clean(d)
                 d = openstep_plist.loads(d, use_numbers=True)
             elif isinstance(d, bytes):
+                d = self._fl7_format_clean(d)
                 d = openstep_plist.loads(d.decode(), use_numbers=True)
             result = self._parse(d)
         except openstep_plist.parser.ParseError as e:
             raise ValueError("Failed to parse file") from e
         return result
+
+    def _fl7_format_clean(self, d):
+        """FontLab 7 glyphs source format exports include a final closing semicolon.
+        This method removes the semicolon before passing the string to the parser."""
+        # see https://github.com/googlefonts/fontmake/issues/806
+        if isinstance(d, str):
+            if d.endswith(";"):
+                d = d.rstrip(";")
+            elif d.endswith(";\n"):
+                d = d.rstrip(";\n")
+        elif isinstance(d, bytes):
+            if d.endswith(b";"):
+                d = d.rstrip(b";")
+            elif d.endswith(b";\n"):
+                d = d.rstrip(b";\n")
+        return d
 
     def _parse(self, d, new_type=None):
         self.current_type = new_type or self.current_type

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -51,9 +51,21 @@ class ParserTest(unittest.TestCase):
         self.run_test('{mystr="a\\"s\\077d\\U2019f";}', [("mystr", 'a"s?d’f')])
         self.run_test('{mystr="\\\\backslash";}', [("mystr", "\\backslash")])
 
-    def test_trailing_content(self):
+    def test_trailing_content_not_semicolon(self):
+        # all trailing content that is not a semicolon should raise
+        # a ValueError
         with self.assertRaises(ValueError):
             self.run_test("{myval=1;}trailing", [("myval", "1")])
+
+    def test_parse_trailing_content_semicolon(self):
+        # FontLab 7 uses a final semicolon in glyphs source exports
+        # This trailing content should parse and not raise a ValueError
+        self.run_test("{myval=1;};", [("myval", 1)])
+
+    def test_parse_trailing_content_bytes_semicolon(self):
+        # FontLab 7 uses a final semicolon in glyphs source exports
+        # This trailing content should parse and not raise a ValueError
+        self.run_test(b"{myval=1;};", [("myval", 1)])
 
     def test_unexpected_content(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Workaround for the FontLab 7 glyphs source export trailing semicolon that raises an error on fontmake compiles as noted in https://github.com/googlefonts/fontmake/issues/806.

