### PR TITLE
drop Python 3.6, require >= 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.9, 3.6]
+        python-version: [3.9, 3.7]
         platform: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -94,11 +94,7 @@ def get_glyph(glyph_name, data=None):
     if data is None:
         global GLYPHDATA
         if GLYPHDATA is None:
-            try:
-                from importlib.resources import open_binary
-            except ImportError:
-                # use backport for python < 3.7
-                from importlib_resources import open_binary
+            from importlib.resources import open_binary
 
             GLYPHDATA = GlyphData.from_files(
                 open_binary("glyphsLib.data", "GlyphData.xml"),

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 glyphsLib
 =========
 
-This Python 3.6+ library provides a bridge from Glyphs source files (.glyphs) to
+This Python 3.7+ library provides a bridge from Glyphs source files (.glyphs) to
 UFOs and Designspace files via `defcon <https://github.com/typesupply/defcon/>`__ and `designspaceLib <https://github.com/fonttools/fonttools>`__.
 
 The main methods for conversion are found in ``__init__.py``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,13 +27,12 @@ classifiers =
 package_dir = =Lib
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =
     ufoLib2 >= 0.6.2
     fonttools[ufo,unicode] >= 4.27.1
-    importlib_resources; python_version < '3.7'
     openstep-plist >= 0.2.2
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py36, py37, py38, py39, htmlcov
+envlist = lint, py37, py38, py39, htmlcov
 ; if any of the requested python interpreters is unavailable (e.g. on the local dev
 ; workstation), the tests are skipped and tox won't return an error
 skip_missing_interpreters = true


### PR DESCRIPTION
3.10 is out next week, while 3.6 reaches end of life at the end of this year.
It's time to require 3.7 or greater, so we can finally use built-in dataclasses and more.