### PR TITLE
[builder] Skip color layers for no export glyphs

### DIFF
--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -86,7 +86,7 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):  # noqa: C901
         if layerMapping is not None:
             if not self.minimal:
                 ufo_glyph.lib[UFO2FT_COLOR_LAYER_MAPPING_KEY] = layerMapping
-            else:
+            elif glyph.export:
                 layers = []
                 for layerId, colorId in layerMapping:
                     layers.append((glyph.layers[layerId], colorId))

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1327,6 +1327,27 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
         assert len(ufo["a.color2"].components) == 1
         assert len(ufo["a.color2"]) == 0
 
+    def test_glyph_color_layers_explode_no_export(self):
+        font = generate_minimal_font()
+        glypha = add_glyph(font, "a")
+        glyphb = add_glyph(font, "b")
+
+        color0 = GSLayer()
+        color1 = GSLayer()
+        color0.name = "Color 0"
+        color1.name = "Color 1"
+
+        glypha.export = False
+        glypha.layers.append(color0)
+        glyphb.layers.append(color1)
+
+        ds = self.to_designspace(font, minimal=True)
+        ufo = ds.sources[0].font
+
+        assert ufo.lib["com.github.googlei18n.ufo2ft.colorLayers"] == {
+            "b": [("b.color0", 1)]
+        }
+
     def test_master_with_light_weight_but_thin_name(self):
         font = generate_minimal_font()
         master = font.masters[0]


### PR DESCRIPTION
In minimal mode we need to skip no export glyphs when exploding color layers otherwise ufo2ft will fail building the font since it does not
seem to filter the `colorLayers` key.