### PR TITLE
Fix two small problems with localised values

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3009,12 +3009,9 @@ class GSFontInfoValue(GSBase):  # Combines localizable/nonlocalizable properties
     def defaultValue(self):
         if not self.localized_values:
             return self.value
-        if "dflt" in self.localized_values:
-            return self.localized_values["dflt"]
-        if "default" in self.localized_values:
-            return self.localized_values["default"]
-        if "ENG" in self.localized_values:
-            return self.localized_values["ENG"]
+        for key in ["dflt", "default", "ENG"]:
+            if key in self.localized_values:
+                return self.localized_values[key]
         return list(self.localized_values.values())[0]
 
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3011,9 +3011,11 @@ class GSFontInfoValue(GSBase):  # Combines localizable/nonlocalizable properties
             return self.value
         if "dflt" in self.localized_values:
             return self.localized_values["dflt"]
+        if "default" in self.localized_values:
+            return self.localized_values["default"]
         if "ENG" in self.localized_values:
             return self.localized_values["ENG"]
-        return self.localized_values.values()[0]
+        return list(self.localized_values.values())[0]
 
 
 class GSInstance(GSBase):


### PR DESCRIPTION
* The key "default" is sometimes used as a default language value
* You can't index into a `dict_values`.

Found while investigating #746