### PR TITLE
[review] Add support for roundtripping Glyphs/UFO custom name table entries.

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1074,6 +1074,8 @@ class CustomParametersProxy(Proxy):
     def _get_parameter_by_key(self, key):
         if key == "Axes" and isinstance(self._owner, GSFont):
             return self._owner._get_custom_parameter_from_axes()
+        if key == "Name Table Entry":
+            return None
         for customParameter in self._owner._customParameters:
             if customParameter.name == key:
                 return customParameter

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -479,6 +479,75 @@ class SetCustomParamsTestBase(object):
         font = glyphsLib.to_glyphs([self.ufo])
         self.assertEqual(font.customParameters["meta Table"], glyphs_meta)
 
+    def test_name_table_entry(self):
+        self.font.customParameters.append(
+            GSCustomParameter("Name Table Entry", "1024; FOO; BAZ")
+        )
+        self.font.customParameters.append(
+            GSCustomParameter("Name Table Entry", "2048 1; FOO")
+        )
+        self.font.customParameters.append(
+            GSCustomParameter("Name Table Entry", "4096 1 2; FOO")
+        )
+        self.font.customParameters.append(
+            GSCustomParameter("Name Table Entry", "8192 1 2 3; FOO")
+        )
+        self.font.customParameters.append(
+            GSCustomParameter("Name Table Entry", "0x4000 074; BAZ")
+        )
+
+        self.set_custom_params()
+
+        ufo_records = [
+            {
+                "nameID": 1024,
+                "platformID": 3,
+                "encodingID": 1,
+                "languageID": 0x49,
+                "string": "FOO; BAZ",
+            },
+            {
+                "nameID": 2048,
+                "platformID": 1,
+                "encodingID": 1,
+                "languageID": 0x49,
+                "string": "FOO",
+            },
+            {
+                "nameID": 4096,
+                "platformID": 1,
+                "encodingID": 2,
+                "languageID": 0x49,
+                "string": "FOO",
+            },
+            {
+                "nameID": 8192,
+                "platformID": 1,
+                "encodingID": 2,
+                "languageID": 3,
+                "string": "FOO",
+            },
+            {
+                "nameID": 16384,
+                "platformID": 60,
+                "encodingID": 1,
+                "languageID": 0x49,
+                "string": "BAZ",
+            },
+        ]
+
+        self.assertEqual(
+            [dict(r) for r in self.ufo.info.openTypeNameRecords], ufo_records
+        )
+
+        font = glyphsLib.to_glyphs([self.ufo])
+
+        self.assertEqual(font.customParameters[0].value, "1024 3 1 73; FOO; BAZ")
+        self.assertEqual(font.customParameters[1].value, "2048 1 1 73; FOO")
+        self.assertEqual(font.customParameters[2].value, "4096 1 2 73; FOO")
+        self.assertEqual(font.customParameters[3].value, "8192 1 2 3; FOO")
+        self.assertEqual(font.customParameters[4].value, "16384 60 1 73; BAZ")
+
 
 class SetCustomParamsTestUfoLib2(SetCustomParamsTestBase, unittest.TestCase):
     ufo_module = ufoLib2


### PR DESCRIPTION
We have some Glyphs source files with custom name table entries that weren't preserved when converting to UFO. This PR parses the Glyphs `<nameid> <platform_id>? <encoding_id>? <language_id>?; <string>` format and creates UFO `openTypeNameRecords` (and vice versa).

I added a new test that covers all the different combinations the Glyphs name table entry format supports. In the case the Glyphs name table entry only specifies a name identifier and string default values are used for the other parameters. The default parameters are not removed when converting from UFO -> Glyphs, so roundtripping a Glyphs will not be literally identical but functionally identical.

This is a partial fix for #633.