### PR TITLE
VF settings fixup for #812/#813

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -18,7 +18,7 @@ import logging
 from fontTools.varLib.models import piecewiseLinearMap
 
 from glyphsLib import classes
-from glyphsLib.classes import INSTANCETYPEVARIABLE, WEIGHT_CODES, WIDTH_CODES
+from glyphsLib.classes import InstanceType, WEIGHT_CODES, WIDTH_CODES
 from glyphsLib.builder.constants import WIDTH_CLASS_TO_VALUE
 
 logger = logging.getLogger(__name__)
@@ -186,7 +186,7 @@ def to_designspace_axes(self):
             for instance in self.font.instances:
                 if (
                     is_instance_active(instance) or self.minimize_glyphs_diffs
-                ) and instance.type != INSTANCETYPEVARIABLE:
+                ) and instance.type != InstanceType.VARIABLE:
                     designLoc = axis_def.get_design_loc(instance)
                     userLoc = axis_def.get_user_loc(instance)
                     if (

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -18,7 +18,7 @@ import logging
 from fontTools.varLib.models import piecewiseLinearMap
 
 from glyphsLib import classes
-from glyphsLib.classes import WEIGHT_CODES, WIDTH_CODES
+from glyphsLib.classes import INSTANCETYPEVARIABLE, WEIGHT_CODES, WIDTH_CODES
 from glyphsLib.builder.constants import WIDTH_CLASS_TO_VALUE
 
 logger = logging.getLogger(__name__)
@@ -186,7 +186,7 @@ def to_designspace_axes(self):
             for instance in self.font.instances:
                 if (
                     is_instance_active(instance) or self.minimize_glyphs_diffs
-                ) and instance.type != "variable":
+                ) and instance.type != INSTANCETYPEVARIABLE:
                     designLoc = axis_def.get_design_loc(instance)
                     userLoc = axis_def.get_user_loc(instance)
                     if (

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3300,6 +3300,7 @@ GSInstance._add_parsers(
         {"plist_name": "axesValues", "object_name": "axes"},
         {"plist_name": "manualInterpolation", "converter": bool},
         {"plist_name": "properties", "type": GSFontInfoValue},
+        {"plist_name": "type", "converter": bool},
     ]
 )
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -20,6 +20,7 @@ import os
 import re
 import uuid
 from collections import OrderedDict
+from enum import IntEnum
 from io import StringIO
 
 import openstep_plist
@@ -141,9 +142,12 @@ CURVE = "curve"
 OFFCURVE = "offcurve"
 QCURVE = "qcurve"
 
+
 # Instance types; normal instance or variable font setting pseudo-instance
-INSTANCETYPESINGLE = 0
-INSTANCETYPEVARIABLE = 1
+class InstanceType(IntEnum):
+    SINGLE = 0
+    VARIABLE = 1
+
 
 TAG = -2
 TOPGHOST = -1
@@ -242,8 +246,9 @@ WIDTH_CODES = {
 }
 
 
-def instance_type_converter(value):
-    return {"variable": INSTANCETYPEVARIABLE}.get(value, INSTANCETYPESINGLE)
+def instance_type(value):
+    # Convert the instance type from the plist ("variable") into the integer constant
+    return getattr(InstanceType, value.upper())
 
 
 class OnlyInGlyphsAppError(NotImplementedError):
@@ -3069,8 +3074,8 @@ class GSInstance(GSBase):
                 self, "widthValue", keyName="interpolationWidth", default=100
             )
         writer.writeObjectKeyValue(self, "instanceInterpolations", "if_true")
-        if writer.format_version > 2 and self.type == INSTANCETYPEVARIABLE:
-            writer.writeValue("variable", "type")
+        if writer.format_version > 2 and self.type == InstanceType.VARIABLE:
+            writer.writeValue(InstanceType.VARIABLE.name.lower(), "type")
         writer.writeObjectKeyValue(self, "isBold", "if_true")
         writer.writeObjectKeyValue(self, "isItalic", "if_true")
         writer.writeObjectKeyValue(self, "linkStyle", "if_true")
@@ -3091,7 +3096,7 @@ class GSInstance(GSBase):
         "weightClass": "Regular",
         "widthClass": "Medium (normal)",
         "instanceInterpolations": {},
-        "type": INSTANCETYPESINGLE,
+        "type": InstanceType.SINGLE,
     }
 
     def __init__(self):
@@ -3305,7 +3310,7 @@ GSInstance._add_parsers(
         {"plist_name": "axesValues", "object_name": "axes"},
         {"plist_name": "manualInterpolation", "converter": bool},
         {"plist_name": "properties", "type": GSFontInfoValue},
-        {"plist_name": "type", "converter": instance_type_converter},
+        {"plist_name": "type", "converter": instance_type},
     ]
 )
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -141,6 +141,7 @@ CURVE = "curve"
 OFFCURVE = "offcurve"
 QCURVE = "qcurve"
 
+# Instance types; normal instance or variable font setting pseudo-instance
 INSTANCETYPESINGLE = 0
 INSTANCETYPEVARIABLE = 1
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -141,6 +141,9 @@ CURVE = "curve"
 OFFCURVE = "offcurve"
 QCURVE = "qcurve"
 
+INSTANCETYPESINGLE = 0
+INSTANCETYPEVARIABLE = 1
+
 TAG = -2
 TOPGHOST = -1
 STEM = 0
@@ -3061,13 +3064,13 @@ class GSInstance(GSBase):
                 self, "widthValue", keyName="interpolationWidth", default=100
             )
         writer.writeObjectKeyValue(self, "instanceInterpolations", "if_true")
+        if writer.format_version > 2 and self.type == INSTANCETYPEVARIABLE:
+            writer.writeValue("variable", "type")
         writer.writeObjectKeyValue(self, "isBold", "if_true")
         writer.writeObjectKeyValue(self, "isItalic", "if_true")
         writer.writeObjectKeyValue(self, "linkStyle", "if_true")
         writer.writeObjectKeyValue(self, "manualInterpolation", "if_true")
         writer.writeObjectKeyValue(self, "name")
-        if writer.format_version > 2:
-            writer.writeObjectKeyValue(self, "type", "if_true")
         writer.writeObjectKeyValue(
             self, "weight", default="Regular", keyName="weightClass"
         )
@@ -3083,6 +3086,7 @@ class GSInstance(GSBase):
         "weightClass": "Regular",
         "widthClass": "Medium (normal)",
         "instanceInterpolations": {},
+        "type": INSTANCETYPESINGLE,
     }
 
     def __init__(self):
@@ -3102,7 +3106,7 @@ class GSInstance(GSBase):
         self.visible = True
         self.weight = self._defaultsForName["weightClass"]
         self.width = self._defaultsForName["widthClass"]
-        self.type = ""
+        self.type = self._defaultsForName["type"]
 
     customParameters = property(
         lambda self: CustomParametersProxy(self),

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -242,6 +242,10 @@ WIDTH_CODES = {
 }
 
 
+def instance_type_converter(value):
+    return {"variable": INSTANCETYPEVARIABLE}.get(value, INSTANCETYPESINGLE)
+
+
 class OnlyInGlyphsAppError(NotImplementedError):
     def __init__(self):
         NotImplementedError.__init__(
@@ -3301,7 +3305,7 @@ GSInstance._add_parsers(
         {"plist_name": "axesValues", "object_name": "axes"},
         {"plist_name": "manualInterpolation", "converter": bool},
         {"plist_name": "properties", "type": GSFontInfoValue},
-        {"plist_name": "type", "converter": bool},
+        {"plist_name": "type", "converter": instance_type_converter},
     ]
 )
 


### PR DESCRIPTION
Small fixup for #812 and #813.

- Use constants in API, as Glyphs does (see https://docu.glyphsapp.com/#instance-types)
- Check against constant when deciding to include an "instance" (i.e. VF setting) in the axis mappings