### PR TITLE
Don't write special "Variable Font Setting" instances to designspace

### DIFF
--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -48,8 +48,12 @@ def to_designspace_instances(self):
         if self.minimize_glyphs_diffs or (
             is_instance_active(instance)
             and _is_instance_included_in_family(self, instance)
+            and not instance.is_variable_setting
         ):
-            _to_designspace_instance(self, instance)
+            if instance.is_variable_setting:
+                _to_designspace_lib(self, instance)
+            else:
+                _to_designspace_instance(self, instance)
 
 
 def _to_designspace_instance(self, instance):
@@ -146,6 +150,12 @@ def _to_designspace_instance(self, instance):
         ufo_instance.lib[CUSTOM_PARAMETERS_KEY] = params
 
     self.designspace.addInstance(ufo_instance)
+
+
+def _to_designspace_lib(self, instance):
+    # Store a "variable font setting" special instance type in the designspace lib
+    pass
+    # TODO
 
 
 def _is_instance_included_in_family(self, instance):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -141,6 +141,9 @@ CURVE = "curve"
 OFFCURVE = "offcurve"
 QCURVE = "qcurve"
 
+INSTANCETYPESINGLE = 0
+INSTANCETYPEVARIABLE = 1
+
 TAG = -2
 TOPGHOST = -1
 STEM = 0
@@ -3020,6 +3023,7 @@ class GSInstance(GSBase):
         writer.writeObjectKeyValue(self, "active", condition=(not self.active))
         if writer.format_version > 2:
             writer.writeObjectKeyValue(self, "axes", keyName="axesValues")
+            writer.writeObjectKeyValue(self, "type", keyName="type", condition="if_true")
         writer.writeObjectKeyValue(self, "exports", condition=(not self.exports))
         writer.writeObjectKeyValue(self, "customParameters", condition="if_true")
         if writer.format_version == 2:
@@ -3071,6 +3075,7 @@ class GSInstance(GSBase):
         "weightClass": "Regular",
         "widthClass": "Medium (normal)",
         "instanceInterpolations": {},
+        "type": INSTANCETYPESINGLE,
     }
 
     def __init__(self):
@@ -3090,11 +3095,31 @@ class GSInstance(GSBase):
         self.visible = True
         self.weight = self._defaultsForName["weightClass"]
         self.width = self._defaultsForName["widthClass"]
+        self.type = self._defaultsForName["type"]
 
     customParameters = property(
         lambda self: CustomParametersProxy(self),
         lambda self, value: CustomParametersProxy(self).setter(value),
     )
+
+    @property
+    def type(self):
+        if self._type == INSTANCETYPEVARIABLE:
+            return "variable"  # "variable" is stored in plist
+        return False
+
+    @type.setter
+    def type(self, value):
+        if value == "variable":  # "variable" is stored in plist
+            self._type = INSTANCETYPEVARIABLE
+        else:
+            self._type = value
+
+    @property
+    def is_variable_setting(self):
+        if self._type == INSTANCETYPEVARIABLE:
+            return True
+        return False
 
     @property
     def exports(self):
@@ -3283,6 +3308,7 @@ GSInstance._add_parsers(
         {"plist_name": "axesValues", "object_name": "axes"},
         {"plist_name": "manualInterpolation", "converter": bool},
         {"plist_name": "properties", "type": GSFontInfoValue},
+        {"plist_name": "type", "object_name": "type"},
     ]
 )
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3023,7 +3023,9 @@ class GSInstance(GSBase):
         writer.writeObjectKeyValue(self, "active", condition=(not self.active))
         if writer.format_version > 2:
             writer.writeObjectKeyValue(self, "axes", keyName="axesValues")
-            writer.writeObjectKeyValue(self, "type", keyName="type", condition="if_true")
+            writer.writeObjectKeyValue(
+                self, "type", keyName="type", condition="if_true"
+            )
         writer.writeObjectKeyValue(self, "exports", condition=(not self.exports))
         writer.writeObjectKeyValue(self, "customParameters", condition="if_true")
         if writer.format_version == 2:


### PR DESCRIPTION
Glyphs 3 stores export settings for variable fonts in special `GSInstance` instances.

Those are currently not special-cased by glyphsLib, and are written as a normal instance into designspaces files, which leads to duplicate instances in the exported variable font.

This PR avoids exporting them to a designspace, but more work needs to be done to preserve them in roundtripping. Probably they should be written to the designspace lib and when going from DS to Glyphs, be reconstructed from there.