### PR TITLE
Fix glyph order for custom parameter with partial coverage

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -819,6 +819,12 @@ class GlyphOrderParamHandler(AbstractParamHandler):
         if glyphs.is_font():
             glyphs_glyphOrder = glyphs.get_custom_value("glyphOrder")
             if glyphs_glyphOrder:
+                ufo_glyphOrder = ufo.get_lib_value(PUBLIC_PREFIX + "glyphOrder")
+                # If the custom parameter provides partial coverage we want to
+                # append the original glyph order for uncovered glyphs.
+                glyphs_glyphOrder += [
+                    g for g in ufo_glyphOrder if g not in glyphs_glyphOrder
+                ]
                 ufo.set_lib_value(PUBLIC_PREFIX + "glyphOrder", glyphs_glyphOrder)
 
 

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -2640,3 +2640,10 @@ class TestGlyphOrder:
         ufo = self.from_glyphs(ufo_module)
         assert ["c", "xxx1", "a", "f", "xxx2"] == ufo.lib["public.glyphOrder"]
         assert GLYPHS_PREFIX + "glyphOrder" not in ufo.lib
+
+    def test_glyphs_to_ufo_with_partial_glyphOrder(self, ufo_module):
+        self.prepare(ufo_module)
+        self.font.customParameters["glyphOrder"] = ["xxx1", "f", "xxx2"]
+        ufo = self.from_glyphs(ufo_module)
+        assert ["xxx1", "f", "xxx2", "c", "a"] == ufo.lib["public.glyphOrder"]
+        assert GLYPHS_PREFIX + "glyphOrder" not in ufo.lib

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -68,7 +68,7 @@ def test_glyphs_to_designspace(filename: Path, caplog: Any) -> None:
             glyphsLib.build_masters(filename, tmp_dir, None, designspace_path=ds)
 
         reference_output_dir = filename.parent / filename.stem
-        report = diff_directories(tmp_dir, reference_output_dir)
+        report = diff_directories(reference_output_dir, tmp_dir)
         if report:
             print("".join(report))
         assert not report


### PR DESCRIPTION
When `glyphOrder` custom parameter is used with partial glyph coverage, Glyphs will use the .glyphs glyph order for the rest of the glyphs, while ufo2ft will sort the glyphs alphabetically. Fix this inconsistency by always making sure UFO `public.glyphOrder` has full coverage.