### PR TITLE
Set feature for designspace rules

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -497,7 +497,7 @@ class UFOBuilder(_LoggerMixin):
         feat = self.font.customParameters["Feature for Feature Variations"]
         if feat == "rclt":
             self._designspace.rulesProcessingLast = True
-        elif feat != "rvrn":
+        elif feat and feat != "rvrn":
             self._designspace.lib[FEAVAR_FEATURETAG_LIB_KEY] = feat
 
         # Finally, copy bracket layers to their own glyphs.

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -22,6 +22,7 @@ from textwrap import dedent
 from typing import Any, Dict
 
 from fontTools import designspaceLib
+from fontTools.varLib import FEAVAR_FEATURETAG_LIB_KEY
 
 from glyphsLib import classes, glyphdata, util
 from .constants import (
@@ -491,6 +492,13 @@ class UFOBuilder(_LoggerMixin):
                     reverse,
                 )
                 self._designspace.addRule(rule)
+
+        # Set feature for rules
+        feat = self.font.customParameters["Feature for Feature Variations"]
+        if feat == "rclt":
+            self._designspace.rulesProcessingLast = True
+        elif feat != "rvrn":
+            self._designspace.lib[FEAVAR_FEATURETAG_LIB_KEY] = feat
 
         # Finally, copy bracket layers to their own glyphs.
         self._copy_bracket_layers_to_ufo_glyphs(bracket_layer_map)

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -18,6 +18,7 @@ import io
 import os
 from fontTools.designspaceLib import DesignSpaceDocument
 from xmldiff import main, formatting
+from fontTools.varLib import FEAVAR_FEATURETAG_LIB_KEY
 
 import itertools
 import pytest
@@ -508,3 +509,25 @@ def test_designspace_generation_bracket_glyphs3_simple(datadir, ufo_module):
 
     for source in designspace.sources:
         assert "A.BRACKET.600" in source.font
+
+
+def test_designspace_generation_bracket_rclt_roundtrip(datadir, ufo_module):
+    with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
+        font = glyphsLib.load(f)
+    font.customParameters["Feature for Feature Variations"] = "rclt"
+    designspace = to_designspace(font, ufo_module=ufo_module)
+    assert designspace.rulesProcessingLast
+
+    font_rt = to_glyphs(designspace)
+    assert font_rt.customParameters["Feature for Feature Variations"] == "rclt"
+
+def test_designspace_generation_bracket_other_roundtrip(datadir, ufo_module):
+    with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
+        font = glyphsLib.load(f)
+    font.customParameters["Feature for Feature Variations"] = "calt"
+    designspace = to_designspace(font, ufo_module=ufo_module)
+    assert FEAVAR_FEATURETAG_LIB_KEY in designspace.lib
+    assert designspace.lib[FEAVAR_FEATURETAG_LIB_KEY] == "calt"
+
+    font_rt = to_glyphs(designspace)
+    assert font_rt.customParameters["Feature for Feature Variations"] == "calt"

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -521,6 +521,7 @@ def test_designspace_generation_bracket_rclt_roundtrip(datadir, ufo_module):
     font_rt = to_glyphs(designspace)
     assert font_rt.customParameters["Feature for Feature Variations"] == "rclt"
 
+
 def test_designspace_generation_bracket_other_roundtrip(datadir, ufo_module):
     with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
         font = glyphsLib.load(f)


### PR DESCRIPTION
Glyphs has a mechanism (the "Feature for Feature Variations" custom parameter) for setting which feature should be used for processing bracket rules. This implements that custom parameter, passing the feature information to designspace. If the user requests `rclt`, we set `processing=last` on the rules tag; otherwise, we use the equivalent designspace lib key `com.github.fonttools.varLib.featureVarsFeatureTag`.