### PR TITLE
Improve `GSNode.read*` performance

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2097,11 +2097,12 @@ class GSPath(GSBase):
         writer.writeObjectKeyValue(self, "nodes", "if_true")
 
     def _parse_nodes_dict(self, parser, d):
+        if parser.format_version == 3:
+            read_node = GSNode.read_v3
+        else:
+            read_node = GSNode.read
         for x in d:
-            if parser.format_version == 3:
-                node = GSNode.read_v3(x)
-            else:
-                node = GSNode.read(x)
+            node = read_node(x)
             node._parent = self
             self._nodes.append(node)
 


### PR DESCRIPTION
Improves reading speed for v2 Glyphs.app files (as done in https://github.com/madig/noto-amalgamated) by roughly 10%:

```
> hyperfine -m 2 'venv_this_pr/bin/python amalgamate-noto.py' 'venv_previous/bin/python amalgamate-noto.py'
Benchmark #1: venv_this_pr/bin/python amalgamate-noto.py
  Time (mean ± σ):     265.923 s ±  4.891 s    [User: 259.716 s, System: 5.978 s]
  Range (min … max):   262.465 s … 269.381 s    2 runs

Benchmark #2: venv_previous/bin/python amalgamate-noto.py
  Time (mean ± σ):     289.823 s ±  0.376 s    [User: 285.430 s, System: 4.185 s]
  Range (min … max):   289.558 s … 290.089 s    2 runs

Summary
  'venv_this_pr/bin/python amalgamate-noto.py' ran
    1.09 ± 0.02 times faster than 'venv_previous/bin/python amalgamate-noto.py'
```