### PR TITLE
Support finding smart component info in G3 format (2)

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3664,13 +3664,19 @@ class GSLayer(GSBase):
 
     @property
     def smartComponentPoleMapping(self):
-        if "PartSelection" not in self.userData:
-            self.userData["PartSelection"] = {}
-        return self.userData["PartSelection"]
+        if self.parent.parent.format_version < 3:
+            if "PartSelection" not in self.userData:
+                self.userData["PartSelection"] = {}
+            return self.userData["PartSelection"]
+        else:
+            return self.partSelection
 
     @smartComponentPoleMapping.setter
     def smartComponentPoleMapping(self, value):
-        self.userData["PartSelection"] = value
+        if self.parent.parent.format_version < 3:
+            self.userData["PartSelection"] = value
+        else:
+            self.partSelection = value
 
     @property
     def bounds(self):

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -734,7 +734,15 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         self.assertIn('unicode = "00C1,E002";', written)
 
     def test_write_layer(self):
+        font = classes.GSFont()
+        font.format_version = 2
+        master = classes.GSFontMaster()
+        master.id = "M1"
+        font.masters.append(master)
+        glyph = classes.GSGlyph("A")
+        font.glyphs.append(glyph)
         layer = classes.GSLayer()
+        glyph.layers.append(layer)
         # http://docu.glyphsapp.com/#gslayer
         # parent: not written
         # name


### PR DESCRIPTION
Same as https://github.com/googlefonts/glyphsLib/pull/835 but checks the format version instead of looking in both places and avoids storing/writing it twice.

Prior to Glyphs 3, smart component information was stored in a `userData` key; in Glyphs 3 format, it's stored in the `partSelection` slot of the layer itself. We need to look in either places depending on the GSFont's format_version.

