### PR TITLE
Fix a typo in the default behavior of naming-table entries

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -646,7 +646,7 @@ class NameRecordParamHandler(AbstractParamHandler):
                 name_id = self.parse_decimal(identifiers[0])
                 platform_id = 3  # Windows
                 encoding_id = 1  # Unicode BMP
-                language_id = 0x49  # English, United States
+                language_id = 0x409  # English, United States
 
                 if len(identifiers) >= 2:
                     platform_id = self.parse_decimal(identifiers[1])

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -504,7 +504,7 @@ class SetCustomParamsTestBase(object):
                 "nameID": 1024,
                 "platformID": 3,
                 "encodingID": 1,
-                "languageID": 0x49,
+                "languageID": 0x409,
                 "string": "FOO; BAZ",
             },
             {
@@ -532,7 +532,7 @@ class SetCustomParamsTestBase(object):
                 "nameID": 16384,
                 "platformID": 60,
                 "encodingID": 1,
-                "languageID": 0x49,
+                "languageID": 0x409,
                 "string": "BAZ",
             },
         ]
@@ -543,11 +543,11 @@ class SetCustomParamsTestBase(object):
 
         font = glyphsLib.to_glyphs([self.ufo])
 
-        self.assertEqual(font.customParameters[0].value, "1024 3 1 73; FOO; BAZ")
+        self.assertEqual(font.customParameters[0].value, "1024 3 1 1033; FOO; BAZ")
         self.assertEqual(font.customParameters[1].value, "2048 1 0 0; FOO")
         self.assertEqual(font.customParameters[2].value, "4096 1 2 0; FOO")
         self.assertEqual(font.customParameters[3].value, "8192 1 2 3; FOO")
-        self.assertEqual(font.customParameters[4].value, "16384 60 1 73; BAZ")
+        self.assertEqual(font.customParameters[4].value, "16384 60 1 1033; BAZ")
 
 
 class SetCustomParamsTestUfoLib2(SetCustomParamsTestBase, unittest.TestCase):


### PR DESCRIPTION
There is arguably the following error in both the Glyphs [handbook](https://glyphsapp.com/media/pages/learn/3ec528a11c-1634835554/glyphs-3-handbook.pdf) and the UI:

> If not specified, platformID will be assumed as 3, and successively, encID as 1 (Unicode), and langID as 0×0049 (Windows English).

It is meant to say that the language is set to 0x409. This is what Glyphs does upon export. Moreover, 0x49 is not a valid language ID as far as the [specification](https://learn.microsoft.com/en-us/typography/opentype/spec/name#windows-language-ids) is concerned.

/cc @schriftgestalt 