### PR TITLE
Smart component speedup

### DIFF
--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -22,10 +22,6 @@ OpenType interpolation model to adjust the node positions.
 
 from enum import IntEnum
 
-# We're going to use pickle/unpickle to copy the node objects because
-# it's considerably faster than copy.deepcopy
-import pickle
-
 from fontTools.varLib.models import VariationModel, normalizeValue
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 

--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -119,12 +119,14 @@ def to_ufo_smart_component(self, layer, component, pen):
     try:
         new_coords = model.interpolateFromMasters(normalized_location, coordinates)
     except Exception as e:
-        raise ValueError("Could not interpolate smart component %s used in %s" % (root.name, layer)) from e
+        raise ValueError(
+            "Could not interpolate smart component %s used in %s" % (root.name, layer)
+        ) from e
 
     # Decompose by creating a new layer, copying its shapes and applying
     # the new coordinates
     new_layer = GSLayer()
-    new_layer._shapes = [ shape.clone() for shape in masters[0]._shapes]
+    new_layer._shapes = [shape.clone() for shape in masters[0]._shapes]
     set_coordinates(new_layer, new_coords)
 
     # Don't forget that the GSComponent might also be transformed, so

--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -120,7 +120,10 @@ def to_ufo_smart_component(self, layer, component, pen):
         for name, value in component.smartComponentValues.items()
     }
     coordinates = [get_coordinates(l) for l in masters]
-    new_coords = model.interpolateFromMasters(normalized_location, coordinates)
+    try:
+        new_coords = model.interpolateFromMasters(normalized_location, coordinates)
+    except Exception as e:
+        raise ValueError("Could not interpolate smart component %s used in %s" % (root.name, layer)) from e
 
     # Decompose by creating a new layer, copying its shapes and applying
     # the new coordinates

--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -125,7 +125,7 @@ def to_ufo_smart_component(self, layer, component, pen):
     # Decompose by creating a new layer, copying its shapes and applying
     # the new coordinates
     new_layer = GSLayer()
-    new_layer._shapes = pickle.loads(pickle.dumps(masters[0]._shapes))
+    new_layer._shapes = [ shape.clone() for shape in masters[0]._shapes]
     set_coordinates(new_layer, new_coords)
 
     # Don't forget that the GSComponent might also be transformed, so

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1893,6 +1893,14 @@ class GSNode(GSBase):
         if name is not None:
             self.name = name
 
+    def clone(self):
+        """Clones the node (does not clone attributes)"""
+        return GSNode(
+            position=(self._position.x, self._position.y),
+            type=self.type,
+            smooth=self.smooth,
+        )
+
     def __repr__(self):
         content = self.type
         if self.smooth:
@@ -2129,6 +2137,13 @@ class GSPath(GSBase):
         self.closed = self._defaultsForName["closed"]
         self._nodes = []
         self.attributes = {}
+
+    def clone(self):
+        """Clones the path (Does not clone attributes)"""
+        cloned = GSPath()
+        cloned.closed = self.closed
+        cloned.nodes = [node.clone() for node in self.nodes]
+        return cloned
 
     @property
     def parent(self):
@@ -2497,6 +2512,9 @@ class GSComponent(GSBase):
                 self.transform = copy.deepcopy(self._defaultsForName["transform"])
         else:
             self.transform = transform
+
+    def clone(self):
+        return GSComponent(self.name, transform=copy.deepcopy(self.transform))
 
     def __repr__(self):
         return '<GSComponent "{}" x={:.1f} y={:.1f}>'.format(


### PR DESCRIPTION
Using `pickle` was indeed faster than using `deepcopy`, but it's still slower than shallow-cloning each node. This should speed up the regression tests significantly (and anything that uses smart components).

Also a slightly more helpful error message when a smart component is not interpolatable.