### PR TITLE
Implements part of #754 via getter/setters for proxying the file format 3 attributes

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1445,6 +1445,8 @@ class GSAlignmentZone(GSBase):
         )
 
     def __lt__(self, other):
+        if not hasattr(other, "position") or not hasattr(other, "size"):
+            return False
         return (self.position, self.size) < (other.position, other.size)
 
     def __eq__(self, other):
@@ -1760,8 +1762,8 @@ class GSFontMaster(GSBase):
 
     @property
     def alignmentZones(self):
-        # If there are values that are parsed from file format 2 or explicitly
-        # set return those
+        # If there are values that are parsed from file format 2 or which are
+        # explicitly set return those
         if self._alignmentZones is not None:
             return self._alignmentZones
 
@@ -1786,12 +1788,21 @@ class GSFontMaster(GSBase):
         return zones
 
     @alignmentZones.setter
-    def alignmentZones(self, value):
-        assert type(value) == list
+    def alignmentZones(self, entries):
+        if type(entries) is not list:
+            raise ValueError(
+                "alignmentZones expected as list, got %s (%s)"
+                % (entries, type(entries))
+            )
         zones = []
-        for val in value:
-            if val not in zones and val is not False:
-                zones.append(val)
+        for zone in entries:
+            if type(zone) is not tuple and type(zone) is not GSAlignmentZone:
+                raise ValueError(
+                    "alignmentZones values expected as tuples of (pos, size) "
+                    "or GSAligmentZone, got: %s (%s)" % (zone, type(zone))
+                )
+            if zone not in zones:
+                zones.append(zone)
         self._alignmentZones = zones
 
     @property

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1445,13 +1445,13 @@ class GSAlignmentZone(GSBase):
         )
 
     def __lt__(self, other):
-        if not hasattr(other, "position") or not hasattr(other, "size"):
-            return False
+        if not isinstance(other, GSAlignmentZone):
+            return NotImplemented
         return (self.position, self.size) < (other.position, other.size)
 
     def __eq__(self, other):
-        if not hasattr(other, "position") or not hasattr(other, "size"):
-            return False
+        if not isinstance(other, GSAlignmentZone):
+            return NotImplemented
         return (self.position, self.size) == (other.position, other.size)
 
     def plistValue(self, format_version=2):
@@ -1789,15 +1789,15 @@ class GSFontMaster(GSBase):
 
     @alignmentZones.setter
     def alignmentZones(self, entries):
-        if type(entries) is not list:
-            raise ValueError(
+        if not isinstance(entries, tuple) and not isinstance(entries, list):
+            raise TypeError(
                 "alignmentZones expected as list, got %s (%s)"
                 % (entries, type(entries))
             )
         zones = []
         for zone in entries:
-            if type(zone) is not tuple and type(zone) is not GSAlignmentZone:
-                raise ValueError(
+            if not isinstance(zone, tuple) and not isinstance(zone, GSAlignmentZone):
+                raise TypeError(
                     "alignmentZones values expected as tuples of (pos, size) "
                     "or GSAligmentZone, got: %s (%s)" % (zone, type(zone))
                 )

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1581,7 +1581,6 @@ class GSFontMaster(GSBase):
         "ascender": 800,
         "descender": -200,
         "italic angle": 0,
-        "baseline": 0,
     }
 
     _axis_defaults = (100, 100)
@@ -1770,19 +1769,15 @@ class GSFontMaster(GSBase):
         if len(self.metrics) == 0:
             return []
 
-        validZoneMetrics = (
-            "ascender",
-            "cap height",
-            "x-height",
-            "baseline",
-            "descender",
-        )
-
         zones = []
         for index, fontMetric in enumerate(self.font.metrics):
-            if fontMetric.type not in validZoneMetrics:
+            # Ignore the "italic angle" "metric", it is not an alignmentZone
+            if fontMetric.type == "italic angle":
                 continue
             metric = self.metrics[index]
+            # Ignore metric without overshoot, it is not an alignmentZone
+            if metric.overshoot == 0:
+                continue
             zone = GSAlignmentZone(pos=metric.position, size=metric.overshoot)
             zones.append(zone)
         return zones

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -1,5 +1,6 @@
 import glyphsLib
-from glyphsLib.classes import GSFont, GSFontMaster
+import pytest
+from glyphsLib.classes import GSFont, GSFontMaster, GSAlignmentZone
 
 
 def test_metrics():
@@ -31,10 +32,51 @@ def test_glyphs3_alignment_zones(datadir):
     assert master.alignmentZones != []
 
     # As per classes_tests::GSAlignmentZoneFromFileTest
-    for i, zone in enumerate([(800, 10), (700, 10), (470, 10), (0, -10), (-200, -10)]):
-        pos, size = zone
+    zones = [(800, 10), (700, 10), (470, 10), (0, -10), (-200, -10)]
+    for i, (pos, size) in enumerate(zones):
         assert master.alignmentZones[i].position == pos
         assert master.alignmentZones[i].size == size
+
+    assert len(master.alignmentZones) == 5
+
+    # alignmentZones can be set as tuples or instances
+    master.alignmentZones = [GSAlignmentZone(800, 10), GSAlignmentZone(0, -10)]
+
+    assert master.alignmentZones[-2].position == 800
+    assert master.alignmentZones[-2].size == 10
+
+    assert master.alignmentZones[-1].position == 0
+    assert master.alignmentZones[-1].size == -10
+
+    assert len(master.alignmentZones) == 2
+
+    # Duplicates should get added only once
+    master.alignmentZones = [(0, -10), (0, -10)]
+    assert len(master.alignmentZones) == 1
+
+    # Let it be emptyable
+    master.alignmentZones = []
+    assert len(master.alignmentZones) == 0
+
+    # Non-list values not allowed
+    with pytest.raises(ValueError):
+        master.alignmentZones = (800, 10)
+
+    with pytest.raises(ValueError):
+        master.alignmentZones = 800
+
+    with pytest.raises(ValueError):
+        master.alignmentZones = "800"
+
+    # Only tuples and GSAlignmentZone allowed inside
+    with pytest.raises(ValueError):
+        master.alignmentZones = [False, True]
+
+    with pytest.raises(ValueError):
+        master.alignmentZones = [[0, -10], [800, 10]]
+
+    with pytest.raises(ValueError):
+        master.alignmentZones = ["", ""]
 
 
 def test_glyphs3_stems(datadir):

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -22,3 +22,24 @@ def test_glyphspackage_load(datadir):
     font1.DisplayStrings = ""  # glyphspackages, rather sensibly, don't store user state
     font2 = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphspackage")))
     assert glyphsLib.dumps(font1) == glyphsLib.dumps(font2)
+
+
+def test_glyphs3_alignment_zones(datadir):
+    font = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphs")))
+    master = font.masters[0]
+
+    assert master.alignmentZones != []
+
+    # As per classes_tests::GSAlignmentZoneFromFileTest
+    for i, zone in enumerate([(800, 10), (700, 10), (470, 10), (0, -10), (-200, -10)]):
+        pos, size = zone
+        assert master.alignmentZones[i].position == pos
+        assert master.alignmentZones[i].size == size
+
+
+def test_glyphs3_stems(datadir):
+    font = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphs")))
+    master = font.masters[0]
+
+    assert master.verticalStems == [17, 19]
+    assert master.horizontalStems == [16, 16, 18]

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -59,23 +59,23 @@ def test_glyphs3_alignment_zones(datadir):
     assert len(master.alignmentZones) == 0
 
     # Non-list values not allowed
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         master.alignmentZones = (800, 10)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         master.alignmentZones = 800
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         master.alignmentZones = "800"
 
     # Only tuples and GSAlignmentZone allowed inside
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         master.alignmentZones = [False, True]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         master.alignmentZones = [[0, -10], [800, 10]]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         master.alignmentZones = ["", ""]
 
 


### PR DESCRIPTION
This implements writing `postscriptBlueValues`, `postscriptOtherBlues`, `postscriptStemSnapV` and `postscriptStemSnapH` for glyphs > ufo.

I added [./tests/glyphs3_test.py](tests) and other tests are passing as well.

I'm not sure how elegant or clumsy it is to have those `GSFontMaster._...` underscore internals and accessing them via the getter/setter proxies, but it seemed the most practical way synthesize them from the `GSFont` attributes required for the offsets.

There are [this](https://github.com/kontur/glyphsLib/blob/fc2b551ddd02da4df0f0b2290fc526a554108847/Lib/glyphsLib/classes.py#L1765), [this](https://github.com/kontur/glyphsLib/blob/fc2b551ddd02da4df0f0b2290fc526a554108847/Lib/glyphsLib/classes.py#L1799) & [this](https://github.com/kontur/glyphsLib/blob/fc2b551ddd02da4df0f0b2290fc526a554108847/Lib/glyphsLib/classes.py#L1819) rather blunt stop gaps in the getters which mainly function to return nothing for cases where the masters are constructed via code, e.g. in the tests (about 50 or so fail otherwise). In a way this could mask a real issue as well, but not sure how realistic it is to rewrite the tests, or add some kind of "defaulting" structures to keep the indexes for constructed objects in sync between GSFont and GSFontMaster.

Should I squash my commits into one? The first commit attempts were a bit hit and miss...