### PR TITLE
Handle Glyphs 3 layer attributes a bit better

### DIFF
--- a/Lib/glyphsLib/builder/components.py
+++ b/Lib/glyphsLib/builder/components.py
@@ -50,7 +50,7 @@ def to_ufo_components(self, ufo_glyph, layer):
         not self.minimal
         and layer.components
         and layer.layerId != layer.associatedMasterId
-        and (layer.name.startswith("Color ") or "colorPalette" in layer.attr)
+        and (layer.name.startswith("Color ") or "colorPalette" in layer.attributes)
     ):
         logger.warning(
             f"Glyph '{ufo_glyph.name}': All components of the color layer "

--- a/Lib/glyphsLib/builder/components.py
+++ b/Lib/glyphsLib/builder/components.py
@@ -50,7 +50,7 @@ def to_ufo_components(self, ufo_glyph, layer):
         not self.minimal
         and layer.components
         and layer.layerId != layer.associatedMasterId
-        and (layer.name.startswith("Color ") or "colorPalette" in layer.attributes)
+        and (layer._is_color_palette_layer())
     ):
         logger.warning(
             f"Glyph '{ufo_glyph.name}': All components of the color layer "

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -32,17 +32,6 @@ ORIGINAL_WIDTH_KEY = GLYPHLIB_PREFIX + "originalWidth"
 BACKGROUND_WIDTH_KEY = GLYPHLIB_PREFIX + "backgroundWidth"
 
 
-def _color_index(index):
-    if isinstance(index, int):
-        return index
-    if index.startswith("*"):
-        return 0xFFFF
-    try:
-        return int(index)
-    except Exception as ex:
-        raise TypeError("Invalid color palette index, must be integer or *") from ex
-
-
 def to_ufo_glyph(self, ufo_glyph, layer, glyph):  # noqa: C901
     """Add .glyphs metadata, paths, components, and anchors to a glyph."""
     ufo_font = self._sources[layer.associatedMasterId or layer.layerId].font
@@ -56,34 +45,18 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):  # noqa: C901
         # When building minimal UFOs, we instead collect color layers and later
         # add them as separate glyphs to the UFO font.
 
-        layerMapping = None
-
-        # Glyphs 2.
         if any(
-            l.name.startswith("Color ")
+            l._is_color_palette_layer()
             and l.associatedMasterId == layer.associatedMasterId
             for l in glyph.layers
         ):
             layerMapping = [
-                (l.layerId, _color_index(l.name[len("Color ") :]))
+                (l.layerId, l._color_palette_index())
                 for l in glyph.layers
-                if l.name.startswith("Color ")
-                and l.associatedMasterId == layer.associatedMasterId
-            ]
-        # Glyphs 3.
-        elif any(
-            "colorPalette" in l.attributes
-            and l.associatedMasterId == layer.associatedMasterId
-            for l in glyph.layers
-        ):
-            layerMapping = [
-                (l.layerId, _color_index(l.attributes["colorPalette"]))
-                for l in glyph.layers
-                if "colorPalette" in l.attributes
+                if l._is_color_palette_layer()
                 and l.associatedMasterId == layer.associatedMasterId
             ]
 
-        if layerMapping is not None:
             if not self.minimal:
                 ufo_glyph.lib[UFO2FT_COLOR_LAYER_MAPPING_KEY] = layerMapping
             elif glyph.export:

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -72,14 +72,14 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):  # noqa: C901
             ]
         # Glyphs 3.
         elif any(
-            "colorPalette" in l.attr
+            "colorPalette" in l.attributes
             and l.associatedMasterId == layer.associatedMasterId
             for l in glyph.layers
         ):
             layerMapping = [
-                (l.layerId, _color_index(l.attr["colorPalette"]))
+                (l.layerId, _color_index(l.attributes["colorPalette"]))
                 for l in glyph.layers
-                if "colorPalette" in l.attr
+                if "colorPalette" in l.attributes
                 and l.associatedMasterId == layer.associatedMasterId
             ]
 

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -32,9 +32,9 @@ def to_ufo_layer(self, glyph, layer):
     ufo_font = self._sources[layer.associatedMasterId or layer.layerId].font
 
     layer_name = layer.name
-    # Give Glyphs 3 color layers better names
-    if "colorPalette" in layer.attributes:
-        layer_name = f"color.{layer.attributes['colorPalette']}"
+    # Give color layers better names
+    if layer._is_color_palette_layer():
+        layer_name = f"color.{layer._color_palette_index()}"
 
     if layer.associatedMasterId == layer.layerId:
         ufo_layer = ufo_font.layers.defaultLayer

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -33,8 +33,8 @@ def to_ufo_layer(self, glyph, layer):
 
     layer_name = layer.name
     # Give Glyphs 3 color layers better names
-    if "colorPalette" in layer.attr:
-        layer_name = f"color.{layer.attr['colorPalette']}"
+    if "colorPalette" in layer.attributes:
+        layer_name = f"color.{layer.attributes['colorPalette']}"
 
     if layer.associatedMasterId == layer.layerId:
         ufo_layer = ufo_font.layers.defaultLayer

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3783,6 +3783,28 @@ class GSLayer(GSBase):
         coordinates = name[name.index("{") + 1 : name.index("}")]
         return [float(c) for c in coordinates.split(",")]
 
+    def _is_color_palette_layer(self):
+        if self.parent.parent.format_version > 2:
+            return "colorPalette" in self.attributes  # Glyphs 3
+        return self.name.startswith("Color ")  # Glyphs 2
+
+    def _color_palette_index(self):
+        if not self._is_color_palette_layer():
+            return None
+
+        if self.parent.parent.format_version > 2:
+            # Glyphs 3
+            index = self.attributes["colorPalette"]
+            if index == "*":
+                return 0xFFFF
+            return index
+
+        # Glyphs 2
+        index = self.name[len("Color ") :]
+        if index.startswith("*"):
+            return 0xFFFF
+        return int(index)
+
 
 GSLayer._add_parsers(
     [

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3765,6 +3765,24 @@ class GSLayer(GSBase):
         else:
             return axis_index, bracket_crossover, None
 
+    def _is_brace_layer(self):
+        if self.parent.parent.format_version > 2:
+            return "coordinates" in self.attributes  # Glyphs 3
+        # Glyphs 2
+        return "{" in self.name and "}" in self.name and ".background" not in self.name
+
+    def _brace_coordinates(self):
+        if not self._is_brace_layer():
+            return None
+
+        if self.parent.parent.format_version > 2:
+            return self.attributes["coordinates"]  # Glyphs 3
+
+        # Glyphs 2
+        name = self.name
+        coordinates = name[name.index("{") + 1 : name.index("}")]
+        return [float(c) for c in coordinates.split(",")]
+
 
 GSLayer._add_parsers(
     [

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3740,15 +3740,15 @@ class GSLayer(GSBase):
     )
 
     def _is_bracket_layer(self):
-        return "axisRules" in self.attributes or re.match(
-            self.BRACKET_LAYER_RE, self.name
-        )
+        if self.parent.parent.format_version > 2:
+            return "axisRules" in self.attributes  # Glyphs 3
+        return re.match(self.BRACKET_LAYER_RE, self.name)  # Glyphs 2
 
     def _bracket_info(self):
         if not self._is_bracket_layer():
             return None
 
-        if "axisRules" in self.attributes:
+        if self.parent.parent.format_version > 2:
             # Glyphs 3
             rules = self.attributes["axisRules"]
             if any(rules[1:]):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3783,10 +3783,12 @@ class GSLayer(GSBase):
         coordinates = name[name.index("{") + 1 : name.index("}")]
         return [float(c) for c in coordinates.split(",")]
 
+    COLOR_PALETTE_LAYER_RE = re.compile(r"^Color (?P<index>\*|\d+)$")
+
     def _is_color_palette_layer(self):
         if self.parent.parent.format_version > 2:
             return "colorPalette" in self.attributes  # Glyphs 3
-        return self.name.startswith("Color ")  # Glyphs 2
+        return re.match(self.COLOR_PALETTE_LAYER_RE, self.name.strip())  # Glyphs 2
 
     def _color_palette_index(self):
         if not self._is_color_palette_layer():
@@ -3800,7 +3802,8 @@ class GSLayer(GSBase):
             return index
 
         # Glyphs 2
-        index = self.name[len("Color ") :]
+        m = re.match(self.COLOR_PALETTE_LAYER_RE, self.name)
+        index = m.group("index")
         if index.startswith("*"):
             return 0xFFFF
         return int(index)

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2094,8 +2094,8 @@ class GSPath(GSBase):
     _parent = None
 
     def _serialize_to_plist(self, writer):
-        if writer.format_version == 3 and self.attr:
-            writer.writeObjectKeyValue(self, "attr")
+        if writer.format_version == 3 and self.attributes:
+            writer.writeObjectKeyValue(self, "attributes", keyName="attr")
         writer.writeObjectKeyValue(self, "closed")
         writer.writeObjectKeyValue(self, "nodes", "if_true")
 
@@ -2112,7 +2112,7 @@ class GSPath(GSBase):
     def __init__(self):
         self.closed = self._defaultsForName["closed"]
         self._nodes = []
-        self.attr = {}
+        self.attributes = {}
 
     @property
     def parent(self):
@@ -2303,6 +2303,9 @@ class GSPath(GSBase):
                 userData=node_data,
             )
         pointPen.endPath()
+
+
+GSPath._add_parsers([{"plist_name": "attr", "object_name": "attributes"}])  # V3
 
 
 # 'offcurve' GSNode.type is equivalent to 'None' in UFO PointPen API
@@ -3421,7 +3424,7 @@ class GSLayer(GSBase):
         if self.layerId != self.associatedMasterId:
             writer.writeObjectKeyValue(self, "associatedMasterId")
         if writer.format_version > 2:
-            writer.writeObjectKeyValue(self, "attr", "if_true")
+            writer.writeObjectKeyValue(self, "attributes", "if_true", keyName="attr")
         writer.writeObjectKeyValue(self, "background", self._background is not None)
         writer.writeObjectKeyValue(self, "backgroundImage")
         writer.writeObjectKeyValue(self, "color")
@@ -3496,7 +3499,7 @@ class GSLayer(GSBase):
         self._selection = []
         self._shapes = []
         self._userData = None
-        self.attr = {}
+        self.attributes = {}
         self.partSelection = {}
         self.associatedMasterId = ""
         self.backgroundImage = None
@@ -3737,15 +3740,17 @@ class GSLayer(GSBase):
     )
 
     def _is_bracket_layer(self):
-        return "axisRules" in self.attr or re.match(self.BRACKET_LAYER_RE, self.name)
+        return "axisRules" in self.attributes or re.match(
+            self.BRACKET_LAYER_RE, self.name
+        )
 
     def _bracket_info(self):
         if not self._is_bracket_layer():
             return None
 
-        if "axisRules" in self.attr:
+        if "axisRules" in self.attributes:
             # Glyphs 3
-            rules = self.attr["axisRules"]
+            rules = self.attributes["axisRules"]
             if any(rules[1:]):
                 raise ValueError("Alternate rules on non-first axis not yet supported")
             return 0, rules[0].get("min"), rules[0].get("max")
@@ -3792,7 +3797,7 @@ GSLayer._add_parsers(
             "object_name": "metricWidth",
             "type": str,
         },  # V2
-        {"plist_name": "attr", "type": dict},  # V3
+        {"plist_name": "attr", "object_name": "attributes", "type": dict},  # V3
     ]
 )
 

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1216,6 +1216,24 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
             ("color.65535", 65535),
         ]
 
+    def test_glyph_lib_color_mapping_invalid_index(self):
+        font = generate_minimal_font()
+        glyph = add_glyph(font, "a")
+        color = GSLayer()
+        color.name = "Color f"
+        glyph.layers.append(color)
+
+        color = GSLayer()
+        color.name = "Color 0"
+        glyph.layers.append(color)
+
+        ds = self.to_designspace(font)
+        ufo = ds.sources[0].font
+
+        assert ufo["a"].lib["com.github.googlei18n.ufo2ft.colorLayerMapping"] == [
+            ("color.0", 0),
+        ]
+
     def test_glyph_color_layers_decompose(self):
         font = generate_minimal_font()
         glypha = add_glyph(font, "a")

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1195,9 +1195,9 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
         ufo = ds.sources[0].font
 
         assert ufo["a"].lib["com.github.googlei18n.ufo2ft.colorLayerMapping"] == [
-            ("Color 1", 1),
-            ("Color 0", 0),
-            ("Color 3", 3),
+            ("color.1", 1),
+            ("color.0", 0),
+            ("color.3", 3),
         ]
         assert "com.github.googlei18n.ufo2ft.colorLayerMapping" not in ufo["b"].lib
 
@@ -1213,7 +1213,7 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
         ufo = ds.sources[0].font
 
         assert ufo["a"].lib["com.github.googlei18n.ufo2ft.colorLayerMapping"] == [
-            ("Color *", 65535),
+            ("color.65535", 65535),
         ]
 
     def test_glyph_color_layers_decompose(self):
@@ -1253,27 +1253,27 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
         ds = self.to_designspace(font)
         ufo = ds.sources[0].font
 
-        assert len(ufo.layers["Color 0"]["a"].components) == 0
-        assert len(ufo.layers["Color 0"]["a"]) == 2
+        assert len(ufo.layers["color.0"]["a"].components) == 0
+        assert len(ufo.layers["color.0"]["a"]) == 2
         pen1 = _PointDataPen()
-        ufo.layers["Color 0"]["a"].drawPoints(pen1)
+        ufo.layers["color.0"]["a"].drawPoints(pen1)
         pen2 = _PointDataPen()
         ufo["d"].drawPoints(pen2)
         ufo["c"].drawPoints(pen2)
         assert pen1.contours == pen2.contours
 
-        assert len(ufo.layers["Color 1"]["a"].components) == 0
-        assert len(ufo.layers["Color 1"]["a"]) == 1
+        assert len(ufo.layers["color.1"]["a"].components) == 0
+        assert len(ufo.layers["color.1"]["a"]) == 1
         pen1 = _PointDataPen()
-        ufo.layers["Color 1"]["a"].drawPoints(pen1)
+        ufo.layers["color.1"]["a"].drawPoints(pen1)
         pen2 = _PointDataPen()
         ufo["d"].drawPoints(pen2)
         assert pen1.contours == pen2.contours
 
-        assert len(ufo.layers["Color 3"]["a"].components) == 0
-        assert len(ufo.layers["Color 3"]["a"]) == 1
+        assert len(ufo.layers["color.3"]["a"].components) == 0
+        assert len(ufo.layers["color.3"]["a"]) == 1
         pen1 = _PointDataPen()
-        ufo.layers["Color 3"]["a"].drawPoints(pen1)
+        ufo.layers["color.3"]["a"].drawPoints(pen1)
         pen2 = _PointDataPen()
         ufo["c"].drawPoints(pen2)
         assert pen1.contours == pen2.contours

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -157,8 +157,9 @@ def test_designspace_generation_same_weight_name(tmpdir, ufo_module):
     assert designspace.sources[0].filename != designspace.sources[2].filename
 
 
-def test_designspace_generation_brace_layers(datadir, ufo_module):
-    with open(str(datadir.join("BraceTestFont.glyphs"))) as f:
+@pytest.mark.parametrize("filename", ["BraceTestFont.glyphs", "BraceTestFontV3.glyphs"])
+def test_designspace_generation_brace_layers(datadir, filename, ufo_module):
+    with open(str(datadir.join(filename))) as f:
         font = glyphsLib.load(f)
     designspace = to_designspace(font, ufo_module=ufo_module)
 
@@ -192,8 +193,9 @@ def test_designspace_generation_brace_layers(datadir, ufo_module):
         masters[source.filename] = source.font
 
 
-def test_designspace_generation_instances(datadir, ufo_module):
-    with open(str(datadir.join("BraceTestFont.glyphs"))) as f:
+@pytest.mark.parametrize("filename", ["BraceTestFont.glyphs", "BraceTestFontV3.glyphs"])
+def test_designspace_generation_instances(datadir, filename, ufo_module):
+    with open(str(datadir.join(filename))) as f:
         font = glyphsLib.load(f)
     designspace = to_designspace(font, ufo_module=ufo_module)
 
@@ -211,8 +213,9 @@ def test_designspace_generation_instances(datadir, ufo_module):
     ]
 
 
-def test_designspace_generation_on_disk(datadir, tmpdir, ufo_module):
-    glyphsLib.build_masters(str(datadir.join("BraceTestFont.glyphs")), str(tmpdir))
+@pytest.mark.parametrize("filename", ["BraceTestFont.glyphs", "BraceTestFontV3.glyphs"])
+def test_designspace_generation_on_disk(datadir, tmpdir, filename, ufo_module):
+    glyphsLib.build_masters(str(datadir.join(filename)), str(tmpdir))
 
     ufo_paths = list(tmpdir.visit(fil="*.ufo"))
     assert len(ufo_paths) == 4  # Source layers should not be written to disk.

--- a/tests/data/BraceTestFontV3.glyphs
+++ b/tests/data/BraceTestFontV3.glyphs
@@ -1,0 +1,872 @@
+{
+.appVersion = "3100";
+.formatVersion = 3;
+axes = (
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Write lastChange";
+value = 0;
+}
+);
+date = "2019-01-09 16:33:47 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+axesValues = (
+100,
+100
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+iconName = Light;
+id = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = Light;
+},
+{
+axesValues = (
+100,
+1000
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
+);
+iconName = Bold;
+id = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = Bold;
+},
+{
+axesValues = (
+50,
+100
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 75;
+},
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+iconName = Condensed;
+id = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = "Condensed Light";
+},
+{
+axesValues = (
+50,
+1000
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 75;
+},
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
+);
+iconName = Bold_Condensed;
+id = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = "Condensed Bold";
+}
+);
+glyphs = (
+{
+glyphname = a;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-22,l),
+(504,356,l),
+(308,519,l),
+(300,522,o),
+(169,442,o),
+(99,403,c),
+(123,316,l),
+(300,453,l),
+(398,318,l),
+(387,-22,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,35,l),
+(420,115,l),
+(277,35,l),
+(101,50,l),
+(106,153,l),
+(427,161,l),
+(430,186,l),
+(36,214,l),
+(25,-23,l),
+(290,-32,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-22,l),
+(504,356,l),
+(308,519,l),
+(300,522,o),
+(141,464,o),
+(71,425,c),
+(103,301,l),
+(258,351,l),
+(398,318,l),
+(387,-22,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,35,l),
+(420,115,l),
+(277,35,l),
+(181,48,l),
+(186,151,l),
+(422,129,l),
+(436,270,l),
+(36,214,l),
+(25,-23,l),
+(290,-32,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,-22,l),
+(252,356,l),
+(154,519,l),
+(150,522,o),
+(85,442,o),
+(50,403,c),
+(62,316,l),
+(135,371,l),
+(199,318,l),
+(194,-22,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,35,l),
+(210,115,l),
+(139,35,l),
+(51,50,l),
+(53,153,l),
+(214,161,l),
+(215,186,l),
+(18,214,l),
+(13,-23,l),
+(145,-32,l)
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,-22,l),
+(252,356,l),
+(154,519,l),
+(150,522,o),
+(71,464,o),
+(36,425,c),
+(52,301,l),
+(129,351,l),
+(199,318,l),
+(194,-22,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,35,l),
+(210,115,l),
+(139,35,l),
+(91,48,l),
+(93,151,l),
+(211,129,l),
+(218,270,l),
+(18,214,l),
+(13,-23,l),
+(145,-32,l)
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+attr = {
+coordinates = (
+75,
+0
+);
+};
+layerId = "1ABBBA7E-D0DC-49B1-AC13-AB42C8F97BA5";
+name = "{75}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,-22,l),
+(378,356,l),
+(231,519,l),
+(225,522,o),
+(127,442,o),
+(74,403,c),
+(92,316,l),
+(162,78,l),
+(299,318,l),
+(290,-22,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,35,l),
+(315,115,l),
+(208,35,l),
+(76,50,l),
+(80,153,l),
+(320,161,l),
+(323,186,l),
+(27,214,l),
+(19,-23,l),
+(218,-32,l)
+);
+}
+);
+width = 450;
+}
+);
+unicode = 97;
+},
+{
+glyphname = b;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,148,l),
+(417,495,l),
+(133,466,l),
+(138,143,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,38,l),
+(569,554,l),
+(95,531,l),
+(43,57,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,148,l),
+(209,495,l),
+(67,466,l),
+(69,143,l)
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,38,l),
+(285,554,l),
+(48,531,l),
+(22,57,l)
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+attr = {
+coordinates = (
+75,
+0
+);
+};
+layerId = "FD486ED6-D76D-490C-B562-C4A027492D0B";
+name = "{75}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,38,l),
+(142,165,l),
+(262,592,l),
+(33,57,l)
+);
+}
+);
+width = 450;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+attr = {
+coordinates = (
+90.5,
+600
+);
+};
+layerId = "632E4528-00C8-4F10-BDDD-AF6AFE04F5C5";
+name = "Test1 {90.5, 600}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,470,l),
+(439,112,l),
+(341,592,l),
+(64,301,l)
+);
+}
+);
+width = 585;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+attr = {
+coordinates = (
+90.5,
+500
+);
+};
+layerId = "B9BEDC92-E24C-4B32-B67C-5E0D08DFC991";
+name = "Test2 {90.5, 500}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,470,l),
+(439,112,l),
+(-240,800,l),
+(64,301,l)
+);
+}
+);
+width = 585;
+}
+);
+unicode = 98;
+},
+{
+glyphname = c;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,253,o),
+(332,281,o),
+(332,317,cs),
+(332,352,o),
+(302,380,o),
+(264,380,cs),
+(226,380,o),
+(196,352,o),
+(196,317,cs),
+(196,281,o),
+(226,253,o),
+(264,253,cs)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,28,o),
+(555,131,o),
+(555,258,cs),
+(555,384,o),
+(447,487,o),
+(314,487,cs),
+(180,487,o),
+(72,384,o),
+(72,258,cs),
+(72,131,o),
+(180,28,o),
+(314,28,cs)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,253,o),
+(166,281,o),
+(166,317,cs),
+(166,352,o),
+(151,380,o),
+(132,380,cs),
+(113,380,o),
+(98,352,o),
+(98,317,cs),
+(98,281,o),
+(113,253,o),
+(132,253,cs)
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,28,o),
+(278,131,o),
+(278,258,cs),
+(278,384,o),
+(224,487,o),
+(157,487,cs),
+(90,487,o),
+(36,384,o),
+(36,258,cs),
+(36,131,o),
+(90,28,o),
+(157,28,cs)
+);
+}
+);
+width = 300;
+}
+);
+unicode = 99;
+},
+{
+glyphname = d;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,143,l),
+(425,443,l),
+(125,443,l),
+(125,143,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,38,l),
+(569,554,l),
+(95,531,l),
+(43,57,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,148,l),
+(209,495,l),
+(67,466,l),
+(69,143,l)
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,38,l),
+(285,554,l),
+(48,531,l),
+(22,57,l)
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "FD486ED6-D76D-490C-B562-C4A027492D0B";
+name = "{55}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,38,l),
+(142,165,l),
+(262,592,l),
+(33,57,l)
+);
+}
+);
+width = 450;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "632E4528-00C8-4F10-BDDD-AF6AFE04F5C5";
+name = "Test1 {90, 600}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,470,l),
+(439,112,l),
+(341,592,l),
+(64,301,l)
+);
+}
+);
+width = 585;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "B9BEDC92-E24C-4B32-B67C-5E0D08DFC991";
+name = "Test2 {90, 500}";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,470,l),
+(439,112,l),
+(-240,800,l),
+(64,301,l)
+);
+}
+);
+width = 585;
+}
+);
+unicode = 100;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+width = 600;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+100,
+100
+);
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 1;
+};
+name = Thin;
+weightClass = 100;
+},
+{
+axesValues = (
+100,
+500
+);
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 0.55556;
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 0.44444;
+};
+name = Regular;
+},
+{
+axesValues = (
+100,
+1000
+);
+instanceInterpolations = {
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+weightClass = 700;
+},
+{
+axesValues = (
+75,
+500
+);
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 0.27778;
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 0.22222;
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 0.27778;
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 0.22222;
+};
+name = "Semi Consensed";
+widthClass = 4;
+},
+{
+axesValues = (
+50,
+100
+);
+instanceInterpolations = {
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 1;
+};
+name = "Thin Condensed";
+weightClass = 100;
+widthClass = 3;
+},
+{
+axesValues = (
+50,
+500
+);
+instanceInterpolations = {
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 0.44444;
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 0.55556;
+};
+name = Condensed;
+widthClass = 3;
+},
+{
+axesValues = (
+50,
+1000
+);
+instanceInterpolations = {
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 1;
+};
+isBold = 1;
+linkStyle = Condensed;
+name = "Bold Condensed";
+weightClass = 700;
+widthClass = 3;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Glyphs 3 has explicit layer attributes for things that Glyphs 2 used magic layer names for, and layer names has no special meanings. We often check for layer attributes and unconditionally fallback to layer name, but this can lead to undesired effects when layer names in Glyphs 3 happen to match magic Glyphs 2 names.

To fix this we now check for layer attributes in Glyphs 3 and layer names in Glyphs 2.