### PR TITLE
Make defaults follow the handbook (custom parameters)

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -653,9 +653,13 @@ class NameRecordParamHandler(AbstractParamHandler):
 
                 if len(identifiers) >= 3:
                     encoding_id = self.parse_decimal(identifiers[2])
+                elif platform_id == 1:
+                    encoding_id = 0
 
                 if len(identifiers) >= 4:
                     language_id = self.parse_decimal(identifiers[3])
+                elif platform_id == 1:
+                    language_id = 0
 
                 return {
                     "nameID": name_id,

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -509,15 +509,15 @@ class SetCustomParamsTestBase(object):
             {
                 "nameID": 2048,
                 "platformID": 1,
-                "encodingID": 1,
-                "languageID": 0x49,
+                "encodingID": 0,
+                "languageID": 0,
                 "string": "FOO",
             },
             {
                 "nameID": 4096,
                 "platformID": 1,
                 "encodingID": 2,
-                "languageID": 0x49,
+                "languageID": 0,
                 "string": "FOO",
             },
             {
@@ -543,8 +543,8 @@ class SetCustomParamsTestBase(object):
         font = glyphsLib.to_glyphs([self.ufo])
 
         self.assertEqual(font.customParameters[0].value, "1024 3 1 73; FOO; BAZ")
-        self.assertEqual(font.customParameters[1].value, "2048 1 1 73; FOO")
-        self.assertEqual(font.customParameters[2].value, "4096 1 2 73; FOO")
+        self.assertEqual(font.customParameters[1].value, "2048 1 0 0; FOO")
+        self.assertEqual(font.customParameters[2].value, "4096 1 2 0; FOO")
         self.assertEqual(font.customParameters[3].value, "8192 1 2 3; FOO")
         self.assertEqual(font.customParameters[4].value, "16384 60 1 73; BAZ")
 


### PR DESCRIPTION
According to the [handbook], when the platform ID is set to 1, the encoding ID and language ID assume zero values:

> If only platformID is specified as 1, then both encID and langID will be assumed as 0 (Mac Roman, and Mac English).

One slightly ambiguous case is what to do when not only the platform ID is set to 1 but also the encoding ID to some value. But it is arguably save to assume zero still.

[handbook]: https://glyphsapp.com/media/pages/learn/3ec528a11c-1634835554/glyphs-3-handbook.pdf