### PR TITLE
More alternate layer fixes

### DIFF
--- a/Lib/glyphsLib/builder/bracket_layers.py
+++ b/Lib/glyphsLib/builder/bracket_layers.py
@@ -41,7 +41,7 @@ def to_designspace_bracket_layers(self):
         rules.append(
             (
                 [box_with_name],
-                {glyph_name: _bracket_glyph_name(glyph_name, box_with_tag)},
+                {glyph_name: _bracket_glyph_name(self, glyph_name, box_with_tag)},
             )
         )
 
@@ -95,7 +95,7 @@ def copy_bracket_layers_to_ufo_glyphs(self, bracket_layer_map):
                 bracket_layers.append(master_layer)
                 implicit_bracket_layers.add(id(master_layer))
 
-            bracket_glyphs.add(_bracket_glyph_name(glyph_name, box))
+            bracket_glyphs.add(_bracket_glyph_name(self, glyph_name, box))
 
     for glyph_name, glyph_bracket_layers in bracket_layer_map.items():
         for frozenbox, layers in glyph_bracket_layers.items():
@@ -104,7 +104,7 @@ def copy_bracket_layers_to_ufo_glyphs(self, bracket_layer_map):
                 layer_id = layer.associatedMasterId or layer.layerId
                 ufo_font = self._sources[layer_id].font
                 ufo_layer = ufo_font.layers.defaultLayer
-                ufo_glyph_name = _bracket_glyph_name(glyph_name, box)
+                ufo_glyph_name = _bracket_glyph_name(self, glyph_name, box)
                 ufo_glyph = ufo_layer.newGlyph(ufo_glyph_name)
                 self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
                 ufo_glyph.unicodes = []  # Avoid cmap interference
@@ -116,7 +116,7 @@ def copy_bracket_layers_to_ufo_glyphs(self, bracket_layer_map):
                 )
                 # swap components if base glyph contains matching bracket layers.
                 for comp in ufo_glyph.components:
-                    bracket_comp_name = _bracket_glyph_name(comp.baseGlyph, box)
+                    bracket_comp_name = _bracket_glyph_name(self, comp.baseGlyph, box)
                     if bracket_comp_name in bracket_glyphs:
                         comp.baseGlyph = bracket_comp_name
                 # Update kerning groups and pairs, bracket glyphs inherit the
@@ -124,10 +124,10 @@ def copy_bracket_layers_to_ufo_glyphs(self, bracket_layer_map):
                 _expand_kerning_to_brackets(glyph_name, ufo_glyph_name, ufo_font)
 
 
-def _bracket_glyph_name(glyph_name, box):
-    description = ".".join(
-        f"{tag}_{min}_{max}" for tag, (min, max) in sorted(box.items())
-    )
+def _bracket_glyph_name(self, glyph_name, box):
+    if box not in self.alternate_names_map[glyph_name]:
+        self.alternate_names_map[glyph_name].append(box)
+    description = "varAlt%02i" % (1 + self.alternate_names_map[glyph_name].index(box))
     return BRACKET_GLYPH_TEMPLATE.format(glyph_name=glyph_name, description=description)
 
 

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -135,6 +135,9 @@ class UFOBuilder(LoggerMixin):
         # VORG tables. VORG will only be included if the font is an otf.
         self.is_vertical = self._is_vertical()
 
+        # Counter to generate shorter names for alternate layer glyphs
+        self.alternate_names_map = defaultdict(list)
+
         # check that source was generated with at least stable version 2.3
         # https://github.com/googlefonts/glyphsLib/pull/65#issuecomment-237158140
         if int(font.appVersion) < 895:

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -101,7 +101,7 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
             production_name += BRACKET_GLYPH_SUFFIX_RE.match(ufo_glyph.name).group(1)
     else:
         production_name = glyphinfo.production_name
-    if production_name != ufo_glyph.name:
+    if production_name and production_name != ufo_glyph.name:
         postscriptNamesKey = PUBLIC_PREFIX + "postscriptNames"
         if postscriptNamesKey not in ufo_font.lib:
             ufo_font.lib[postscriptNamesKey] = dict()

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -2261,8 +2261,8 @@ def test_load_kerning_bracket(ufo_module):
 
     ds = glyphsLib.to_designspace(font, minimize_glyphs_diffs=True)
     bracketed_groups = {
-        "public.kern2.foo": ["a", "a.BRACKET.wght_300_1000"],
-        "public.kern1.foo": ["x", "x.BRACKET.wght_300_1000", "x.BRACKET.wght_600_1000"],
+        "public.kern2.foo": ["a", "a.BRACKET.varAlt01"],
+        "public.kern1.foo": ["x", "x.BRACKET.varAlt01", "x.BRACKET.varAlt02"],
     }
     assert ds.sources[0].font.groups == bracketed_groups
     assert ds.sources[1].font.groups == bracketed_groups
@@ -2271,11 +2271,11 @@ def test_load_kerning_bracket(ufo_module):
     assert ds.sources[0].font.kerning == {
         ("public.kern1.foo", "public.kern2.foo"): -200,
         ("a", "x"): -100,
-        ("a.BRACKET.wght_300_1000", "x"): -100,
-        ("a", "x.BRACKET.wght_300_1000"): -100,
-        ("a.BRACKET.wght_300_1000", "x.BRACKET.wght_300_1000"): -100,
-        ("a", "x.BRACKET.wght_600_1000"): -100,
-        ("a.BRACKET.wght_300_1000", "x.BRACKET.wght_600_1000"): -100,
+        ("a.BRACKET.varAlt01", "x"): -100,
+        ("a", "x.BRACKET.varAlt01"): -100,
+        ("a.BRACKET.varAlt01", "x.BRACKET.varAlt01"): -100,
+        ("a", "x.BRACKET.varAlt02"): -100,
+        ("a.BRACKET.varAlt01", "x.BRACKET.varAlt02"): -100,
     }
     assert ds.sources[1].font.kerning == {}
     assert ds.sources[2].font.kerning == {
@@ -2294,8 +2294,8 @@ def test_load_kerning_bracket(ufo_module):
 
     ds2 = glyphsLib.to_designspace(font, minimize_glyphs_diffs=True)
     bracketed_groups = {
-        "public.kern2.foo": ["a", "a.BRACKET.wght_300_1000"],
-        "public.kern1.foo": ["x", "x.BRACKET.wght_300_1000", "x.BRACKET.wght_600_1000"],
+        "public.kern2.foo": ["a", "a.BRACKET.varAlt01"],
+        "public.kern1.foo": ["x", "x.BRACKET.varAlt01", "x.BRACKET.varAlt02"],
     }
     assert ds2.sources[0].font.groups == bracketed_groups
     assert ds2.sources[1].font.groups == bracketed_groups
@@ -2304,11 +2304,11 @@ def test_load_kerning_bracket(ufo_module):
     assert ds2.sources[0].font.kerning == {
         ("public.kern1.foo", "public.kern2.foo"): -200,
         ("a", "x"): -100,
-        ("a.BRACKET.wght_300_1000", "x"): -100,
-        ("a", "x.BRACKET.wght_300_1000"): -100,
-        ("a.BRACKET.wght_300_1000", "x.BRACKET.wght_300_1000"): -100,
-        ("a", "x.BRACKET.wght_600_1000"): -100,
-        ("a.BRACKET.wght_300_1000", "x.BRACKET.wght_600_1000"): -100,
+        ("a.BRACKET.varAlt01", "x"): -100,
+        ("a", "x.BRACKET.varAlt01"): -100,
+        ("a.BRACKET.varAlt01", "x.BRACKET.varAlt01"): -100,
+        ("a", "x.BRACKET.varAlt02"): -100,
+        ("a.BRACKET.varAlt01", "x.BRACKET.varAlt02"): -100,
     }
     assert ds2.sources[1].font.kerning == {}
     assert ds2.sources[2].font.kerning == {

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -381,6 +381,9 @@ def test_designspace_generation_bracket_composite_glyph(datadir, ufo_module):
             ufo["B.BRACKET.varAlt01"].components[0].baseGlyph
             == "A.BRACKET.varAlt01"
         )
+        # G has no alternate layers, but it uses a component
+        # which does, so it too must develop some.
+        assert "G.BRACKET.varAlt01" in ufo
 
     font_rt = to_glyphs(designspace)
 
@@ -404,11 +407,11 @@ def test_designspace_generation_reverse_bracket_roundtrip(datadir, ufo_module):
     designspace = to_designspace(font, ufo_module=ufo_module)
 
     # Bottom box should include substitutions for D (400->600)
-    assert designspace.rules[1].name == "BRACKET.Weight_400_570"
-    assert designspace.rules[1].conditionSets == [
+    assert designspace.rules[2].name == "BRACKET.Weight_400_570"
+    assert designspace.rules[2].conditionSets == [
         [dict(name="Weight", minimum=400, maximum=570)]
     ]
-    assert designspace.rules[1].subs == [
+    assert designspace.rules[2].subs == [
         ("D", "D.BRACKET.varAlt01"),
         ("E", "E.BRACKET.varAlt01"),
         ("F", "F.BRACKET.varAlt02"),

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -377,10 +377,7 @@ def test_designspace_generation_bracket_composite_glyph(datadir, ufo_module):
         ufo = source.font
         assert "B.BRACKET.varAlt01" in ufo
         assert ufo["B"].components[0].baseGlyph == "A"
-        assert (
-            ufo["B.BRACKET.varAlt01"].components[0].baseGlyph
-            == "A.BRACKET.varAlt01"
-        )
+        assert ufo["B.BRACKET.varAlt01"].components[0].baseGlyph == "A.BRACKET.varAlt01"
         # G has no alternate layers, but it uses a component
         # which does, so it too must develop some.
         assert "G.BRACKET.varAlt01" in ufo

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -242,8 +242,8 @@ def test_designspace_generation_bracket_roundtrip(datadir, ufo_module):
         [dict(name="Weight", minimum=600, maximum=1000)]
     ]
     assert sorted(designspace.rules[0].subs) == [
-        ("a", "a.BRACKET.wght_300_1000"),
-        ("x", "x.BRACKET.wght_600_1000"),
+        ("a", "a.BRACKET.varAlt01"),
+        ("x", "x.BRACKET.varAlt02"),
     ]
 
     assert designspace.rules[1].name == "BRACKET.Weight_300_600"
@@ -251,8 +251,8 @@ def test_designspace_generation_bracket_roundtrip(datadir, ufo_module):
         [dict(name="Weight", minimum=300, maximum=600)]
     ]
     assert sorted(designspace.rules[1].subs) == [
-        ("a", "a.BRACKET.wght_300_1000"),
-        ("x", "x.BRACKET.wght_300_1000"),
+        ("a", "a.BRACKET.varAlt01"),
+        ("x", "x.BRACKET.varAlt01"),
     ]
 
     for source in designspace.sources:
@@ -260,9 +260,9 @@ def test_designspace_generation_bracket_roundtrip(datadir, ufo_module):
         assert "Something [300]" not in source.font.layers
         assert "[600]" not in source.font.layers
         assert "Other [600]" not in source.font.layers
-        g1 = source.font["x.BRACKET.wght_300_1000"]
+        g1 = source.font["x.BRACKET.varAlt01"]
         assert not g1.unicodes
-        g2 = source.font["x.BRACKET.wght_600_1000"]
+        g2 = source.font["x.BRACKET.varAlt02"]
         assert not g2.unicodes
 
     font_rt = to_glyphs(designspace)
@@ -298,7 +298,7 @@ def test_designspace_generation_bracket_roundtrip_psnames(datadir, ufo_module):
 
     assert designspace.findDefault().font.lib["public.postscriptNames"] == {
         "a-cy": "uni0430",
-        "a-cy.BRACKET.opsz_18_20": "uni0430.BRACKET.opsz_18_20",
+        "a-cy.BRACKET.varAlt01": "uni0430.BRACKET.varAlt01",
         "a-cy.alt": "uni0430.alt",
     }
 
@@ -307,7 +307,7 @@ def test_designspace_generation_bracket_roundtrip_psnames(datadir, ufo_module):
 
     assert designspace_rt.findDefault().font.lib["public.postscriptNames"] == {
         "a-cy": "uni0430",
-        "a-cy.BRACKET.opsz_18_20": "uni0430.BRACKET.opsz_18_20",
+        "a-cy.BRACKET.varAlt01": "uni0430.BRACKET.varAlt01",
         "a-cy.alt": "uni0430.alt",
     }
 
@@ -316,7 +316,7 @@ def test_designspace_generation_bracket_roundtrip_psnames(datadir, ufo_module):
 
     assert designspace_rt2.findDefault().font.lib["public.postscriptNames"] == {
         "a-cy": "uni0430",
-        "a-cy.BRACKET.opsz_18_20": "uni0430.BRACKET.opsz_18_20",
+        "a-cy.BRACKET.varAlt01": "uni0430.BRACKET.varAlt01",
         "a-cy.alt": "uni0430.alt",
     }
 
@@ -353,14 +353,14 @@ def test_designspace_generation_bracket_unbalanced_brackets(datadir, ufo_module)
     designspace = to_designspace(font, ufo_module=ufo_module)
 
     for source in designspace.sources:
-        assert "C.BRACKET.wght_600_700" in source.font
+        assert "C.BRACKET.varAlt01" in source.font
 
     font_rt = to_glyphs(designspace)
 
     assert "C" in font_rt.glyphs
 
     assert {l.name for l in font_rt.glyphs["C"].layers} == layer_names
-    assert "C.BRACKET.wght_600_700" not in font_rt.glyphs
+    assert "C.BRACKET.varAlt01" not in font_rt.glyphs
 
 
 def test_designspace_generation_bracket_composite_glyph(datadir, ufo_module):
@@ -375,11 +375,11 @@ def test_designspace_generation_bracket_composite_glyph(datadir, ufo_module):
 
     for source in designspace.sources:
         ufo = source.font
-        assert "B.BRACKET.wght_600_700" in ufo
+        assert "B.BRACKET.varAlt01" in ufo
         assert ufo["B"].components[0].baseGlyph == "A"
         assert (
-            ufo["B.BRACKET.wght_600_700"].components[0].baseGlyph
-            == "A.BRACKET.wght_600_700"
+            ufo["B.BRACKET.varAlt01"].components[0].baseGlyph
+            == "A.BRACKET.varAlt01"
         )
 
     font_rt = to_glyphs(designspace)
@@ -409,14 +409,14 @@ def test_designspace_generation_reverse_bracket_roundtrip(datadir, ufo_module):
         [dict(name="Weight", minimum=400, maximum=570)]
     ]
     assert designspace.rules[1].subs == [
-        ("D", "D.BRACKET.wght_400_600"),
-        ("E", "E.BRACKET.wght_400_570"),
-        ("F", "F.BRACKET.wght_400_630"),
+        ("D", "D.BRACKET.varAlt01"),
+        ("E", "E.BRACKET.varAlt01"),
+        ("F", "F.BRACKET.varAlt02"),
     ]
 
     for source in designspace.sources:
         ufo = source.font
-        assert "D.BRACKET.wght_400_600" in ufo
+        assert "D.BRACKET.varAlt01" in ufo
 
     font_rt = to_glyphs(designspace)
 
@@ -477,8 +477,8 @@ def test_designspace_generation_bracket_GDEF(datadir, ufo_module):
 
         assert categories == {
             "x": "base",
-            "x.BRACKET.wght_300_1000": "base",
-            "x.BRACKET.wght_600_1000": "base",
+            "x.BRACKET.varAlt01": "base",
+            "x.BRACKET.varAlt02": "base",
         }
 
 
@@ -489,7 +489,7 @@ def test_designspace_generation_bracket_glyphs3_simple(datadir, ufo_module):
     designspace = to_designspace(font, ufo_module=ufo_module)
 
     for source in designspace.sources:
-        assert "A.BRACKET.wght_600_700" in source.font
+        assert "A.BRACKET.varAlt01" in source.font
 
 
 def test_designspace_generation_bracket_rclt_roundtrip(datadir, ufo_module):
@@ -531,7 +531,7 @@ def test_designspace_generation_multiaxis_bracket(datadir, ufo_module):
     assert info == {"opsz": (5, 410), "wdth": (50, 75), "wght": (690, 900)}
 
     for source in designspace.sources:
-        assert "v.BRACKET.opsz_5_410.wdth_50_75.wght_690_900" in source.font
+        assert "v.BRACKET.varAlt01" in source.font
 
     assert (
         designspace.rules[0].name
@@ -545,5 +545,5 @@ def test_designspace_generation_multiaxis_bracket(datadir, ufo_module):
         ]
     ]
     assert designspace.rules[0].subs == [
-        ("v", "v.BRACKET.opsz_5_410.wdth_50_75.wght_690_900"),
+        ("v", "v.BRACKET.varAlt01"),
     ]

--- a/tests/data/BracketTestFont2.glyphs
+++ b/tests/data/BracketTestFont2.glyphs
@@ -442,6 +442,31 @@ width = 600;
 unicode = 0046;
 },
 {
+glyphname = G;
+lastChange = "2022-12-09 12:34:54 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+}
+);
+layerId = "AC80BBED-896D-4DAA-A852-C79F9201ACE8";
+width = 252;
+},
+{
+components = (
+{
+name = A;
+}
+);
+layerId = "48798C20-C9A0-4BB9-9A3E-BDB30805D9C9";
+width = 416;
+}
+);
+unicode = 0047;
+},
+{
 glyphname = space;
 lastChange = "2019-07-25 10:21:14 +0000";
 layers = (

--- a/tests/special_layer_width_test.py
+++ b/tests/special_layer_width_test.py
@@ -40,5 +40,5 @@ def test_substitution_layer_width():
     masters, instances = load_to_ufos(glyphs_file_path(), include_instances=True)
     assert masters[0]["B"].width == 500
     assert masters[1]["B"].width == 600
-    assert masters[0]["B.BRACKET.wght_40_100"].width == 510
-    assert masters[1]["B.BRACKET.wght_40_100"].width == 610
+    assert masters[0]["B.BRACKET.varAlt01"].width == 510
+    assert masters[1]["B.BRACKET.varAlt01"].width == 610


### PR DESCRIPTION
This fixes as much of #837 as I'm prepared to fix. It deals with the situation of parent glyphs which have no alternate layers but use component glyphs which do have alternate layers.

It doesn't deal with the situation of parent glyphs which have alternate layer setups which differ from those of their component glyphs, but it has a decent stab at it and warns the user. (Those are pretty rare, anyway. In the situation of Playfair 3 which had 633 "problematic" layers, only 8 of them were in this category.)

It also deals with my obviously short-sighted approach to glyph naming for alternate layers. Instead of producing long names like `_f_ydieresis.ligature.BRACKET.opsz_5_410.wdth_50_75.wght_690_900`, it now just numbers them.