### PR TITLE
Allow alternate layers to be unnamed

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -283,7 +283,7 @@ class UFOBuilder(LoggerMixin):
                     )
                 continue
 
-            if not layer.name:
+            if not layer.name and not layer._is_bracket_layer():
                 # Empty layer names are invalid according to the UFO spec.
                 if self.minimize_glyphs_diffs:
                     self.logger.warning(

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -518,6 +518,13 @@ def test_designspace_generation_bracket_other_roundtrip(datadir, ufo_module):
 def test_designspace_generation_multiaxis_bracket(datadir, ufo_module):
     with open(str(datadir.join("Playfair-v.glyphs")), encoding="utf-8") as f:
         font = glyphsLib.load(f)
+
+    # Remove names of bracket layers, make sure the layers get
+    # copied anyway
+    for l in font.glyphs["v"].layers:
+        if l._is_bracket_layer():
+            l.name = ""
+
     designspace = to_designspace(font, ufo_module=ufo_module)
     axes = designspace.axes
     info = font.glyphs["v"].layers[8]._bracket_info(axes)


### PR DESCRIPTION
Fixes the *other* issue with Playfair Italic in #741. Alternate layers may be unnamed because Glyphs does not rely on (or even display) the user-supplied name for them, and we make up our own name for them anyway.