### PR TITLE
Implement corner components

### DIFF
--- a/Lib/glyphsLib/builder/font.py
+++ b/Lib/glyphsLib/builder/font.py
@@ -42,7 +42,11 @@ def to_ufo_font_attributes(self, family_name):
 
         if has_any_corner_components(font, master):
             ufo.lib.setdefault(UFO2FT_FILTERS_KEY, []).append(
-                {"namespace": "glyphsLib.filters", "name": "cornerComponents", "pre": True}
+                {
+                    "namespace": "glyphsLib.filters",
+                    "name": "cornerComponents",
+                    "pre": True,
+                }
             )
 
         ufo.lib.setdefault(UFO2FT_FILTERS_KEY, []).append(
@@ -180,7 +184,11 @@ def _original_master_order(source):
 def has_any_corner_components(font, master):
     for glyph in font.glyphs:
         for layer in glyph.layers:
-            if layer.layerId != master.id or layer.associatedMasterId != master.id or not layer.hints:
+            if (
+                layer.layerId != master.id
+                or layer.associatedMasterId != master.id
+                or not layer.hints
+            ):
                 continue
             if any(h.type.upper() == "CORNER" for h in layer.hints):
                 return True

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -141,7 +141,6 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
         self.to_ufo_guidelines(ufo_glyph, layer)  # .guidelines
         self.to_ufo_glyph_background(ufo_glyph, layer)  # below
         self.to_ufo_annotations(ufo_glyph, layer)  # .annotations
-        self.to_ufo_hints(ufo_glyph, layer)  # .hints
         self.to_ufo_glyph_user_data(ufo_font, glyph)  # .user_data
         self.to_ufo_layer_user_data(ufo_glyph, layer)  # .user_data
         self.to_ufo_smart_component_axes(ufo_glyph, glyph)  # .components
@@ -160,6 +159,7 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
     ):
         ufo_glyph.lib[GLYPHLIB_PREFIX + "lastChange"] = to_ufo_time(glyph.lastChange)
 
+    self.to_ufo_hints(ufo_glyph, layer)  # .hints
     self.to_ufo_paths(ufo_glyph, layer)  # .paths
     self.to_ufo_components(ufo_glyph, layer)  # .components
     self.to_ufo_glyph_anchors(ufo_glyph, layer.anchors)  # .anchors

--- a/Lib/glyphsLib/builder/hints.py
+++ b/Lib/glyphsLib/builder/hints.py
@@ -24,7 +24,7 @@ def to_ufo_hints(self, ufo_glyph, layer):
     hints = []
     for source in layer.hints:
         hint = {}
-        for name in ["horizontal", "options", "stem", "type"]:
+        for name in ["horizontal", "options", "stem", "type", "name"]:
             hint[name] = getattr(source, name, None)
         for name in ["origin", "other1", "other2", "target"]:
             index_path = getattr(source, name, None)
@@ -47,7 +47,7 @@ def to_glyphs_hints(self, ufo_glyph, layer):
         return
     for source in ufo_glyph.lib[HINTS_LIB_KEY]:
         hint = self.glyphs_module.GSHint()
-        for name in ["horizontal", "options", "stem", "type"]:
+        for name in ["horizontal", "options", "stem", "type", "name"]:
             setattr(hint, name, source[name])
         for name in ["origin", "other1", "other2", "target"]:
             if name in source:

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -215,10 +215,16 @@ class CornerComponentsFilter(BaseFilter):
                 )
                 continue
 
+            corner_path = copy.deepcopy(layer[0])
+            if "scale" in glyphs_cc:
+                scaling = Affine.scale(*glyphs_cc["scale"])
+                for pt in corner_path:
+                    pt.x, pt.y = scaling * (pt.x, pt.y)
+
             cc = CornerComponentApplier(
                 name=glyph.name,
                 alignment=Alignment(glyphs_cc.get("options", 0)),
-                corner_path=copy.deepcopy(layer[0]),
+                corner_path=corner_path,
                 target_node_ix=(node_idx + 1) % len(glyph[path_idx]),
                 path=glyph[path_idx],
             )

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -297,7 +297,8 @@ class CornerComponentApplier:
                 self.corner_path[0].y - self.effective_start[1],
             )
             self.fail(
-                "left and right anchors to corner components are not currently supported",
+                "left and right anchors to corner components are"
+                " not currently supported",
                 hard=False,
             )
 
@@ -309,7 +310,8 @@ class CornerComponentApplier:
                 self.corner_path[-1].y - self.effective_end[1],
             )
             self.fail(
-                "left and right anchors to corner components are not currently supported",
+                "left and right anchors to corner components are"
+                " not currently supported",
                 hard=False,
             )
 

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -246,6 +246,11 @@ class CornerComponentApplier:
         # quite work yet
         self.determine_start_and_end_vectors()
 
+        # Align all paths to the "origin" anchor.
+        for path in [self.corner_path] + self.other_paths:
+            for pt in path:
+                pt.x, pt.y = pt.x - self.origin[0], pt.y - self.origin[1]
+
         # Apply scaling. We are considered "flipped" if one or other
         # of the scale factors is negative, but not both. Being flipped
         # means that the corner path gets applied backwards.
@@ -330,10 +335,6 @@ class CornerComponentApplier:
                 pt.x, pt.y = scaling * (pt.x, pt.y)
 
     def align_my_path_to_main_path(self):
-        # First align myself to the "origin" anchor.
-        for pt in self.corner_path:
-            pt.x, pt.y = pt.x - self.origin[0], pt.y - self.origin[1]
-
         # Work out my rotation (1): Rotation occurring due to corner paths
         angle = math.atan2(-self.corner_path[-1].y, self.corner_path[-1].x)
 

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -22,6 +22,14 @@ from glyphsLib.builder.constants import HINTS_LIB_KEY
 from glyphsLib.affine import Affine
 
 
+try:
+    from math import dist
+except ImportError:
+
+    def dist(p1, p2):
+        return math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -98,7 +106,7 @@ def closest_point_on_cubic(bez, pt, start=0.0, end=1.0, iterations=5, slices=5):
     best_pt = pt
     while t < end:
         this_pt = cubicPointAtT(*bez, t)
-        current_distance = math.dist(this_pt, pt)
+        current_distance = dist(this_pt, pt)
         if current_distance <= best_dist:
             best_dist = current_distance
             best = t
@@ -166,7 +174,7 @@ def split_cubic_at_point(seg, point, inward=True):
     else:
         new_cubic_1 = splitCubic(*seg, point[0], False)[-1]
         new_cubic_2 = splitCubic(*seg, point[1], True)[-1]
-    if math.dist(new_cubic_1[-1], point) < math.dist(new_cubic_2[-1], point):
+    if dist(new_cubic_1[-1], point) < dist(new_cubic_2[-1], point):
         return new_cubic_1
     else:
         return new_cubic_2

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -1,0 +1,103 @@
+import copy
+from dataclasses import dataclass
+from enum import IntEnum
+import logging
+import math
+
+from ufo2ft.filters import BaseFilter
+
+from glyphsLib.builder.constants import HINTS_LIB_KEY
+from glyphsLib.affine import Affine
+
+
+logger = logging.getLogger(__name__)
+
+
+class Alignment(IntEnum):
+    LEFT = 0
+    MIDDLE = 1
+    RIGHT = 2
+    UNUSED = 3
+    UNALIGNED = 4
+
+
+# Using a class here is mild overkill but it allows us to store
+# the information about the component in a slightly more readable
+# manner.
+@dataclass
+class CornerComponent:
+    alignment: Alignment
+    corner_path: object
+    target_node_ix: int
+    origin: (int, int) = (0, 0)
+    left_x: int = 0
+    right_x: int = 0
+
+    def insert_into_path(self, path):
+        self.align_my_path_to_main_path(path)
+        raise NotImplementedError
+
+    def align_my_path_to_main_path(self, path):
+        target_node = path[self.target_node_ix]
+        target_node_next = path[(self.target_node_ix + 1) % len(path)]
+        if self.alignment == Alignment.LEFT:
+            stroke_angle = math.atan2(
+                target_node_next.y - target_node.y, target_node_next.x - target_node.x
+            )
+            rot = Affine.rotation(math.degrees(stroke_angle), self.origin)
+            # Rotate the whole path around the origin
+            for pt in self.corner_path:
+                pt.x, pt.y = rot * (pt.x, pt.y)
+
+        elif self.alignment == Alignment.MIDDLE:
+            raise NotImplementedError
+        elif self.alignment == Alignment.RIGHT:
+            raise NotImplementedError
+        elif self.alignment == Alignment.UNUSED:
+            raise NotImplementedError
+        elif self.alignment == Alignment.UNALIGNED:
+            pass  # right?
+
+        # Now position our path onto the point?
+        for pt in self.corner_path:
+            pt.x, pt.y = pt.x + target_node.x, pt.y + target_node.y
+
+        raise NotImplementedError
+
+
+class CornerComponentsFilter(BaseFilter):
+    def filter(self, glyph):
+        if not len(glyph):
+            return False
+
+        if not HINTS_LIB_KEY in glyph.lib:
+            return False
+
+        corner_components = [
+            hint
+            for hint in glyph.lib[HINTS_LIB_KEY]
+            if hint.get("type").upper() == "CORNER"
+        ]
+
+        if not corner_components:
+            return False
+
+        for glyphs_cc in corner_components:
+            path_idx, node_idx = glyphs_cc["origin"]
+            layer = self.context.glyphSet[glyphs_cc["name"]]
+            if len(layer) > 1:
+                logger.warn(
+                    "Corner components of more than one path (%s in %s) not supported",
+                    glyphs_cc["name"],
+                    glyph.name,
+                )
+                continue
+
+            cc = CornerComponent(
+                alignment=Alignment(glyphs_cc.get("options", 0)),
+                corner_path=copy.deepcopy(layer[0]),
+                target_node_ix=(node_idx + 1) % len(glyph[path_idx]),
+            )
+            cc.insert_into_path(glyph[path_idx])
+
+        return True

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -230,7 +230,8 @@ class CornerComponentApplier:
 
         if self.corner_path[0].x != self.origin[0]:
             self.fail(
-                "Can't deal with offset instrokes yet; start corner components on axis"
+                "Can't deal with offset instrokes yet; start corner components on axis",
+                hard=False,
             )
 
         # This is for handling the left and right anchors and doesn't
@@ -295,6 +296,10 @@ class CornerComponentApplier:
                 self.corner_path[0].x - self.effective_start[0],
                 self.corner_path[0].y - self.effective_start[1],
             )
+            self.fail(
+                "left and right anchors to corner components are not currently supported",
+                hard=False,
+            )
 
         if not self.effective_end:
             self.effective_end = (0, 0)
@@ -302,6 +307,10 @@ class CornerComponentApplier:
             self.effective_end = (
                 self.corner_path[-1].x - self.effective_end[0],
                 self.corner_path[-1].y - self.effective_end[1],
+            )
+            self.fail(
+                "left and right anchors to corner components are not currently supported",
+                hard=False,
             )
 
     def scale_paths(self):

--- a/tests/corner_components_test.py
+++ b/tests/corner_components_test.py
@@ -7,13 +7,14 @@ import pytest
 datadir = py.path.local(py.path.local(__file__).dirname).join("data")
 
 ufo = glyphsLib.load_to_ufos(datadir.join("CornerComponents.glyphs"))[0]
-CornerComponentsFilter()(ufo)
 
 test_glyphs = [glyph[:-12] for glyph in ufo.keys() if glyph.endswith(".expectation")]
 
 
-@pytest.mark.parametrize("glyph", test_glyphs)
+@pytest.mark.parametrize("glyph", sorted(test_glyphs))
 def test_corner_components(glyph):
+    philter = CornerComponentsFilter(include={glyph})
+    assert philter(ufo)
     test_glyph = ufo[glyph]
     expectation = ufo[glyph + ".expectation"]
     for test_contour, expectation_contour in zip(

--- a/tests/corner_components_test.py
+++ b/tests/corner_components_test.py
@@ -13,6 +13,8 @@ test_glyphs = [glyph[:-12] for glyph in ufo.keys() if glyph.endswith(".expectati
 
 @pytest.mark.parametrize("glyph", sorted(test_glyphs))
 def test_corner_components(glyph):
+    if "left_anchor" in glyph:
+        pytest.xfail("left anchors not quite working yet")
     philter = CornerComponentsFilter(include={glyph})
     assert philter(ufo)
     test_glyph = ufo[glyph]

--- a/tests/corner_components_test.py
+++ b/tests/corner_components_test.py
@@ -17,7 +17,8 @@ def test_corner_components(glyph):
     assert philter(ufo)
     test_glyph = ufo[glyph]
     expectation = ufo[glyph + ".expectation"]
+    assert len(test_glyph) == len(expectation)
     for test_contour, expectation_contour in zip(
-        test_glyph.contours, expectation.contours
+        expectation.contours, test_glyph.contours
     ):
         assert test_contour == expectation_contour, glyph

--- a/tests/corner_components_test.py
+++ b/tests/corner_components_test.py
@@ -1,19 +1,22 @@
 import glyphsLib
 from glyphsLib.filters.cornerComponents import CornerComponentsFilter
+import py
+import pytest
 
 
-def test_corner_components(datadir):
-    ufo = glyphsLib.load_to_ufos(datadir.join("CornerComponents.glyphs"))[0]
-    philter = CornerComponentsFilter()
+datadir = py.path.local(py.path.local(__file__).dirname).join("data")
 
-    assert philter(ufo)
+ufo = glyphsLib.load_to_ufos(datadir.join("CornerComponents.glyphs"))[0]
+CornerComponentsFilter()(ufo)
 
-    for glyph in ufo.keys():
-        if not glyph.endswith(".expectation"):
-            continue
-        expectation = ufo[glyph]
-        test_glyph = ufo[glyph[:-12]]
-        for test_contour, expectation_contour in zip(
-            test_glyph.contours, expectation.contours
-        ):
-            assert test_contour == expectation_contour, glyph
+test_glyphs = [glyph[:-12] for glyph in ufo.keys() if glyph.endswith(".expectation")]
+
+
+@pytest.mark.parametrize("glyph", test_glyphs)
+def test_corner_components(glyph):
+    test_glyph = ufo[glyph]
+    expectation = ufo[glyph + ".expectation"]
+    for test_contour, expectation_contour in zip(
+        test_glyph.contours, expectation.contours
+    ):
+        assert test_contour == expectation_contour, glyph

--- a/tests/corner_components_test.py
+++ b/tests/corner_components_test.py
@@ -1,0 +1,17 @@
+import glyphsLib
+from glyphsLib.filters.cornerComponents import CornerComponentsFilter
+
+
+def test_corner_components(datadir):
+    ufo = glyphsLib.load_to_ufos(datadir.join("CornerComponents.glyphs"))[0]
+    philter = CornerComponentsFilter()
+
+    assert philter(ufo)
+
+    for glyph in ufo.keys():
+        if not glyph.endswith(".expectation"):
+            continue
+        expectation = ufo[glyph]
+        test_glyph = ufo[ glyph[:-12] ]
+        for test_contour, expectation_contour in zip(test_glyph.contours, expectation.contours):
+            assert test_contour == expectation_contour, glyph

--- a/tests/corner_components_test.py
+++ b/tests/corner_components_test.py
@@ -12,6 +12,8 @@ def test_corner_components(datadir):
         if not glyph.endswith(".expectation"):
             continue
         expectation = ufo[glyph]
-        test_glyph = ufo[ glyph[:-12] ]
-        for test_contour, expectation_contour in zip(test_glyph.contours, expectation.contours):
+        test_glyph = ufo[glyph[:-12]]
+        for test_contour, expectation_contour in zip(
+            test_glyph.contours, expectation.contours
+        ):
             assert test_contour == expectation_contour, glyph

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,14 +2,7 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"",
-"",
-"",
-"",
-"",
-"",
-"",
-"/_corner.six/au_left_anchoronpath/au_left_anchoronpath.expectation/av_left_anchoroffpath.expectation"
+"/_corner.seven/al_unaligned/ai_curved_outstroke/ai_curved_outstroke.expectation"
 );
 customParameters = (
 {
@@ -109,7 +102,7 @@ glyphs = (
 {
 export = 0;
 glyphname = _corner.one;
-lastChange = "2022-11-17 14:20:25 +0000";
+lastChange = "2022-11-22 09:48:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -482,12 +475,12 @@ subCategory = Other;
 {
 category = Letter;
 glyphname = ad_curved_instroke;
-lastChange = "2022-11-17 09:18:59 +0000";
+lastChange = "2022-11-21 20:48:47 +0000";
 layers = (
 {
 anchors = (
 {
-name = "new anchor";
+name = intersection;
 pos = (134,188);
 }
 );
@@ -548,7 +541,7 @@ subCategory = Other;
 {
 category = Letter;
 glyphname = ae_curved_corner_firstseg;
-lastChange = "2022-11-17 09:18:35 +0000";
+lastChange = "2022-11-21 21:52:20 +0000";
 layers = (
 {
 hints = (
@@ -605,9 +598,15 @@ subCategory = Other;
 {
 category = Letter;
 glyphname = af_curved_corner_firstseg_slanted;
-lastChange = "2022-11-17 09:24:04 +0000";
+lastChange = "2022-11-21 22:02:07 +0000";
 layers = (
 {
+anchors = (
+{
+name = intersection;
+pos = (113,50);
+}
+);
 hints = (
 {
 name = _corner.two;
@@ -630,13 +629,13 @@ nodes = (
 width = 600;
 }
 );
-production = ae_curved_corner_firstseg_slanted;
+production = af_curved_corner_firstseg_slanted;
 subCategory = Other;
 },
 {
 category = Letter;
 glyphname = af_curved_corner_firstseg_slanted.expectation;
-lastChange = "2022-11-17 09:25:23 +0000";
+lastChange = "2022-11-21 21:16:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -658,7 +657,7 @@ nodes = (
 width = 600;
 }
 );
-production = ae_curved_corner_firstseg_slanted.001;
+production = af_curved_corner_firstseg_slanted.expectation;
 subCategory = Other;
 },
 {
@@ -839,9 +838,15 @@ width = 600;
 },
 {
 glyphname = ai_curved_outstroke;
-lastChange = "2022-11-21 10:03:09 +0000";
+lastChange = "2022-11-22 12:46:24 +0000";
 layers = (
 {
+anchors = (
+{
+name = foo;
+pos = (531,270);
+}
+);
 hints = (
 {
 name = _corner.one;
@@ -854,11 +859,11 @@ shapes = (
 {
 closed = 1;
 nodes = (
-(100,100,l),
-(148,100,o),
-(500,302,o),
-(500,400,c),
-(100,400,l)
+(550,252,l),
+(526,294,o),
+(175,497,o),
+(90,448,c),
+(290,102,l)
 );
 }
 );
@@ -868,22 +873,39 @@ width = 600;
 },
 {
 glyphname = ai_curved_outstroke.expectation;
-lastChange = "2022-11-17 09:51:17 +0000";
+lastChange = "2022-11-22 13:21:43 +0000";
 layers = (
 {
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,226,l),
+(550,181,l),
+(585,217,l),
+(532,270,l),
+(455,333,o),
+(166,492,o),
+(90,448,c),
+(290,102,l)
+);
+}
+);
+};
 layerId = m01;
 shapes = (
 {
 closed = 1;
 nodes = (
-(100,153,l),
-(68,163,l),
-(52,115,l),
-(124,92,l),
-(240,71,o),
-(500,214,o),
-(500,400,c),
-(100,400,l)
+(505,226,l),
+(550,181,l),
+(585,217,l),
+(532,270,l),
+(455,334,o),
+(166,492,o),
+(90,448,c),
+(290,102,l)
 );
 }
 );
@@ -893,7 +915,7 @@ width = 600;
 },
 {
 glyphname = aj_right_alignment;
-lastChange = "2022-11-17 11:02:52 +0000";
+lastChange = "2022-11-22 10:27:50 +0000";
 layers = (
 {
 hints = (
@@ -946,9 +968,15 @@ width = 600;
 },
 {
 glyphname = ak_right_slanted;
-lastChange = "2022-11-17 12:42:13 +0000";
+lastChange = "2022-11-22 12:28:56 +0000";
 layers = (
 {
+anchors = (
+{
+name = "out anchor";
+pos = (212,40);
+}
+);
 hints = (
 {
 name = _corner.one;
@@ -1111,7 +1139,7 @@ width = 600;
 },
 {
 glyphname = an_flippy;
-lastChange = "2022-11-17 14:39:00 +0000";
+lastChange = "2022-11-22 10:11:53 +0000";
 layers = (
 {
 hints = (
@@ -1218,17 +1246,18 @@ width = 600;
 },
 {
 glyphname = ap_twoofthem;
-lastChange = "2022-11-17 22:32:10 +0000";
+lastChange = "2022-11-22 12:13:37 +0000";
 layers = (
 {
 hints = (
 {
-name = _corner.slab;
+name = _corner.two;
 origin = (0,0);
 type = Corner;
 },
 {
-name = _corner.slab;
+name = _corner.two;
+options = 1;
 origin = (0,1);
 scale = (-1,1);
 type = Corner;
@@ -1240,9 +1269,9 @@ shapes = (
 closed = 1;
 nodes = (
 (148,0,l),
-(283,0,l),
-(283,504,l),
-(148,504,l)
+(283,50,l),
+(283,500,l),
+(148,450,l)
 );
 }
 );
@@ -1252,24 +1281,47 @@ width = 933;
 },
 {
 glyphname = ap_twoofthem.expectation;
-lastChange = "2022-11-17 22:31:39 +0000";
+lastChange = "2022-11-22 12:56:14 +0000";
 layers = (
 {
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,53,l),
+(116,42,o),
+(49,17,o),
+(66,-30,c),
+(168,7,l),
+(263,43,l),
+(364,80,l),
+(347,127,o),
+(315,115,o),
+(283,103,c),
+(283,500,l),
+(148,450,l)
+);
+}
+);
+};
 layerId = m01;
 shapes = (
 {
 closed = 1;
 nodes = (
-(148,27,l),
-(52,27,l),
-(52,0,l),
-(157,0,l),
-(274,0,l),
-(379,0,l),
-(379,27,l),
-(283,27,l),
-(283,504,l),
-(148,504,l)
+(148,53,l),
+(116,42,o),
+(49,17,o),
+(66,-30,c),
+(168,7,l),
+(263,43,l),
+(364,80,l),
+(347,127,o),
+(297,109,o),
+(283,103,c),
+(283,500,l),
+(148,450,l)
 );
 }
 );
@@ -1279,7 +1331,7 @@ width = 933;
 },
 {
 glyphname = aq_rightleg;
-lastChange = "2022-11-18 12:02:28 +0000";
+lastChange = "2022-11-22 10:40:46 +0000";
 layers = (
 {
 hints = (
@@ -1587,9 +1639,15 @@ unicode = 32;
 },
 {
 glyphname = au_left_anchoronpath;
-lastChange = "2022-11-21 11:56:50 +0000";
+lastChange = "2022-11-22 12:59:37 +0000";
 layers = (
 {
+anchors = (
+{
+name = "new anchor";
+pos = (170,150);
+}
+);
 hints = (
 {
 name = _corner.six;
@@ -1602,10 +1660,10 @@ shapes = (
 {
 closed = 1;
 nodes = (
-(99,0,l),
-(399,0,l),
-(470,500,l),
-(170,500,l)
+(244,-40,l),
+(503,110,l),
+(315,579,l),
+(55,429,l)
 );
 }
 );
@@ -1643,7 +1701,7 @@ width = 600;
 },
 {
 glyphname = au_left_anchoronpath.expectation;
-lastChange = "2022-11-21 12:05:40 +0000";
+lastChange = "2022-11-22 12:59:46 +0000";
 layers = (
 {
 layerId = m01;
@@ -1651,13 +1709,13 @@ shapes = (
 {
 closed = 1;
 nodes = (
-(170,150,l),
-(20,150,l),
-(20,0,l),
-(195,0,l),
-(399,0,l),
-(470,500,l),
-(170,500,l)
+(231,126,l),
+(101,50,l),
+(176,-79,l),
+(327,8,l),
+(503,110,l),
+(315,579,l),
+(55,429,l)
 );
 }
 );
@@ -1667,7 +1725,7 @@ width = 600;
 },
 {
 glyphname = av_left_anchoroffpath.expectation;
-lastChange = "2022-11-21 11:15:12 +0000";
+lastChange = "2022-11-21 22:03:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -1675,13 +1733,13 @@ shapes = (
 {
 closed = 1;
 nodes = (
-(179,150,l),
-(0,150,l),
-(0,0,l),
-(175,0,l),
+(130,150,l),
+(-30,150,l),
+(-30,0,l),
+(145,0,l),
 (400,0,l),
-(400,500,l),
-(100,500,l)
+(500,500,l),
+(200,500,l)
 );
 }
 );
@@ -1692,7 +1750,7 @@ width = 600;
 {
 export = 0;
 glyphname = _corner.seven;
-lastChange = "2022-11-21 11:37:05 +0000";
+lastChange = "2022-11-22 12:06:08 +0000";
 layers = (
 {
 anchors = (
@@ -1720,7 +1778,7 @@ width = 200;
 {
 export = 0;
 glyphname = _corner.six;
-lastChange = "2022-11-21 12:03:52 +0000";
+lastChange = "2022-11-22 11:53:42 +0000";
 layers = (
 {
 anchors = (
@@ -1742,6 +1800,60 @@ nodes = (
 }
 );
 width = 200;
+}
+);
+},
+{
+glyphname = ax_curved_instroke2;
+lastChange = "2022-11-21 22:09:49 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,2);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,469,o),
+(106,256,o),
+(106,128,c),
+(382,0,l),
+(501,469,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ax_curved_instroke2.expectation;
+lastChange = "2022-11-21 22:11:23 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,469,o),
+(169,305,o),
+(117,178,c),
+(82,194,l),
+(61,149,l),
+(129,117,l),
+(382,0,l),
+(501,469,l)
+);
+}
+);
+width = 600;
 }
 );
 }

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,12 +2,14 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"/_corner.two/_corner.four/_corner.slab/an_flippy/_corner.pretty/as_closedpaths/as_closedpaths.expectation/an_flippy.expectation",
-"/an_flippy",
-"/ao_firstnode/ao_firstnode.expectation",
-"/ak_right_slanted/am_middle",
-"/ar_leftleg",
-"/at_unaligned_lastseg.expectation/ai_curved_outstroke/at_unaligned_lastseg"
+"",
+"",
+"",
+"",
+"",
+"",
+"",
+"/_corner.six/au_left_anchoronpath/au_left_anchoronpath.expectation/av_left_anchoroffpath.expectation"
 );
 customParameters = (
 {
@@ -1582,6 +1584,166 @@ width = 200;
 }
 );
 unicode = 32;
+},
+{
+glyphname = au_left_anchoronpath;
+lastChange = "2022-11-21 11:56:50 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.six;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(399,0,l),
+(470,500,l),
+(170,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = av_left_anchoroffpath;
+lastChange = "2022-11-21 11:36:53 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.seven;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(400,0,l),
+(500,500,l),
+(200,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = au_left_anchoronpath.expectation;
+lastChange = "2022-11-21 12:05:40 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,150,l),
+(20,150,l),
+(20,0,l),
+(195,0,l),
+(399,0,l),
+(470,500,l),
+(170,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = av_left_anchoroffpath.expectation;
+lastChange = "2022-11-21 11:15:12 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,150,l),
+(0,150,l),
+(0,0,l),
+(175,0,l),
+(400,0,l),
+(400,500,l),
+(100,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+export = 0;
+glyphname = _corner.seven;
+lastChange = "2022-11-21 11:37:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = left;
+pos = (0,100);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,150,l),
+(-150,150,l),
+(-150,0,l),
+(25,0,l)
+);
+}
+);
+width = 200;
+}
+);
+},
+{
+export = 0;
+glyphname = _corner.six;
+lastChange = "2022-11-21 12:03:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = left;
+pos = (-50,150);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,150,l),
+(-150,150,l),
+(-150,0,l),
+(25,0,l)
+);
+}
+);
+width = 200;
+}
+);
 }
 );
 metrics = (
@@ -1604,6 +1766,9 @@ type = descender;
 type = "italic angle";
 }
 );
+settings = {
+disablesNiceNames = 1;
+};
 unitsPerEm = 1000;
 versionMajor = 1;
 versionMinor = 0;

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -4,7 +4,8 @@
 DisplayStrings = (
 "/_corner.two/_corner.four/_corner.slab/an_flippy/an_flippy.expectation",
 "/an_flippy",
-"/ao_firstnode/ao_firstnode.expectation"
+"/ao_firstnode/ao_firstnode.expectation",
+"/ap_twoofthem"
 );
 customParameters = (
 {
@@ -1116,6 +1117,67 @@ nodes = (
 }
 );
 width = 600;
+}
+);
+},
+{
+glyphname = ap_twoofthem;
+lastChange = "2022-11-17 22:32:10 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.slab;
+origin = (0,0);
+type = Corner;
+},
+{
+name = _corner.slab;
+origin = (0,1);
+scale = (-1,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(283,0,l),
+(283,504,l),
+(148,504,l)
+);
+}
+);
+width = 933;
+}
+);
+},
+{
+glyphname = ap_twoofthem.expectation;
+lastChange = "2022-11-17 22:31:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,27,l),
+(52,27,l),
+(52,0,l),
+(157,0,l),
+(274,0,l),
+(379,0,l),
+(379,27,l),
+(283,27,l),
+(283,504,l),
+(148,504,l)
+);
+}
+);
+width = 933;
 }
 );
 }

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,15 +2,19 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"/aj_right_alignment/aj_right_alignment.expectation"
+"/_corner.two/_corner.four/_corner.slab/an_flippy/an_flippy.expectation",
+"/an_flippy",
+"/ao_firstnode/ao_firstnode.expectation"
 );
 customParameters = (
 {
 name = glyphOrder;
 value = (
 _corner.one,
-_corner.three,
 _corner.two,
+_corner.three,
+_corner.four,
+_corner.slab,
 aa_simple_angleinstroke,
 aa_simple_angleinstroke.expectation,
 ab_simple_angled,
@@ -24,6 +28,23 @@ ae_curved_corner_firstseg.expectation,
 af_curved_corner_firstseg_slanted,
 af_curved_corner_firstseg_slanted.expectation,
 ag_curved_corner_bothsegs,
+ag_curved_corner_bothsegs.expectation,
+ag_curved_corner_bothsegs_rotated,
+ag_curved_corner_bothsegs_rotated.expectation,
+ah_origin,
+ah_origin.expectation,
+ai_curved_outstroke,
+ai_curved_outstroke.expectation,
+aj_right_alignment,
+aj_right_alignment.expectation,
+ak_right_slanted,
+ak_right_slanted.expectation,
+al_unaligned,
+al_unaligned.expectation,
+am_middle,
+am_middle.expectation,
+an_flippy,
+an_flippy.expectation,
 space
 );
 }
@@ -62,8 +83,9 @@ name = Regular;
 );
 glyphs = (
 {
+export = 0;
 glyphname = _corner.one;
-lastChange = "2022-11-17 10:04:33 +0000";
+lastChange = "2022-11-17 14:20:25 +0000";
 layers = (
 {
 layerId = m01;
@@ -83,8 +105,32 @@ width = 250;
 );
 },
 {
+export = 0;
+glyphname = _corner.two;
+lastChange = "2022-11-17 14:20:23 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,50,l),
+(-34,50,o),
+(-87,50,o),
+(-87,0,c),
+(21,0,l)
+);
+}
+);
+width = 20;
+}
+);
+},
+{
+export = 0;
 glyphname = _corner.three;
-lastChange = "2022-11-17 09:17:59 +0000";
+lastChange = "2022-11-17 14:20:24 +0000";
 layers = (
 {
 layerId = m01;
@@ -108,8 +154,37 @@ width = 20;
 );
 },
 {
-glyphname = _corner.two;
-lastChange = "2022-11-17 09:15:01 +0000";
+export = 0;
+glyphname = _corner.four;
+lastChange = "2022-11-17 09:45:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = origin;
+pos = (0,500);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,550,l),
+(-30,502,l),
+(3,474,l),
+(50,500,l)
+);
+}
+);
+width = 200;
+}
+);
+},
+{
+export = 0;
+glyphname = _corner.slab;
+lastChange = "2022-11-17 14:09:13 +0000";
 layers = (
 {
 layerId = m01;
@@ -117,15 +192,14 @@ shapes = (
 {
 closed = 0;
 nodes = (
-(0,50,l),
-(-34,50,o),
-(-87,50,o),
-(-87,0,c),
-(21,0,l)
+(0,27,l),
+(-96,27,l),
+(-96,0,l),
+(9,0,l)
 );
 }
 );
-width = 20;
+width = 200;
 }
 );
 },
@@ -512,14 +586,35 @@ production = ae_curved_corner_bothsegs;
 subCategory = Other;
 },
 {
-glyphname = space;
+category = Letter;
+glyphname = ag_curved_corner_bothsegs.expectation;
+lastChange = "2022-11-17 09:41:12 +0000";
 layers = (
 {
 layerId = m01;
-width = 200;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,50,l),
+(75,50,o),
+(26,53,o),
+(10,32,c),
+(0,10,l),
+(36,32,o),
+(84,14,o),
+(120,0,c),
+(400,0,l),
+(400,500,l),
+(100,500,l)
+);
 }
 );
-unicode = 32;
+width = 600;
+}
+);
+production = ae_curved_corner_bothsegs.001;
+subCategory = Other;
 },
 {
 category = Letter;
@@ -554,37 +649,6 @@ subCategory = Other;
 },
 {
 category = Letter;
-glyphname = ag_curved_corner_bothsegs.expectation;
-lastChange = "2022-11-17 09:41:12 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(100,50,l),
-(75,50,o),
-(26,53,o),
-(10,32,c),
-(0,10,l),
-(36,32,o),
-(84,14,o),
-(120,0,c),
-(400,0,l),
-(400,500,l),
-(100,500,l)
-);
-}
-);
-width = 600;
-}
-);
-production = ae_curved_corner_bothsegs.001;
-subCategory = Other;
-},
-{
-category = Letter;
 glyphname = ag_curved_corner_bothsegs_rotated.expectation;
 lastChange = "2022-11-17 09:42:40 +0000";
 layers = (
@@ -615,34 +679,6 @@ production = ae_curved_corner_bothsegs.rotated.001;
 subCategory = Other;
 },
 {
-export = 0;
-glyphname = _corner.four;
-lastChange = "2022-11-17 09:45:44 +0000";
-layers = (
-{
-anchors = (
-{
-name = origin;
-pos = (0,500);
-}
-);
-layerId = m01;
-shapes = (
-{
-closed = 0;
-nodes = (
-(0,550,l),
-(-30,502,l),
-(3,474,l),
-(50,500,l)
-);
-}
-);
-width = 200;
-}
-);
-},
-{
 glyphname = ah_origin;
 lastChange = "2022-11-17 09:45:35 +0000";
 layers = (
@@ -660,6 +696,30 @@ shapes = (
 closed = 1;
 nodes = (
 (50,0,l),
+(210,0,l),
+(210,500,l),
+(50,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ah_origin.expectation;
+lastChange = "2022-11-17 09:46:23 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,50,l),
+(20,2,l),
+(53,-26,l),
+(100,0,l),
 (210,0,l),
 (210,500,l),
 (50,500,l)
@@ -700,60 +760,6 @@ width = 600;
 );
 },
 {
-glyphname = aj_right_alignment;
-lastChange = "2022-11-17 10:21:01 +0000";
-layers = (
-{
-hints = (
-{
-name = _corner.one;
-options = 1;
-origin = (0,1);
-scale = (0.72622,1);
-type = Corner;
-}
-);
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(84,0,l),
-(234,0,l),
-(433,500,l),
-(283,500,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
-glyphname = ah_origin.expectation;
-lastChange = "2022-11-17 09:46:23 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(50,50,l),
-(20,2,l),
-(53,-26,l),
-(100,0,l),
-(210,0,l),
-(210,500,l),
-(50,500,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
 glyphname = ai_curved_outstroke.expectation;
 lastChange = "2022-11-17 09:51:17 +0000";
 layers = (
@@ -779,8 +785,37 @@ width = 600;
 );
 },
 {
+glyphname = aj_right_alignment;
+lastChange = "2022-11-17 11:02:52 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+options = 1;
+origin = (0,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(234,0,l),
+(234,500,l),
+(84,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
 glyphname = aj_right_alignment.expectation;
-lastChange = "2022-11-17 10:21:38 +0000";
+lastChange = "2022-11-17 11:18:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -790,11 +825,293 @@ closed = 1;
 nodes = (
 (84,0,l),
 (184,0,l),
-(184,-36,l),
-(234,-36,l),
-(241,17,l),
-(433,500,l),
-(283,500,l)
+(184,-50,l),
+(234,-50,l),
+(234,25,l),
+(234,500,l),
+(84,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ak_right_slanted;
+lastChange = "2022-11-17 12:42:13 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+options = 1;
+origin = (0,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(234,0,l),
+(534,500,l),
+(384,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ak_right_slanted.expectation;
+lastChange = "2022-11-17 12:42:33 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(184,0,l),
+(184,-50,l),
+(234,-50,l),
+(245,18,l),
+(534,500,l),
+(384,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = al_unaligned;
+lastChange = "2022-11-17 12:26:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = foo;
+pos = (254,-17);
+}
+);
+hints = (
+{
+name = _corner.one;
+options = 4;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,-29,l),
+(496,121,l),
+(246,554,l),
+(-14,404,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = al_unaligned.expectation;
+lastChange = "2022-11-17 12:33:21 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,21,l),
+(186,21,l),
+(186,-29,l),
+(255,-18,l),
+(496,121,l),
+(246,554,l),
+(-14,404,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = am_middle;
+lastChange = "2022-11-17 12:53:12 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+options = 2;
+origin = (0,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,l),
+(425,0,l),
+(125,500,l),
+(25,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = am_middle.expectation;
+lastChange = "2022-11-17 13:07:56 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,l),
+(373,0,l),
+(390,-62,l),
+(438,-48,l),
+(413,21,l),
+(125,500,l),
+(25,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = an_flippy;
+lastChange = "2022-11-17 14:39:00 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.two;
+origin = (0,0);
+scale = (-1,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,0,l),
+(141,0,l),
+(141,500,l),
+(41,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = an_flippy.expectation;
+lastChange = "2022-11-17 14:39:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,21,l),
+(41,-87,l),
+(91,-87,o),
+(91,-34,o),
+(91,0,c),
+(141,0,l),
+(141,500,l),
+(41,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+},
+{
+glyphname = ao_firstnode;
+lastChange = "2022-11-17 15:12:47 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.two;
+origin = (0,3);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,0,l),
+(141,0,l),
+(141,500,l),
+(41,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ao_firstnode.expectation;
+lastChange = "2022-11-17 15:15:24 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,534,o),
+(91,587,o),
+(41,587,c),
+(41,479,l),
+(41,0,l),
+(141,0,l),
+(141,500,l),
+(91,500,l)
 );
 }
 );

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,11 +2,31 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"/_corner.one/curved_instroke",
-"",
-"",
-"/curved_instroke.expectation/curved_instroke",
-"/curved_instroke.expectation"
+"/aj_right_alignment/aj_right_alignment.expectation"
+);
+customParameters = (
+{
+name = glyphOrder;
+value = (
+_corner.one,
+_corner.three,
+_corner.two,
+aa_simple_angleinstroke,
+aa_simple_angleinstroke.expectation,
+ab_simple_angled,
+ab_simple_angled.expectation,
+ac_scale,
+ac_scale.expectation,
+ad_curved_instroke,
+ad_curved_instroke.expectation,
+ae_curved_corner_firstseg,
+ae_curved_corner_firstseg.expectation,
+af_curved_corner_firstseg_slanted,
+af_curved_corner_firstseg_slanted.expectation,
+ag_curved_corner_bothsegs,
+space
+);
+}
 );
 date = "2022-11-14 14:19:00 +0000";
 familyName = "Corner Component Alignment Test";
@@ -42,8 +62,131 @@ name = Regular;
 );
 glyphs = (
 {
-glyphname = a;
-lastChange = "2022-11-16 16:11:01 +0000";
+glyphname = _corner.one;
+lastChange = "2022-11-17 10:04:33 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,50,l),
+(-50,50,l),
+(-50,0,l),
+(25,0,l)
+);
+}
+);
+width = 250;
+}
+);
+},
+{
+glyphname = _corner.three;
+lastChange = "2022-11-17 09:17:59 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,50,l),
+(-25,50,o),
+(-74,53,o),
+(-90,32,c),
+(-100,10,l),
+(-64,32,o),
+(-16,14,o),
+(20,0,c)
+);
+}
+);
+width = 20;
+}
+);
+},
+{
+glyphname = _corner.two;
+lastChange = "2022-11-17 09:15:01 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,50,l),
+(-34,50,o),
+(-87,50,o),
+(-87,0,c),
+(21,0,l)
+);
+}
+);
+width = 20;
+}
+);
+},
+{
+category = Letter;
+glyphname = aa_simple_angleinstroke;
+lastChange = "2022-11-17 09:18:35 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,100,l),
+(414,100,l),
+(100,300,l)
+);
+}
+);
+width = 600;
+}
+);
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = aa_simple_angleinstroke.expectation;
+lastChange = "2022-11-17 09:18:35 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,150,l),
+(150,150,l),
+(150,100,l),
+(225,100,l),
+(414,100,l),
+(100,300,l)
+);
+}
+);
+width = 600;
+}
+);
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = ab_simple_angled;
+lastChange = "2022-11-17 09:18:59 +0000";
 layers = (
 {
 hints = (
@@ -67,64 +210,39 @@ nodes = (
 width = 600;
 }
 );
-unicode = 97;
+script = latin;
+subCategory = Other;
 },
 {
-glyphname = space;
-layers = (
-{
-layerId = m01;
-width = 200;
-}
-);
-unicode = 32;
-},
-{
-glyphname = _corner.one;
-lastChange = "2022-11-16 21:34:27 +0000";
+category = Letter;
+glyphname = ab_simple_angled.expectation;
+lastChange = "2022-11-17 09:18:59 +0000";
 layers = (
 {
 layerId = m01;
 shapes = (
 {
-closed = 0;
+closed = 1;
 nodes = (
-(0,50,l),
-(-50,50,l),
-(-50,0,l),
-(25,0,l)
+(100,163,l),
+(30,110,l),
+(60,70,l),
+(120,115,l),
+(500,400,l),
+(100,400,l)
 );
 }
 );
-width = 250;
+width = 600;
 }
 );
+script = latin;
+subCategory = Other;
 },
 {
-glyphname = _corner.two;
-lastChange = "2022-11-14 14:38:32 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 0;
-nodes = (
-(20,50,l),
-(-14,50,o),
-(-87,50,o),
-(-87,0,c),
-(-21,0,l)
-);
-}
-);
-width = 20;
-}
-);
-},
-{
-glyphname = scale;
-lastChange = "2022-11-16 16:10:06 +0000";
+category = Letter;
+glyphname = ac_scale;
+lastChange = "2022-11-17 09:18:59 +0000";
 layers = (
 {
 hints = (
@@ -150,64 +268,13 @@ nodes = (
 width = 600;
 }
 );
+script = latin;
+subCategory = Other;
 },
 {
-glyphname = simple_angled;
-lastChange = "2022-11-16 22:20:27 +0000";
-layers = (
-{
-hints = (
-{
-name = _corner.one;
-origin = (0,0);
-type = Corner;
-}
-);
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(100,100,l),
-(500,400,l),
-(100,400,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
-glyphname = simple_angleinstroke;
-lastChange = "2022-11-16 16:11:33 +0000";
-layers = (
-{
-hints = (
-{
-name = _corner.one;
-origin = (0,0);
-type = Corner;
-}
-);
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(200,100,l),
-(414,100,l),
-(100,300,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
-glyphname = scale.expectation;
-lastChange = "2022-11-16 16:13:48 +0000";
+category = Letter;
+glyphname = ac_scale.expectation;
+lastChange = "2022-11-17 09:18:59 +0000";
 layers = (
 {
 layerId = m01;
@@ -228,57 +295,13 @@ nodes = (
 width = 600;
 }
 );
+script = latin;
+subCategory = Other;
 },
 {
-glyphname = simple_angled.expectation;
-lastChange = "2022-11-16 22:25:03 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(100,163,l),
-(30,110,l),
-(60,70,l),
-(120,115,l),
-(500,400,l),
-(100,400,l)
-);
-}
-);
-width = 600;
-}
-);
-production = simple_angled.expectation;
-},
-{
-glyphname = simple_angleinstroke.expectation;
-lastChange = "2022-11-16 16:11:42 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(175,150,l),
-(150,150,l),
-(150,100,l),
-(225,100,l),
-(414,100,l),
-(100,300,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
-glyphname = curved_instroke;
-lastChange = "2022-11-16 22:24:17 +0000";
+category = Letter;
+glyphname = ad_curved_instroke;
+lastChange = "2022-11-17 09:18:59 +0000";
 layers = (
 {
 anchors = (
@@ -287,23 +310,6 @@ name = "new anchor";
 pos = (134,188);
 }
 );
-background = {
-shapes = (
-{
-closed = 1;
-nodes = (
-(136,328,o),
-(146,256,o),
-(129,184,c),
-(30,110,l),
-(60,70,l),
-(120,115,l),
-(500,400,l),
-(100,400,l)
-);
-}
-);
-};
 hints = (
 {
 name = _corner.one;
@@ -327,10 +333,13 @@ nodes = (
 width = 600;
 }
 );
+script = latin;
+subCategory = Other;
 },
 {
-glyphname = curved_instroke.expectation;
-lastChange = "2022-11-16 22:27:26 +0000";
+category = Letter;
+glyphname = ad_curved_instroke.expectation;
+lastChange = "2022-11-17 09:18:59 +0000";
 layers = (
 {
 layerId = m01;
@@ -346,6 +355,446 @@ nodes = (
 (120,115,l),
 (500,400,l),
 (100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+script = latin;
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = ae_curved_corner_firstseg;
+lastChange = "2022-11-17 09:18:35 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.two;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(400,0,l),
+(400,500,l),
+(100,500,l)
+);
+}
+);
+width = 600;
+}
+);
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = ae_curved_corner_firstseg.expectation;
+lastChange = "2022-11-17 09:18:35 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,50,l),
+(66,50,o),
+(13,50,o),
+(13,0,c),
+(121,0,l),
+(400,0,l),
+(400,500,l),
+(100,500,l)
+);
+}
+);
+width = 600;
+}
+);
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = af_curved_corner_firstseg_slanted;
+lastChange = "2022-11-17 09:24:04 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.two;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(400,0,l),
+(534,500,l),
+(234,500,l)
+);
+}
+);
+width = 600;
+}
+);
+production = ae_curved_corner_firstseg_slanted;
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = af_curved_corner_firstseg_slanted.expectation;
+lastChange = "2022-11-17 09:25:23 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,50,l),
+(79,50,o),
+(13,50,o),
+(13,0,c),
+(121,0,l),
+(400,0,l),
+(534,500,l),
+(234,500,l)
+);
+}
+);
+width = 600;
+}
+);
+production = ae_curved_corner_firstseg_slanted.001;
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = ag_curved_corner_bothsegs;
+lastChange = "2022-11-17 09:24:10 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.three;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(400,0,l),
+(400,500,l),
+(100,500,l)
+);
+}
+);
+width = 600;
+}
+);
+production = ae_curved_corner_bothsegs;
+subCategory = Other;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+},
+{
+category = Letter;
+glyphname = ag_curved_corner_bothsegs_rotated;
+lastChange = "2022-11-17 09:42:08 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.three;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(-12,83,l),
+(248,-67,l),
+(498,367,l),
+(238,517,l)
+);
+}
+);
+width = 600;
+}
+);
+production = ae_curved_corner_bothsegs.rotated;
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = ag_curved_corner_bothsegs.expectation;
+lastChange = "2022-11-17 09:41:12 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,50,l),
+(75,50,o),
+(26,53,o),
+(10,32,c),
+(0,10,l),
+(36,32,o),
+(84,14,o),
+(120,0,c),
+(400,0,l),
+(400,500,l),
+(100,500,l)
+);
+}
+);
+width = 600;
+}
+);
+production = ae_curved_corner_bothsegs.001;
+subCategory = Other;
+},
+{
+category = Letter;
+glyphname = ag_curved_corner_bothsegs_rotated.expectation;
+lastChange = "2022-11-17 09:42:40 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,126,l),
+(-9,139,o),
+(-50,166,o),
+(-74,156,c),
+(-94,142,l),
+(-51,143,o),
+(-19,103,o),
+(5,73,c),
+(248,-67,l),
+(498,367,l),
+(238,517,l)
+);
+}
+);
+width = 600;
+}
+);
+production = ae_curved_corner_bothsegs.rotated.001;
+subCategory = Other;
+},
+{
+export = 0;
+glyphname = _corner.four;
+lastChange = "2022-11-17 09:45:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = origin;
+pos = (0,500);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,550,l),
+(-30,502,l),
+(3,474,l),
+(50,500,l)
+);
+}
+);
+width = 200;
+}
+);
+},
+{
+glyphname = ah_origin;
+lastChange = "2022-11-17 09:45:35 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.four;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(210,0,l),
+(210,500,l),
+(50,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ai_curved_outstroke;
+lastChange = "2022-11-17 10:11:27 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,100,l),
+(148,100,o),
+(500,302,o),
+(500,400,c),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = aj_right_alignment;
+lastChange = "2022-11-17 10:21:01 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+options = 1;
+origin = (0,1);
+scale = (0.72622,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(234,0,l),
+(433,500,l),
+(283,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ah_origin.expectation;
+lastChange = "2022-11-17 09:46:23 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,50,l),
+(20,2,l),
+(53,-26,l),
+(100,0,l),
+(210,0,l),
+(210,500,l),
+(50,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ai_curved_outstroke.expectation;
+lastChange = "2022-11-17 09:51:17 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,153,l),
+(68,163,l),
+(52,115,l),
+(124,92,l),
+(240,71,o),
+(500,214,o),
+(500,400,c),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = aj_right_alignment.expectation;
+lastChange = "2022-11-17 10:21:38 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(184,0,l),
+(184,-36,l),
+(234,-36,l),
+(241,17,l),
+(433,500,l),
+(283,500,l)
 );
 }
 );

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -6,7 +6,8 @@ DisplayStrings = (
 "/an_flippy",
 "/ao_firstnode/ao_firstnode.expectation",
 "/ak_right_slanted/am_middle",
-"/ar_leftleg"
+"/ar_leftleg",
+"/at_unaligned_lastseg.expectation/ai_curved_outstroke/at_unaligned_lastseg"
 );
 customParameters = (
 {
@@ -16,6 +17,8 @@ _corner.one,
 _corner.two,
 _corner.three,
 _corner.four,
+_corner.five,
+_corner.pretty,
 _corner.slab,
 aa_simple_angleinstroke,
 aa_simple_angleinstroke.expectation,
@@ -47,6 +50,18 @@ am_middle,
 am_middle.expectation,
 an_flippy,
 an_flippy.expectation,
+ao_firstnode,
+ao_firstnode.expectation,
+ap_twoofthem,
+ap_twoofthem.expectation,
+aq_rightleg,
+aq_rightleg.expectation,
+ar_leftleg,
+ar_leftleg.expectation,
+as_closedpaths,
+as_closedpaths.expectation,
+at_unaligned_lastseg,
+at_unaligned_lastseg.expectation,
 space
 );
 }
@@ -181,6 +196,89 @@ nodes = (
 (-30,502,l),
 (3,474,l),
 (50,500,l)
+);
+}
+);
+width = 200;
+}
+);
+},
+{
+export = 0;
+glyphname = _corner.five;
+lastChange = "2022-11-21 09:59:10 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,24,l),
+(-84,24,l),
+(-84,-34,l),
+(58,-34,l)
+);
+}
+);
+width = 200;
+}
+);
+},
+{
+export = 0;
+glyphname = _corner.pretty;
+lastChange = "2022-11-18 13:48:51 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,27,l),
+(-39,65,o),
+(-124,11,o),
+(-145,-52,c),
+(-105,-77,o),
+(-55,-86,o),
+(9,0,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(-108,-51,o),
+(-118,-41,o),
+(-118,-29,cs),
+(-118,-18,o),
+(-108,-8,o),
+(-97,-8,cs),
+(-85,-8,o),
+(-75,-18,o),
+(-75,-29,cs),
+(-75,-41,o),
+(-85,-51,o),
+(-97,-51,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(-51,-102,o),
+(-113,-94,o),
+(-165,-63,c),
+(-136,19,o),
+(-29,85,o),
+(19,37,c),
+(27,45,l),
+(-30,100,o),
+(-150,22,o),
+(-177,-67,c),
+(-122,-102,o),
+(-51,-118,o),
+(39,2,c),
+(31,8,l)
 );
 }
 );
@@ -739,7 +837,7 @@ width = 600;
 },
 {
 glyphname = ai_curved_outstroke;
-lastChange = "2022-11-17 10:11:27 +0000";
+lastChange = "2022-11-21 10:03:09 +0000";
 layers = (
 {
 hints = (
@@ -1064,16 +1162,6 @@ width = 600;
 );
 },
 {
-glyphname = space;
-layers = (
-{
-layerId = m01;
-width = 200;
-}
-);
-unicode = 32;
-},
-{
 glyphname = ao_firstnode;
 lastChange = "2022-11-17 15:12:47 +0000";
 layers = (
@@ -1127,67 +1215,6 @@ width = 600;
 );
 },
 {
-export = 0;
-glyphname = _corner.pretty;
-lastChange = "2022-11-18 13:48:51 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 0;
-nodes = (
-(0,27,l),
-(-39,65,o),
-(-124,11,o),
-(-145,-52,c),
-(-105,-77,o),
-(-55,-86,o),
-(9,0,c)
-);
-},
-{
-closed = 1;
-nodes = (
-(-108,-51,o),
-(-118,-41,o),
-(-118,-29,cs),
-(-118,-18,o),
-(-108,-8,o),
-(-97,-8,cs),
-(-85,-8,o),
-(-75,-18,o),
-(-75,-29,cs),
-(-75,-41,o),
-(-85,-51,o),
-(-97,-51,cs)
-);
-},
-{
-closed = 1;
-nodes = (
-(-51,-102,o),
-(-113,-94,o),
-(-165,-63,c),
-(-136,19,o),
-(-29,85,o),
-(19,37,c),
-(27,45,l),
-(-30,100,o),
-(-150,22,o),
-(-177,-67,c),
-(-122,-102,o),
-(-51,-118,o),
-(39,2,c),
-(31,8,l)
-);
-}
-);
-width = 200;
-}
-);
-},
-{
 glyphname = ap_twoofthem;
 lastChange = "2022-11-17 22:32:10 +0000";
 layers = (
@@ -1212,6 +1239,33 @@ closed = 1;
 nodes = (
 (148,0,l),
 (283,0,l),
+(283,504,l),
+(148,504,l)
+);
+}
+);
+width = 933;
+}
+);
+},
+{
+glyphname = ap_twoofthem.expectation;
+lastChange = "2022-11-17 22:31:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,27,l),
+(52,27,l),
+(52,0,l),
+(157,0,l),
+(274,0,l),
+(379,0,l),
+(379,27,l),
+(283,27,l),
 (283,504,l),
 (148,504,l)
 );
@@ -1252,6 +1306,30 @@ width = 600;
 );
 },
 {
+glyphname = aq_rightleg.expectation;
+lastChange = "2022-11-18 12:45:53 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(179,0,l),
+(284,0,l),
+(284,27,l),
+(193,27,l),
+(284,500,l),
+(184,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
 glyphname = ar_leftleg;
 lastChange = "2022-11-18 12:17:17 +0000";
 layers = (
@@ -1272,6 +1350,30 @@ closed = 1;
 nodes = (
 (433,0,l),
 (483,0,l),
+(110,381,l),
+(84,359,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ar_leftleg.expectation;
+lastChange = "2022-11-18 12:13:40 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(474,0,l),
+(579,0,l),
+(579,27,l),
+(457,27,l),
 (110,381,l),
 (84,359,l)
 );
@@ -1315,83 +1417,8 @@ width = 600;
 );
 },
 {
-glyphname = ap_twoofthem.expectation;
-lastChange = "2022-11-17 22:31:39 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(148,27,l),
-(52,27,l),
-(52,0,l),
-(157,0,l),
-(274,0,l),
-(379,0,l),
-(379,27,l),
-(283,27,l),
-(283,504,l),
-(148,504,l)
-);
-}
-);
-width = 933;
-}
-);
-},
-{
-glyphname = aq_rightleg.expectation;
-lastChange = "2022-11-18 12:45:53 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(88,0,l),
-(179,0,l),
-(284,0,l),
-(284,27,l),
-(193,27,l),
-(284,500,l),
-(184,500,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
-glyphname = ar_leftleg.expectation;
-lastChange = "2022-11-18 12:13:40 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(433,0,l),
-(474,0,l),
-(579,0,l),
-(579,27,l),
-(457,27,l),
-(110,381,l),
-(84,359,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
 glyphname = as_closedpaths.expectation;
-lastChange = "2022-11-18 14:36:29 +0000";
+lastChange = "2022-11-18 14:37:09 +0000";
 layers = (
 {
 layerId = m01;
@@ -1493,6 +1520,68 @@ nodes = (
 width = 600;
 }
 );
+},
+{
+glyphname = at_unaligned_lastseg;
+lastChange = "2022-11-18 14:46:55 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.five;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,0,l),
+(396,0,l),
+(396,500,l),
+(96,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = at_unaligned_lastseg.expectation;
+lastChange = "2022-11-18 14:49:32 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,28,l),
+(11,-22,l),
+(41,-72,l),
+(163,0,l),
+(396,0,l),
+(396,500,l),
+(96,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
 }
 );
 metrics = (

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,10 +2,10 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"/_corner.one  ab",
-b,
-"a/a.expectation b/b.expectation",
-a
+"/_corner.one  ",
+"",
+"/simple_angled/simple_angled.expectation/simple_angleinstroke/scale.expectation/simple_angleinstroke.expectation/simple_angleinstroke.expectation",
+""
 );
 date = "2022-11-14 14:19:00 +0000";
 familyName = "Corner Component Alignment Test";
@@ -40,108 +40,6 @@ name = Regular;
 }
 );
 glyphs = (
-{
-glyphname = a;
-lastChange = "2022-11-16 15:28:12 +0000";
-layers = (
-{
-hints = (
-{
-name = _corner.one;
-origin = (0,0);
-type = Corner;
-}
-);
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(100,100,l),
-(500,400,l),
-(100,400,l)
-);
-}
-);
-width = 600;
-}
-);
-unicode = 97;
-},
-{
-glyphname = b;
-lastChange = "2022-11-16 13:52:55 +0000";
-layers = (
-{
-hints = (
-{
-name = _corner.one;
-origin = (0,0);
-type = Corner;
-}
-);
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(200,100,l),
-(414,100,l),
-(100,300,l)
-);
-}
-);
-width = 600;
-}
-);
-unicode = 98;
-},
-{
-glyphname = a.expectation;
-lastChange = "2022-11-16 15:41:41 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(100,163,l),
-(30,110,l),
-(60,70,l),
-(120,115,l),
-(500,400,l),
-(100,400,l)
-);
-}
-);
-width = 600;
-}
-);
-},
-{
-glyphname = b.expectation;
-lastChange = "2022-11-16 15:41:37 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(175,150,l),
-(150,150,l),
-(150,100,l),
-(225,100,l),
-(414,100,l),
-(100,300,l)
-);
-}
-);
-width = 600;
-}
-);
-},
 {
 glyphname = space;
 layers = (
@@ -192,6 +90,159 @@ nodes = (
 }
 );
 width = 20;
+}
+);
+},
+{
+glyphname = scale;
+lastChange = "2022-11-16 16:10:06 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+scale = (1.2,1.5);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(38,86,l),
+(302,86,l),
+(412,500,l),
+(148,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = simple_angled;
+lastChange = "2022-11-16 16:11:01 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,100,l),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = simple_angleinstroke;
+lastChange = "2022-11-16 16:11:33 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,100,l),
+(414,100,l),
+(100,300,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = scale.expectation;
+lastChange = "2022-11-16 16:13:48 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,161,l),
+(-22,161,l),
+(-22,86,l),
+(68,86,l),
+(302,86,l),
+(412,500,l),
+(148,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = simple_angled.expectation;
+lastChange = "2022-11-16 16:11:06 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,163,l),
+(30,110,l),
+(60,70,l),
+(120,115,l),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = simple_angleinstroke.expectation;
+lastChange = "2022-11-16 16:11:42 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,150,l),
+(150,150,l),
+(150,100,l),
+(225,100,l),
+(414,100,l),
+(100,300,l)
+);
+}
+);
+width = 600;
 }
 );
 }

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,10 +2,11 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"/_corner.one  ",
+"/_corner.one/curved_instroke",
 "",
-"/simple_angled/simple_angled.expectation/simple_angleinstroke/scale.expectation/simple_angleinstroke.expectation/simple_angleinstroke.expectation",
-""
+"",
+"/curved_instroke.expectation/curved_instroke",
+"/curved_instroke.expectation"
 );
 date = "2022-11-14 14:19:00 +0000";
 familyName = "Corner Component Alignment Test";
@@ -41,6 +42,34 @@ name = Regular;
 );
 glyphs = (
 {
+glyphname = a;
+lastChange = "2022-11-16 16:11:01 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,100,l),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 97;
+},
+{
 glyphname = space;
 layers = (
 {
@@ -52,7 +81,7 @@ unicode = 32;
 },
 {
 glyphname = _corner.one;
-lastChange = "2022-11-16 15:06:16 +0000";
+lastChange = "2022-11-16 21:34:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -67,7 +96,7 @@ nodes = (
 );
 }
 );
-width = 25;
+width = 250;
 }
 );
 },
@@ -124,7 +153,7 @@ width = 600;
 },
 {
 glyphname = simple_angled;
-lastChange = "2022-11-16 16:11:01 +0000";
+lastChange = "2022-11-16 22:20:27 +0000";
 layers = (
 {
 hints = (
@@ -202,7 +231,7 @@ width = 600;
 },
 {
 glyphname = simple_angled.expectation;
-lastChange = "2022-11-16 16:11:06 +0000";
+lastChange = "2022-11-16 22:25:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -222,6 +251,7 @@ nodes = (
 width = 600;
 }
 );
+production = simple_angled.expectation;
 },
 {
 glyphname = simple_angleinstroke.expectation;
@@ -239,6 +269,83 @@ nodes = (
 (225,100,l),
 (414,100,l),
 (100,300,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = curved_instroke;
+lastChange = "2022-11-16 22:24:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = "new anchor";
+pos = (134,188);
+}
+);
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,328,o),
+(146,256,o),
+(129,184,c),
+(30,110,l),
+(60,70,l),
+(120,115,l),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+};
+hints = (
+{
+name = _corner.one;
+origin = (0,2);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,279,o),
+(150,200,o),
+(100,100,c),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = curved_instroke.expectation;
+lastChange = "2022-11-16 22:27:26 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,316,o),
+(150,253,o),
+(134,188,c),
+(30,110,l),
+(60,70,l),
+(120,115,l),
+(500,400,l),
+(100,400,l)
 );
 }
 );

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -1,0 +1,222 @@
+{
+.appVersion = "3109";
+.formatVersion = 3;
+DisplayStrings = (
+"/_corner.one  ab",
+b,
+"a/a.expectation b/b.expectation",
+a
+);
+date = "2022-11-14 14:19:00 +0000";
+familyName = "Corner Component Alignment Test";
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+over = -16;
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = a;
+lastChange = "2022-11-16 15:28:12 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,100,l),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 97;
+},
+{
+glyphname = b;
+lastChange = "2022-11-16 13:52:55 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.one;
+origin = (0,0);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,100,l),
+(414,100,l),
+(100,300,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 98;
+},
+{
+glyphname = a.expectation;
+lastChange = "2022-11-16 15:41:41 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,163,l),
+(30,110,l),
+(60,70,l),
+(120,115,l),
+(500,400,l),
+(100,400,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = b.expectation;
+lastChange = "2022-11-16 15:41:37 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,150,l),
+(150,150,l),
+(150,100,l),
+(225,100,l),
+(414,100,l),
+(100,300,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+},
+{
+glyphname = _corner.one;
+lastChange = "2022-11-16 15:06:16 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,50,l),
+(-50,50,l),
+(-50,0,l),
+(25,0,l)
+);
+}
+);
+width = 25;
+}
+);
+},
+{
+glyphname = _corner.two;
+lastChange = "2022-11-14 14:38:32 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(20,50,l),
+(-14,50,o),
+(-87,50,o),
+(-87,0,c),
+(-21,0,l)
+);
+}
+);
+width = 20;
+}
+);
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -2,11 +2,11 @@
 .appVersion = "3109";
 .formatVersion = 3;
 DisplayStrings = (
-"/_corner.two/_corner.four/_corner.slab/an_flippy/an_flippy.expectation",
+"/_corner.two/_corner.four/_corner.slab/an_flippy/_corner.pretty/as_closedpaths/as_closedpaths.expectation/an_flippy.expectation",
 "/an_flippy",
 "/ao_firstnode/ao_firstnode.expectation",
-"/ap_twoofthem",
-"/_corner.one/aq_rightleg.expectation"
+"/ak_right_slanted/am_middle",
+"/ar_leftleg"
 );
 customParameters = (
 {
@@ -81,6 +81,11 @@ over = -16;
 }
 );
 name = Regular;
+userData = {
+GSOffsetHorizontal = 5;
+GSOffsetMakeStroke = 1;
+GSOffsetVertical = 5;
+};
 }
 );
 glyphs = (
@@ -1122,6 +1127,67 @@ width = 600;
 );
 },
 {
+export = 0;
+glyphname = _corner.pretty;
+lastChange = "2022-11-18 13:48:51 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 0;
+nodes = (
+(0,27,l),
+(-39,65,o),
+(-124,11,o),
+(-145,-52,c),
+(-105,-77,o),
+(-55,-86,o),
+(9,0,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(-108,-51,o),
+(-118,-41,o),
+(-118,-29,cs),
+(-118,-18,o),
+(-108,-8,o),
+(-97,-8,cs),
+(-85,-8,o),
+(-75,-18,o),
+(-75,-29,cs),
+(-75,-41,o),
+(-85,-51,o),
+(-97,-51,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(-51,-102,o),
+(-113,-94,o),
+(-165,-63,c),
+(-136,19,o),
+(-29,85,o),
+(19,37,c),
+(27,45,l),
+(-30,100,o),
+(-150,22,o),
+(-177,-67,c),
+(-122,-102,o),
+(-51,-118,o),
+(39,2,c),
+(31,8,l)
+);
+}
+);
+width = 200;
+}
+);
+},
+{
 glyphname = ap_twoofthem;
 lastChange = "2022-11-17 22:32:10 +0000";
 layers = (
@@ -1216,6 +1282,39 @@ width = 600;
 );
 },
 {
+glyphname = as_closedpaths;
+lastChange = "2022-11-18 14:17:51 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.pretty;
+origin = (0,0);
+type = Corner;
+},
+{
+name = _corner.pretty;
+origin = (0,2);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,1,l),
+(452,1,l),
+(452,501,l),
+(152,501,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
 glyphname = ap_twoofthem.expectation;
 lastChange = "2022-11-17 22:31:39 +0000";
 layers = (
@@ -1283,6 +1382,111 @@ nodes = (
 (457,27,l),
 (110,381,l),
 (84,359,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = as_closedpaths.expectation;
+lastChange = "2022-11-18 14:36:29 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,28,l),
+(113,66,o),
+(28,12,o),
+(7,-51,c),
+(47,-76,o),
+(97,-85,o),
+(161,1,c),
+(452,1,l),
+(452,474,l),
+(491,436,o),
+(576,490,o),
+(597,553,c),
+(557,578,o),
+(507,587,o),
+(443,501,c),
+(152,501,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(44,-50,o),
+(34,-40,o),
+(34,-28,cs),
+(34,-17,o),
+(44,-7,o),
+(55,-7,cs),
+(67,-7,o),
+(77,-17,o),
+(77,-28,cs),
+(77,-40,o),
+(67,-50,o),
+(55,-50,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(101,-101,o),
+(39,-93,o),
+(-13,-62,c),
+(16,20,o),
+(123,86,o),
+(171,38,c),
+(179,46,l),
+(122,101,o),
+(2,23,o),
+(-25,-66,c),
+(30,-101,o),
+(101,-117,o),
+(191,3,c),
+(183,9,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(560,552,o),
+(570,542,o),
+(570,530,cs),
+(570,519,o),
+(560,509,o),
+(549,509,cs),
+(537,509,o),
+(527,519,o),
+(527,530,cs),
+(527,542,o),
+(537,552,o),
+(549,552,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,603,o),
+(565,595,o),
+(617,564,c),
+(588,482,o),
+(481,416,o),
+(433,464,c),
+(425,456,l),
+(482,401,o),
+(602,479,o),
+(629,568,c),
+(574,603,o),
+(503,619,o),
+(413,499,c),
+(421,493,l)
 );
 }
 );

--- a/tests/data/CornerComponents.glyphs
+++ b/tests/data/CornerComponents.glyphs
@@ -5,7 +5,8 @@ DisplayStrings = (
 "/_corner.two/_corner.four/_corner.slab/an_flippy/an_flippy.expectation",
 "/an_flippy",
 "/ao_firstnode/ao_firstnode.expectation",
-"/ap_twoofthem"
+"/ap_twoofthem",
+"/_corner.one/aq_rightleg.expectation"
 );
 customParameters = (
 {
@@ -981,7 +982,7 @@ width = 600;
 },
 {
 glyphname = am_middle.expectation;
-lastChange = "2022-11-17 13:07:56 +0000";
+lastChange = "2022-11-18 12:33:25 +0000";
 layers = (
 {
 layerId = m01;
@@ -1155,6 +1156,66 @@ width = 933;
 );
 },
 {
+glyphname = aq_rightleg;
+lastChange = "2022-11-18 12:02:28 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.slab;
+options = 1;
+origin = (0,1);
+scale = (-1,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(188,0,l),
+(284,500,l),
+(184,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ar_leftleg;
+lastChange = "2022-11-18 12:17:17 +0000";
+layers = (
+{
+hints = (
+{
+name = _corner.slab;
+options = 1;
+origin = (0,1);
+scale = (-1,1);
+type = Corner;
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(483,0,l),
+(110,381,l),
+(84,359,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
 glyphname = ap_twoofthem.expectation;
 lastChange = "2022-11-17 22:31:39 +0000";
 layers = (
@@ -1178,6 +1239,54 @@ nodes = (
 }
 );
 width = 933;
+}
+);
+},
+{
+glyphname = aq_rightleg.expectation;
+lastChange = "2022-11-18 12:45:53 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(179,0,l),
+(284,0,l),
+(284,27,l),
+(193,27,l),
+(284,500,l),
+(184,500,l)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = ar_leftleg.expectation;
+lastChange = "2022-11-18 12:13:40 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(474,0,l),
+(579,0,l),
+(579,27,l),
+(457,27,l),
+(110,381,l),
+(84,359,l)
+);
+}
+);
+width = 600;
 }
 );
 }


### PR DESCRIPTION
Smart components were easy! Corner components... not so much. I don't quite understand how they work. But once I *do*, here's a framework for getting them implemented:

* Export them as hints (which we do already) in the UFO, ensuring we pass along the hint's name (since this is the name of the corner component glyph).
* Add a custom filter to "apply" those hints, by modifying the glyphs' path.
  * Convert the hints into a sensible data structure
  * ???
  * Profit!