### PR TITLE
Fix italic angle on Glyphs 3

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1526,7 +1526,8 @@ class GSFontMaster(GSBase):
 
         writer.writeObjectKeyValue(self, "iconName", "if_true")
         writer.writeObjectKeyValue(self, "id")
-        writer.writeObjectKeyValue(self, "italicAngle", "if_true")
+        if writer.format_version == 2:
+            writer.writeObjectKeyValue(self, "italicAngle", "if_true")
         if writer.format_version == 3:
             writer.writeKeyValue("metricValues", self.metrics)
 
@@ -1561,7 +1562,7 @@ class GSFontMaster(GSBase):
         "cap height": 700,
         "ascender": 800,
         "descender": -200,
-        "italicAngle": 0,
+        "italic angle": 0,
     }
 
     _axis_defaults = (100, 100)
@@ -1583,7 +1584,6 @@ class GSFontMaster(GSBase):
         self.horizontalStems = 0
         self.iconName = ""
         self.id = str(uuid.uuid4()).upper()
-        self.italicAngle = self._defaultsForName["italicAngle"]
         self.numbers = []
         self.stems = []
         self.verticalStems = 0
@@ -1766,6 +1766,14 @@ class GSFontMaster(GSBase):
     @descender.setter
     def descender(self, value):
         self._set_metric("descender", value)
+
+    @property
+    def italicAngle(self):
+        return self._get_metric("italic angle")
+
+    @italicAngle.setter
+    def italicAngle(self, value):
+        self._set_metric("italic angle", value)
 
     def _get_axis_value(self, index):
         if index < len(self.axes):
@@ -4128,6 +4136,7 @@ class GSFont(GSBase):
         GSMetric(type="x-height"),
         GSMetric(type="baseline"),
         GSMetric(type="descender"),
+        GSMetric(type="italic angle"),
     ]
     _defaultAxes = [GSAxis(name="Weight", tag="wght"), GSAxis(name="Width", tag="wdth")]
 

--- a/tests/data/Italic-G3.glyphs
+++ b/tests/data/Italic-G3.glyphs
@@ -1,0 +1,70 @@
+{
+.appVersion = "3072";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+date = "2021-10-06 13:16:36 +0000";
+fontMaster = (
+{
+axesValues = (
+40
+);
+iconName = Light;
+id = "21A50CEC-A8F8-47E3-8EB4-99CD9DCFA5F3";
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 17;
+pos = 704;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+pos = 11;
+}
+);
+name = "72pt Thin Italic";
+}
+);
+glyphs = (
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 3;
+}

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -1,0 +1,17 @@
+import glyphsLib
+from glyphsLib.classes import GSFont, GSFontMaster
+
+
+def test_metrics():
+    font = GSFont()
+    master = GSFontMaster()
+    font.masters.append(master)
+    master.ascender = 400
+    assert master.ascender == 400
+    assert master.metrics[0].position == 400
+
+
+def test_glyphs3_italic_angle(datadir):
+    with open(str(datadir.join("Italic-G3.glyphs"))) as f:
+        font = glyphsLib.load(f)
+    assert font.masters[0].italicAngle == 11


### PR DESCRIPTION
This fixes #717. The underlying problem was that the italic angle was not being read from the new G3 metrics list, which meant it was defaulting to zero, so the isItalic was being set to false, and the style names were not being written correctly. Urgh.