### PR TITLE
builder/sources.py: only write locations along defined axes

### DIFF
--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -126,9 +126,12 @@ def _to_designspace_source(self, master, is_regular):
             )
         n += 1
 
+    designspace_axis_tags = {a.tag for a in self.designspace.axes}
     location = {}
     for axis_def in get_axis_definitions(self.font):
-        location[axis_def.name] = axis_def.get_design_loc(master)
+        # Only write locations along defined axes
+        if axis_def.tag in designspace_axis_tags:
+            location[axis_def.name] = axis_def.get_design_loc(master)
     source.location = location
 
 


### PR DESCRIPTION
similarly to what we already do for instance.location at

https://github.com/googlefonts/glyphsLib/blob/e00221c7bdc860ee161bc7bc0a30cbcd15cd2725/Lib/glyphsLib/builder/instances.py#L90-L96

Otherwise source.locations may contain a spurious third axis called "Custom" which may not alwyas be used (e.g. NotoSans only uses "Weight" and "Width".

We don't normally see this because fontTools.designspaceLib prunes those automatically upon writing the designspace file. But if one attempts to build a VF from the glyphsLib-generated designspace _object_ (not the file path saved on disk), the extra undefined axis prompts an error while attempting to find the default location.