### PR TITLE
Write master names when writing v3 version

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1524,8 +1524,10 @@ class GSFontMaster(GSBase):
         if writer.format_version == 3:
             writer.writeKeyValue("metricValues", self.metrics)
 
-        if (self._name and self._name != self.name) or writer.format_version == 3:
-            writer.writeKeyValue("name", self._name or "Regular")
+        if (self._name and self._name != self.name):
+            writer.writeKeyValue("name", self._name)
+        elif writer.format_version == 3:
+            writer.writeKeyValue("name", self.name)
 
         if writer.format_version == 3:
             writer.writeObjectKeyValue(

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1524,7 +1524,7 @@ class GSFontMaster(GSBase):
         if writer.format_version == 3:
             writer.writeKeyValue("metricValues", self.metrics)
 
-        if (self._name and self._name != self.name):
+        if self._name and self._name != self.name:
             writer.writeKeyValue("name", self._name)
         elif writer.format_version == 3:
             writer.writeKeyValue("name", self.name)


### PR DESCRIPTION
If a G2 file is saved with `format_version=3`, currently all its master names get reset to Regular. This fixes that.