### PR TITLE
Treat unvarying smart components as ordinary components

### DIFF
--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -110,6 +110,11 @@ def to_ufo_smart_component(self, layer, component, pen):
             % (root.name, layer.name)
         )
 
+    if len(masters) == 1:
+        # Treat this as a dumb component.
+        pen.addComponent(component.name, component.transform)
+        return
+
     model = variation_model(root, masters, layer)
 
     # Determine the normalized location of the interpolant within the

--- a/tests/data/DumbSmarts.glyphs
+++ b/tests/data/DumbSmarts.glyphs
@@ -1,0 +1,273 @@
+{
+.appVersion = "3180";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+date = "2023-02-19 10:20:26 +0000";
+familyName = "Smart Glyph Compatibility";
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = "47D66DC4-73DB-4479-A054-050107B0D274";
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "B60047CA-AE91-4964-B836-8E776E828431";
+metricValues = (
+{
+over = 16;
+pos = 716;
+},
+{
+over = 16;
+pos = 716;
+},
+{
+over = 16;
+pos = 510;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -219;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+color = 4;
+glyphname = "lam-ar.swsh";
+layers = (
+{
+layerId = "47D66DC4-73DB-4479-A054-050107B0D274";
+shapes = (
+{
+closed = 1;
+nodes = (
+(1659,24,l),
+(1641,669,l),
+(1535,650,l),
+(1576,-75,l)
+);
+},
+{
+alignment = -1;
+piece = {
+Wide = 0;
+};
+pos = (0,-84);
+ref = _part.noon.swash;
+}
+);
+width = 1728.88333;
+},
+{
+layerId = "B60047CA-AE91-4964-B836-8E776E828431";
+shapes = (
+{
+closed = 1;
+nodes = (
+(1689,14,l),
+(1671,678,l),
+(1545,655,l),
+(1591,-89,l)
+);
+},
+{
+pos = (0,-158);
+ref = _part.noon.swash;
+}
+);
+width = 1758.55;
+}
+);
+production = uni0644.swsh;
+},
+{
+color = 1;
+export = 0;
+glyphname = _part.noon.swash;
+layers = (
+{
+layerId = "47D66DC4-73DB-4479-A054-050107B0D274";
+partSelection = {
+Wide = 1;
+};
+shapes = (
+{
+closed = 1;
+nodes = (
+(1122,-330,o),
+(1324,-282,o),
+(1481,-171,cs),
+(1609,-82,o),
+(1659,8,o),
+(1659,108,c),
+(1584,56,l),
+(1506,-59,o),
+(1273,-201,o),
+(938,-201,cs),
+(564,-201,o),
+(307,-80,o),
+(107,72,c),
+(50,1,l),
+(146,-93,o),
+(252,-165,o),
+(375,-218,cs),
+(557,-297,o),
+(751,-330,o),
+(924,-330,cs)
+);
+}
+);
+width = 1658.88333;
+},
+{
+layerId = "B60047CA-AE91-4964-B836-8E776E828431";
+partSelection = {
+Wide = 1;
+};
+shapes = (
+{
+closed = 1;
+nodes = (
+(1152,-284,o),
+(1355,-238,o),
+(1514,-121,cs),
+(1632,-33,o),
+(1689,58,o),
+(1689,171,c),
+(1597,112,l),
+(1529,7,o),
+(1296,-129,o),
+(967,-129,cs),
+(547,-129,o),
+(273,17,o),
+(118,145,c),
+(50,62,l),
+(155,-46,o),
+(271,-128,o),
+(413,-185,cs),
+(592,-257,o),
+(784,-284,o),
+(946,-284,cs)
+);
+}
+);
+width = 1688.55;
+}
+);
+partsSettings = (
+{
+bottomValue = 0;
+name = Wide;
+topValue = 100;
+}
+);
+script = arabic;
+}
+);
+instances = (
+{
+axesValues = (
+100
+);
+instanceInterpolations = {
+"47D66DC4-73DB-4479-A054-050107B0D274" = 2;
+"B60047CA-AE91-4964-B836-8E776E828431" = -1;
+};
+name = Thin;
+weightClass = 100;
+},
+{
+axesValues = (
+200
+);
+instanceInterpolations = {
+"47D66DC4-73DB-4479-A054-050107B0D274" = 1.66667;
+"B60047CA-AE91-4964-B836-8E776E828431" = -0.66667;
+};
+name = UltraLight;
+properties = (
+{
+key = styleMapFamilyNames;
+values = (
+{
+language = dflt;
+value = "Google Sans Persian UltraLight";
+}
+);
+},
+{
+key = postscriptFontName;
+value = "GoogleSansPersian-UltraLight";
+}
+);
+weightClass = 200;
+},
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+"47D66DC4-73DB-4479-A054-050107B0D274" = 1;
+};
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+instanceInterpolations = {
+"B60047CA-AE91-4964-B836-8E776E828431" = 1;
+};
+name = Bold;
+weightClass = 700;
+},
+{
+axesValues = (
+900
+);
+instanceInterpolations = {
+"47D66DC4-73DB-4479-A054-050107B0D274" = -0.66667;
+"B60047CA-AE91-4964-B836-8E776E828431" = 1.66667;
+};
+name = Black;
+weightClass = 900;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/smart_components_test.py
+++ b/tests/smart_components_test.py
@@ -17,7 +17,7 @@
 import pytest
 
 from fontTools.pens.areaPen import AreaPen
-from glyphsLib import to_ufos
+from glyphsLib import to_ufos, load
 from glyphsLib.classes import (
     GSFont,
     GSFontMaster,
@@ -217,3 +217,16 @@ def get_rectangle_data(ufo, glyph_name="a"):
     clockwise = pen.value < 0
 
     return (left, bottom, right - left, top - bottom), clockwise
+
+
+def test_smarts_with_one_master(datadir, ufo_module):
+    file = "DumbSmarts.glyphs"
+    with open(str(datadir.join(file)), encoding="utf-8") as f:
+        original_glyphs_font = load(f)
+
+    ufos = to_ufos(original_glyphs_font, ufo_module=ufo_module)
+
+    assert len(ufos[0]["lam-ar.swsh"].components) == 1
+    assert len(ufos[0]["lam-ar.swsh"]) == 1
+    assert len(ufos[1]["lam-ar.swsh"].components) == 1
+    assert len(ufos[1]["lam-ar.swsh"]) == 1


### PR DESCRIPTION
When there are smart components which are incorrectly set up (i.e. only one master, no variation), Glyphs treats these as ordinary components. GlyphsLib however does something strange that I don't understand - sometimes across a variable font, some masters have the components decomposed and others do not have them decomposed. This PR treats single-master smart components as ordinary components.

This may be an underlying problem with smart components and variability, as I presume they should just work fine with a single master, so I may be putting a band-aid over a deeper problem here. At the same time, there's no point building a variation model and doing all that stuff if nothing is actually going to vary anyway.

Test fails before fix and passes after.