### PR TITLE
Load all .glyphspackage glyphs

### DIFF
--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -104,11 +104,18 @@ def load_glyphspackage(package_dir):
     package = Path(package_dir)
     infofile = package / "fontinfo.plist"
     orderfile = package / "order.plist"
-    glyphorder = openstep_plist.load(open(orderfile, "r", encoding="utf-8"))
-    data = openstep_plist.load(open(infofile, "r", encoding="utf-8"), use_numbers=True)
+
+    glyphorder = []
+    if orderfile.exists():
+        with open(orderfile, "r", encoding="utf-8") as order_fh:
+            glyphorder = openstep_plist.load(order_fh)
+
+    with open(infofile, "r", encoding="utf-8") as info_fh:
+        data = openstep_plist.load(info_fh, use_numbers=True)
     data["glyphs"] = []
     for glyphfile in (package / "glyphs").glob("*.glyph"):
-        glyph = openstep_plist.load(open(glyphfile, "r"), use_numbers=True)
+        with open(glyphfile, "r") as fh:
+            glyph = openstep_plist.load(fh, use_numbers=True)
         data["glyphs"].append(glyph)
     # Sort according to glyphorder
 

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -111,15 +111,15 @@ def load_glyphspackage(package_dir):
         glyph = openstep_plist.load(open(glyphfile, "r"), use_numbers=True)
         data["glyphs"].append(glyph)
     # Sort according to glyphorder
-    data["glyphs"] = list(
-        sorted(
-            data["glyphs"],
-            key=lambda x: (
-                x["glyphname"] not in glyphorder,  # unknown glyphs at end
-                x["glyphname"] in glyphorder and glyphorder.index(x["glyphname"]),
-            ),
-        )
-    )
+
+    def sort_key(glyph):
+        glyphname = glyph["glyphname"]
+        if glyphname in glyphorder:
+            return (0, glyphorder.index(glyphname))
+        else:
+            return (1, glyphname)
+
+    data["glyphs"] = list(sorted(data["glyphs"], key=sort_key))
 
     return data
 

--- a/tests/data/GlyphsUnitTestSans3.glyphspackage/order.plist
+++ b/tests/data/GlyphsUnitTestSans3.glyphspackage/order.plist
@@ -8,6 +8,5 @@ m,
 n,
 a.sc,
 dieresis,
-_part.shoulder,
-_part.stem
+_part.shoulder
 )

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -22,6 +22,20 @@ def test_glyphspackage_load(datadir):
     font1 = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphs")))
     font1.DisplayStrings = ""  # glyphspackages, rather sensibly, don't store user state
     font2 = glyphsLib.load(str(datadir.join("GlyphsUnitTestSans3.glyphspackage")))
+    names = [glyph.name for glyph in font2.glyphs]
+    assert names == [
+        "A",
+        "Adieresis",
+        "a",
+        "adieresis",
+        "h",
+        "m",
+        "n",
+        "a.sc",
+        "dieresis",
+        "_part.shoulder",
+        "_part.stem",  # Deliberately removed from glyph order file
+    ]
     assert glyphsLib.dumps(font1) == glyphsLib.dumps(font2)
 
 


### PR DESCRIPTION
In https://github.com/googlefonts/glyphsLib/issues/846#issuecomment-1478023500, Georg said

> But was in really intended to load the .glif file based on the name? I thought that you should read all files and map them based off the name in the file?

This PR does that: loads all files in the `glyphspackage` directory and then reorders them based on the order in `order.plist`.