### PR TITLE
Support finding smart component info in G3 format

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3666,11 +3666,14 @@ class GSLayer(GSBase):
     def smartComponentPoleMapping(self):
         if "PartSelection" not in self.userData:
             self.userData["PartSelection"] = {}
+        if self.partSelection:
+            return self.partSelection
         return self.userData["PartSelection"]
 
     @smartComponentPoleMapping.setter
     def smartComponentPoleMapping(self, value):
         self.userData["PartSelection"] = value
+        self.partSelection = value
 
     @property
     def bounds(self):


### PR DESCRIPTION
Prior to Glyphs 3, smart component information was stored in a userData key; in Glyphs 3 format, it's stored in the `partSelection` slot of the layer itself. We need to look in both places.