### PR TITLE
Support (some) Glyphs 3 alternate layers

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -440,15 +440,20 @@ class UFOBuilder(_LoggerMixin):
                 bracket_max = None
 
             if bracket_min is not None and bracket_max is not None:
-                raise ValueError("Alternate rules with min and max range not yet supported")
+                raise ValueError(
+                    "Alternate rules with min and max range not yet supported"
+                )
             if bracket_min is None and bracket_max is None:
                 continue
 
             glyph_name = layer.parent.name
 
             if (
-                (bracket_min is not None and not bracket_axis_min <= bracket_min <= bracket_axis_max) or
-                (bracket_max is not None and not bracket_axis_min <= bracket_max <= bracket_axis_max)
+                bracket_min is not None
+                and not bracket_axis_min <= bracket_min <= bracket_axis_max
+            ) or (
+                bracket_max is not None
+                and not bracket_axis_min <= bracket_max <= bracket_axis_max
             ):
                 raise ValueError(
                     "Glyph {glyph_name}: Bracket layer {layer_name} must be within the "
@@ -542,7 +547,10 @@ class UFOBuilder(_LoggerMixin):
 
         for glyph_name, glyph_bracket_layers in bracket_layer_map.items():
             glyph = font.glyphs[glyph_name]
-            for (bracket_min, bracket_max), bracket_layers in glyph_bracket_layers.items():
+            for (
+                (bracket_min, bracket_max),
+                bracket_layers,
+            ) in glyph_bracket_layers.items():
 
                 for missing_master_layer_id in master_ids.difference(
                     bl.associatedMasterId for bl in bracket_layers

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3709,7 +3709,9 @@ class GSLayer(GSBase):
     def widthMetricsKey(self, value):
         self.metricWidth = value
 
-    BRACKET_LAYER_RE = re.compile(r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\s*\].*")
+    BRACKET_LAYER_RE = re.compile(
+        r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\s*\].*"
+    )
 
     def _is_bracket_layer(self):
         return "axisRules" in self.attr or re.match(self.BRACKET_LAYER_RE, self.name)
@@ -3727,7 +3729,7 @@ class GSLayer(GSBase):
 
         # Glyphs 2
         m = re.match(self.BRACKET_LAYER_RE, self.name)
-        axis_index = 0 # For glyphs 2
+        axis_index = 0  # For glyphs 2
         reverse = m.group("first_bracket") == "]"
         bracket_crossover = int(m.group("value"))
         if reverse:

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3712,11 +3712,22 @@ class GSLayer(GSBase):
     BRACKET_LAYER_RE = re.compile(r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\s*\].*")
 
     def _is_bracket_layer(self):
-        return re.match(self.BRACKET_LAYER_RE, self.name)
+        return "axisRules" in self.attr or re.match(self.BRACKET_LAYER_RE, self.name)
 
     def _bracket_info(self):
         if not self._is_bracket_layer():
             return None
+
+        if "axisRules" in self.attr:
+            # Glyphs 3
+            rules = self.attr["axisRules"]
+            if any(rules[1:]):
+                raise ValueError("Alternate rules on non-first axis not yet supported")
+            if "min" in rules[0] and "max" in rules[0]:
+                raise ValueError("Alternate rules with min and max range not yet supported")
+            return 0, rules[0].get("min"), rules[0].get("max")
+
+        # Glyphs 2
         m = re.match(self.BRACKET_LAYER_RE, self.name)
         axis_index = 0 # For glyphs 2
         reverse = m.group("first_bracket") == "]"

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3709,6 +3709,23 @@ class GSLayer(GSBase):
     def widthMetricsKey(self, value):
         self.metricWidth = value
 
+    BRACKET_LAYER_RE = re.compile(r".*(?P<first_bracket>[\[\]])\s*(?P<value>\d+)\s*\].*")
+
+    def _is_bracket_layer(self):
+        return re.match(self.BRACKET_LAYER_RE, self.name)
+
+    def _bracket_info(self):
+        if not self._is_bracket_layer():
+            return None
+        m = re.match(self.BRACKET_LAYER_RE, self.name)
+        axis_index = 0 # For glyphs 2
+        reverse = m.group("first_bracket") == "]"
+        bracket_crossover = int(m.group("value"))
+        if reverse:
+            return axis_index, None, bracket_crossover
+        else:
+            return axis_index, bracket_crossover, None
+
 
 GSLayer._add_parsers(
     [

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3723,8 +3723,6 @@ class GSLayer(GSBase):
             rules = self.attr["axisRules"]
             if any(rules[1:]):
                 raise ValueError("Alternate rules on non-first axis not yet supported")
-            if "min" in rules[0] and "max" in rules[0]:
-                raise ValueError("Alternate rules with min and max range not yet supported")
             return 0, rules[0].get("min"), rules[0].get("max")
 
         # Glyphs 2

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -493,11 +493,10 @@ def test_designspace_generation_bracket_GDEF(datadir, ufo_module):
             "x.BRACKET.600",
         }
 
+
 def test_designspace_generation_bracket_glyphs3_simple(datadir, ufo_module):
     with open(str(datadir.join("Alternate-g3-axis1.glyphs"))) as f:
         font = glyphsLib.load(f)
-
-    layer_names = {l.name for l in font.glyphs["A"].layers}
 
     designspace = to_designspace(font, ufo_module=ufo_module)
 

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -492,3 +492,14 @@ def test_designspace_generation_bracket_GDEF(datadir, ufo_module):
             "x.BRACKET.300",
             "x.BRACKET.600",
         }
+
+def test_designspace_generation_bracket_glyphs3_simple(datadir, ufo_module):
+    with open(str(datadir.join("Alternate-g3-axis1.glyphs"))) as f:
+        font = glyphsLib.load(f)
+
+    layer_names = {l.name for l in font.glyphs["A"].layers}
+
+    designspace = to_designspace(font, ufo_module=ufo_module)
+
+    for source in designspace.sources:
+        assert "A.BRACKET.600" in source.font

--- a/tests/data/Alternate-g3-axis1.glyphs
+++ b/tests/data/Alternate-g3-axis1.glyphs
@@ -1,0 +1,317 @@
+{
+.appVersion = "3072";
+.formatVersion = 3;
+DisplayStrings = (
+A
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+}
+);
+customParameters = (
+{
+name = "Variable Font Origin";
+value = m01;
+},
+{
+name = "Axis Mappings";
+value = {
+wght = {
+400 = 400;
+700 = 700;
+};
+};
+}
+);
+date = "2021-10-05 11:56:06 +0000";
+familyName = Alternate;
+fontMaster = (
+{
+axesValues = (
+400,
+0
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+over = -16;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700,
+0
+);
+iconName = Bold;
+id = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2021-10-06 11:10:46 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,222,o),
+(402,270,o),
+(402,329,cs),
+(402,388,o),
+(354,436,o),
+(295,436,cs),
+(236,436,o),
+(188,388,o),
+(188,329,cs),
+(188,270,o),
+(236,222,o),
+(295,222,cs)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,94,o),
+(530,200,o),
+(530,329,cs),
+(530,458,o),
+(424,564,o),
+(295,564,cs),
+(166,564,o),
+(60,458,o),
+(60,329,cs),
+(60,200,o),
+(166,94,o),
+(295,94,cs)
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+attr = {
+axisRules = (
+{
+max = 700;
+min = 600;
+},
+{
+}
+);
+};
+layerId = "E524F042-C209-4174-909B-0E140C3988DD";
+name = "5. Oct 21, 13:57";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,44,l),
+(544,44,l),
+(544,700,l),
+(66,700,l)
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = m01;
+attr = {
+axisRules = (
+{
+max = 700;
+min = 600;
+},
+{
+}
+);
+};
+layerId = "EDCD8E04-B04E-4543-952B-DBE4913CDDD1";
+name = "5. Oct 21, 13:58";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,230,l),
+(408,230,l),
+(408,514,l),
+(202,514,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+lastChange = "2021-10-05 11:59:54 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+ref = A;
+}
+);
+width = 600;
+},
+{
+layerId = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+shapes = (
+{
+ref = A;
+}
+);
+width = 600;
+}
+);
+unicode = 66;
+},
+{
+glyphname = .notdef;
+layers = (
+{
+layerId = m01;
+width = 600;
+},
+{
+layerId = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+width = 600;
+}
+);
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = m01;
+width = 600;
+},
+{
+layerId = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+width = 600;
+}
+);
+},
+{
+glyphname = space;
+lastChange = "2021-10-05 12:00:13 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+400,
+0
+);
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
+},
+{
+axesValues = (
+700,
+0
+);
+instanceInterpolations = {
+"C4CE11D0-4BF1-48BE-A00C-E1DC6594EA66" = 1;
+};
+isBold = 1;
+name = Bold;
+weightClass = 700;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
This PR partially addresses #715. Notably, it only deals with alternate layers:

* Which apply to one axis only
* Which apply only to the *first* axis
* Which have a max value or a min value but not both

I believe this is all that can be done without serious reworking of how alternate layers are handled by the builders, in particular the way that we name them on export. (It may be possible to have alternate layers on other axes than the first without too much trouble, but I deliberately want to do this in fairly small steps.)

This may be easier to review commit-by-commit as I have done things in small discrete changes