### PR TITLE
add option to both UFO|GlyphsBuilders to expand_includes in features

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -53,6 +53,7 @@ def load_to_ufos(
     family_name=None,
     propagate_anchors=None,
     ufo_module=None,
+    expand_includes=False,
     minimal=False,
     glyph_data=None,
 ):
@@ -70,6 +71,7 @@ def load_to_ufos(
         family_name=family_name,
         propagate_anchors=propagate_anchors,
         ufo_module=ufo_module,
+        expand_includes=expand_includes,
         minimal=minimal,
         glyph_data=glyph_data,
     )
@@ -88,6 +90,7 @@ def build_masters(
     generate_GDEF=True,
     store_editor_state=True,
     write_skipexportglyphs=False,
+    expand_includes=False,
     ufo_module=None,
     minimal=False,
     glyph_data=None,
@@ -126,6 +129,7 @@ def build_masters(
         generate_GDEF=generate_GDEF,
         store_editor_state=store_editor_state,
         write_skipexportglyphs=write_skipexportglyphs,
+        expand_includes=expand_includes,
         ufo_module=ufo_module,
         minimal=minimal,
         glyph_data=glyph_data,

--- a/Lib/glyphsLib/builder/__init__.py
+++ b/Lib/glyphsLib/builder/__init__.py
@@ -31,6 +31,7 @@ def to_ufos(
     generate_GDEF=True,
     store_editor_state=True,
     write_skipexportglyphs=False,
+    expand_includes=False,
     minimal=False,
     glyph_data=None,
 ):
@@ -47,6 +48,9 @@ def to_ufos(
     If generate_GDEF is True, write a `table GDEF {...}` statement in the
     UFO's features.fea, containing GlyphClassDef and LigatureCaretByPos.
 
+    If expand_includes is True, resolve include statements in the GSFont features
+    and inline them in the UFO features.fea.
+
     If minimal is True, it is assumed that the UFOs will only be used in
     font production, and unnecessary steps (e.g. converting background layers)
     will be skipped.
@@ -60,6 +64,7 @@ def to_ufos(
         generate_GDEF=generate_GDEF,
         store_editor_state=store_editor_state,
         write_skipexportglyphs=write_skipexportglyphs,
+        expand_includes=expand_includes,
         minimal=minimal,
         glyph_data=glyph_data,
     )
@@ -81,6 +86,7 @@ def to_designspace(
     generate_GDEF=True,
     store_editor_state=True,
     write_skipexportglyphs=False,
+    expand_includes=False,
     minimal=False,
     glyph_data=None,
 ):
@@ -117,6 +123,7 @@ def to_designspace(
         generate_GDEF=generate_GDEF,
         store_editor_state=store_editor_state,
         write_skipexportglyphs=write_skipexportglyphs,
+        expand_includes=expand_includes,
         minimal=minimal,
         glyph_data=glyph_data,
     )
@@ -128,6 +135,7 @@ def to_glyphs(
     glyphs_module=classes,
     ufo_module=None,
     minimize_ufo_diffs=False,
+    expand_includes=False,
 ):
     """
     Take a list of UFOs or a single DesignspaceDocument with attached UFOs
@@ -146,6 +154,7 @@ def to_glyphs(
             glyphs_module=glyphs_module,
             ufo_module=ufo_module,
             minimize_ufo_diffs=minimize_ufo_diffs,
+            expand_includes=expand_includes,
         )
     else:
         builder = GlyphsBuilder(
@@ -153,5 +162,6 @@ def to_glyphs(
             glyphs_module=glyphs_module,
             ufo_module=ufo_module,
             minimize_ufo_diffs=minimize_ufo_diffs,
+            expand_includes=expand_includes,
         )
     return builder.font

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -47,6 +47,7 @@ class UFOBuilder(LoggerMixin):
         generate_GDEF=True,
         store_editor_state=True,
         write_skipexportglyphs=False,
+        expand_includes=False,
         minimal=False,
         glyph_data=None,
     ):
@@ -79,6 +80,10 @@ class UFOBuilder(LoggerMixin):
                                          into the UFOs' and Designspace's lib instead
                                          of the glyph level lib key
                                          "com.schriftgestaltung.Glyphs.Export".
+        expand_includes -- If True, expand include statements in the GSFont features
+                           and inline them in the UFO features.fea.
+        minimal -- If True, it is assumed that the UFOs will only be used in font
+                   production, and unnecessary steps will be skipped.
         glyph_data -- A list of GlyphData.
         """
         self.font = font
@@ -96,6 +101,7 @@ class UFOBuilder(LoggerMixin):
         self.store_editor_state = store_editor_state
         self.bracket_layers = []
         self.write_skipexportglyphs = write_skipexportglyphs
+        self.expand_includes = expand_includes
         self.minimal = minimal
 
         if propagate_anchors is None:
@@ -422,6 +428,7 @@ class GlyphsBuilder(LoggerMixin):
         glyphs_module=classes,
         ufo_module=None,
         minimize_ufo_diffs=False,
+        expand_includes=False,
     ):
         """Create a builder that goes from UFOs + designspace to Glyphs.
 
@@ -450,9 +457,12 @@ class GlyphsBuilder(LoggerMixin):
         minimize_ufo_diffs -- set to True to store extra info in .glyphs files
                               in order to get smaller diffs between UFOs
                               when going UFOs->glyphs->UFOs
+        expand_includes -- If True, expand include statements in the UFOs' features.fea
+                           and inline them in the GSFont features.
         """
         self.glyphs_module = glyphs_module
         self.minimize_ufo_diffs = minimize_ufo_diffs
+        self.expand_includes = expand_includes
 
         if designspace is not None:
             if ufos:

--- a/Lib/glyphsLib/cli.py
+++ b/Lib/glyphsLib/cli.py
@@ -151,6 +151,14 @@ def main(args=None):
             "key."
         ),
     )
+    group.add_argument(
+        "--expand-includes",
+        action="store_true",
+        help=(
+            "Expand include statements in the .glyphs features and inline them in "
+            "the exported UFO features.fea."
+        ),
+    )
     group = parser_glyphs2ufo.add_argument_group("Glyph data")
     group.add_argument(
         "--glyph-data",
@@ -211,6 +219,14 @@ def main(args=None):
         action="store_false",
         help="Enable automatic alignment of components in glyphs.",
     )
+    group.add_argument(
+        "--expand-includes",
+        action="store_true",
+        help=(
+            "Expand include statements in the UFO features.fea and inline them in "
+            "the exported .glyphs features."
+        ),
+    )
 
     options = parser.parse_args(args)
 
@@ -246,6 +262,7 @@ def glyphs2ufo(options):
         generate_GDEF=options.generate_GDEF,
         store_editor_state=not options.no_store_editor_state,
         write_skipexportglyphs=options.write_public_skip_export_glyphs,
+        expand_includes=options.expand_includes,
         ufo_module=__import__(options.ufo_module),
         minimal=options.minimal,
         glyph_data=options.glyph_data or None,
@@ -298,6 +315,7 @@ def ufo2glyphs(options):
         object_to_read,
         ufo_module=ufo_module,
         minimize_ufo_diffs=options.no_preserve_glyphsapp_metadata,
+        expand_includes=options.expand_includes,
     )
 
     # Make the Glyphs file more suitable for roundtrip:

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -343,6 +343,50 @@ def test_include_no_semicolon(tmpdir, ufo_module):
     assert rtufo.features.text == ufo.features.text
 
 
+def test_to_glyphs_expand_includes(tmp_path, ufo_module):
+    ufo = ufo_module.Font()
+    ufo.features.text = dedent(
+        """\
+        include(family.fea);
+        """
+    )
+    ufo.save(str(tmp_path / "font.ufo"))
+
+    included_path = tmp_path / "family.fea"
+    included_path.write_text("# hello from family.fea")
+    assert included_path.exists()
+
+    font = to_glyphs([ufo], minimize_ufo_diffs=True, expand_includes=True)
+
+    assert len(font.featurePrefixes) == 1
+    assert font.featurePrefixes[0].code.strip() == "# hello from family.fea"
+
+
+def test_to_ufos_expand_includes(tmp_path, ufo_module):
+    font = classes.GSFont()
+    font.masters.append(classes.GSFontMaster())
+
+    feature_prefix = classes.GSFeaturePrefix()
+    feature_prefix.name = "include"
+    feature_prefix.code = dedent(
+        """\
+        include(family.fea);
+        """
+    )
+    font.featurePrefixes.append(feature_prefix)
+
+    font.filepath = str(tmp_path / "font.glyphs")
+    font.save()
+
+    included_path = tmp_path / "family.fea"
+    included_path.write_text("# hello from family.fea")
+    assert included_path.exists()
+
+    (ufo,) = to_ufos(font, ufo_module=ufo_module, expand_includes=True)
+
+    assert ufo.features.text == ("# Prefix: include\n# hello from family.fea")
+
+
 def test_standalone_lookup(tmpdir, ufo_module):
     ufo = ufo_module.Font()
     # FIXME: (jany) does not preserve whitespace before and after


### PR DESCRIPTION
As suggested in https://github.com/googlefonts/glyphsLib/issues/797, it may be useful sometimes to resolve and expand include statements in features, to create self-contained UFOs/glyphs sources that don't reference any external files. It is disabled by default, to make sure rountripping continues to work. It is not conflated with 'minimal' option because they are distinct things, one may want to enable one without the other.

fontmake may use this to `--expand-features-to-masters` (e.g. when doing `fontmake -o ufo`) similarly to the existing `--expand-features-to-instances` option. However, to fix #797, I prefer to override the include directory (https://github.com/googlefonts/fontmake/pull/917).