### PR TITLE
pre-commit: No need to use venv anymore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,35 +4,25 @@ repos:
   hooks:
   - id: black
     language_version: python3
-    language: python_venv
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.4.0
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==19.10b0]
-    language: python_venv
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.25.3
   hooks:
   - id: pyupgrade
-    language: python_venv
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.4.0
   hooks:
   - id: trailing-whitespace
-    language: python_venv
     exclude: ^tests/data
   - id: end-of-file-fixer
-    language: python_venv
     exclude: ^tests/data
   - id: check-yaml
-    language: python_venv
   - id: check-ast
-    language: python_venv
   - id: mixed-line-ending
-    language: python_venv
   - id: debug-statements
-    language: python_venv
   - id: flake8
-    language: python_venv
     additional_dependencies: [flake8-bugbear]


### PR DESCRIPTION
The default virtualenv is faster.