### PR TITLE
Only add box to box list if there's actually a box

### DIFF
--- a/Lib/glyphsLib/builder/bracket_layers.py
+++ b/Lib/glyphsLib/builder/bracket_layers.py
@@ -213,9 +213,13 @@ def find_component_use(self):
                     if my_bracket_layers != components_bracket_layers:
                         # Find what we need to add, and make them hashable
                         they_have = set(
-                            tuple(x.items()) for x in components_bracket_layers
+                            tuple(x.items())
+                            for x in components_bracket_layers
+                            if x.items()
                         )
-                        i_have = set(tuple(x.items()) for x in my_bracket_layers)
+                        i_have = set(
+                            tuple(x.items()) for x in my_bracket_layers if x.items()
+                        )
                         needed = they_have - i_have
                         if needed:
                             problematic_glyphs[(glyph_name, master)] |= needed


### PR DESCRIPTION
So it turns out that #841 was caused by the fact that `[()]` is True, and so boxes were getting added to the list of layers to synthesise even if there wasn't actually any alternate-layer information in the layer. 