### PR TITLE
[builder] Fix re-use of master layer in color glyphs

### DIFF
--- a/Lib/glyphsLib/builder/color_layers.py
+++ b/Lib/glyphsLib/builder/color_layers.py
@@ -28,13 +28,15 @@ def _to_ufo_color_palette_layers(builder, master, layerMapping):
 
         colorLayers = []
         for i, (layer, colorId) in enumerate(layers):
-            if layer != masterLayer:
+            if layer.layerId == master.id:
+                # This is master layer, we can re-use its UFO glyph.
+                layerGlyphName = glyph.name
+            else:
+                # Not the master layer, create a new UFO glyph for it.
                 layerGlyphName = f"{glyph.name}.color{i}"
                 ufo_layer = builder.to_ufo_layer(glyph, masterLayer)
                 ufo_glyph = ufo_layer.newGlyph(layerGlyphName)
                 builder.to_ufo_glyph(ufo_glyph, layer, glyph)
-            else:
-                layerGlyphName = glyph.name
             colorLayers.append((layerGlyphName, colorId))
         layerMapping[glyph.name] = colorLayers
 
@@ -181,13 +183,15 @@ def _to_ufo_color_layers(builder, ufo, master, layerMapping):
                 colorLayers.append(_to_component_paint(layer.components[0]))
                 continue
 
-            if layer != masterLayer:
+            if layer.layerId == master.id:
+                # This is master layer, we can re-use its UFO glyph.
+                layerGlyphName = glyph.name
+            else:
+                # Not the master layer, create a new UFO glyph for it.
                 layerGlyphName = f"{glyph.name}.color{i}"
                 ufo_layer = builder.to_ufo_layer(glyph, masterLayer)
                 ufo_glyph = ufo_layer.newGlyph(layerGlyphName)
                 builder.to_ufo_glyph(ufo_glyph, layer, glyph, do_color_layers=False)
-            else:
-                layerGlyphName = glyph.name
 
             attributes = layer.paths[0].attributes if layer.paths else {}
             if "gradient" in attributes:

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1918,7 +1918,7 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
                 "Layers": [
                     {
                         "Format": 10,
-                        "Glyph": "b.color0",
+                        "Glyph": "b",
                         "Paint": {
                             "Format": 6,
                             "ColorLine": {
@@ -1992,7 +1992,7 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
                 "Layers": [
                     {
                         "Format": 10,
-                        "Glyph": "b.color0",
+                        "Glyph": "b",
                         "Paint": {
                             "Format": 6,
                             "ColorLine": {
@@ -2065,7 +2065,7 @@ class ToUfosTestBase(ParametrizedUfoModuleTestMixin):
                 "Layers": [
                     {
                         "Format": 10,
-                        "Glyph": "b.color0",
+                        "Glyph": "b",
                         "Paint": {
                             "Format": 6,
                             "ColorLine": {


### PR DESCRIPTION
Apparently comparing layer objects is not reliable. Comparing layer ID with master ID instead.