### PR TITLE
Load glyphspackage files

### DIFF
--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -15,3 +15,10 @@ def test_glyphs3_italic_angle(datadir):
     with open(str(datadir.join("Italic-G3.glyphs"))) as f:
         font = glyphsLib.load(f)
     assert font.masters[0].italicAngle == 11
+
+
+def test_glyphspackage_load(datadir):
+    font1 = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphs")))
+    font1.DisplayStrings = "" # glyphspackages, rather sensibly, don't store user state
+    font2 = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphspackage")))
+    assert glyphsLib.dumps(font1) == glyphsLib.dumps(font2)


### PR DESCRIPTION
This implements loading .glyphspackages. We can do saving later if we really need to, but for the 80% case (loading fonts for compilations) this gives you useful functionality.

`glyphsLib.load` now takes a filename or a file object, and if the filename is a directory, the glyphspackage loader is used.