### PR TITLE
Make comments follow the specification (custom parameters)

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -644,9 +644,9 @@ class NameRecordParamHandler(AbstractParamHandler):
 
             try:
                 name_id = self.parse_decimal(identifiers[0])
-                platform_id = 3  # Unicode
-                encoding_id = 1  # Unicode
-                language_id = 0x49  # Windows English
+                platform_id = 3  # Windows
+                encoding_id = 1  # Unicode BMP
+                language_id = 0x49  # English, United States
 
                 if len(identifiers) >= 2:
                     platform_id = self.parse_decimal(identifiers[1])


### PR DESCRIPTION
According to the [specification], platform ID 3 is Windows, not Unicode. I have also synched the other comments with the specification. In the [handbook], it is sloppily written as follows, which could be the source of confusion:

> If not specified, platformID will be assumed as 3, and successively, encID as 1 (Unicode), and langID as 0×0049 (Windows English).

[handbook]: https://glyphsapp.com/media/pages/learn/3ec528a11c-1634835554/glyphs-3-handbook.pdf
[specification]: https://learn.microsoft.com/en-us/typography/opentype/spec/name#platform-ids