### PR TITLE
Fix brace layer parsing to force int where there may be strings

### DIFF
--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -164,7 +164,7 @@ def _to_designspace_source_layer(self):
     designspace = self._designspace
     layers_to_insert = collections.defaultdict(list)
     for key, master_ids in layer_to_master_ids.items():
-        brace_coordinates = list(key[1])
+        brace_coordinates = list(map(int,key[1]))
         layer_name = key[0]
         for master_id in master_ids:
             # ... as they may need to be filled up with the values of the associated


### PR DESCRIPTION
I was running into this error while converting a file that uses brace layers:

```
    brace_layers.sort(key=lambda x: tuple(x.location.values()))
TypeError: '<' not supported between instances of 'str' and 'int'
```

The issue was that my Glyphs file had some integers in its brace layer axis locations, along with some strings. I'm not sure how or why this divergence occurred, but I think it would make sense to force an `int` for these values.

