### PR TITLE
Use postscriptFontName from Glyphs format v3 when generating instances.

### DIFF
--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -71,6 +71,13 @@ def _to_designspace_instance(self, instance):
                 fname = self.instance_dir + "/" + fname
             ufo_instance.filename = fname
 
+    # Since Glyphs Format v3 the "postscriptFontName" property
+    # is stored in "properties" instead of "customParameters".
+    for p in instance.properties:
+        key, value = p.key, p.value
+        if key == "postscriptFontName":
+            ufo_instance.postScriptFontName = value
+
     # Read either from properties or custom parameter or the font
     ufo_instance.familyName = instance.familyName
     ufo_instance.styleName = instance.name


### PR DESCRIPTION
For compatibility with Adobe apps we maintain strict backwards compatibility for postscript names (name ID 6) in all our families. To achieve this, we explicitly set the `postscriptFontName` in UFO and Glyphs files. However, we noticed that for some fonts generated from Glyphs files the postscript name was auto generated regardless of the Glyphs `Font Name` setting.

It seems that in Glyphs v2 format, the `postscriptFontName` property was stored in `customParameters`, but for the Glyphs v3 format it is stored in `properties`. The code that generates instances only looks at `customParameters`, so any Glyphs format v3 file with a custom postscript name will receive an auto-generated postscript name instead.

This pull request modifies the instance generation code to also check the `properties` on each instance for the `postscriptFontName` property so that custom postscript names are respected for both Glyphs format v2 and v3.