### PR TITLE
Fall back from properties to custom parameters

### DIFF
--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -558,7 +558,7 @@ class SetCustomParamsTestDefcon(SetCustomParamsTestBase, unittest.TestCase):
     ufo_module = defcon
 
 
-def test_ufo_filename_custom_param(ufo_module):
+def test_ufo_filename(ufo_module):
     """Test that new-style UFO_FILENAME_CUSTOM_PARAM is written instead of
     (UFO_FILENAME_KEY|FULL_FILENAME_KEY)."""
     font = glyphsLib.GSFont(os.path.join(DATA, "UFOFilenameTest.glyphs"))
@@ -588,7 +588,7 @@ def test_ufo_filename_custom_param(ufo_module):
     assert ds_rt.instances[0].filename == "../build/instance_ufos/MyFont.ufo"
 
 
-def test_ufo_filename_custom_param_plus_legacy(ufo_module):
+def test_ufo_filename_with_legacy(ufo_module):
     """Test that new-style UFO_FILENAME_CUSTOM_PARAM overrides legacy
     (UFO_FILENAME_KEY|FULL_FILENAME_KEY)."""
     font = glyphsLib.GSFont(os.path.join(DATA, "UFOFilenameTest.glyphs"))
@@ -602,7 +602,7 @@ def test_ufo_filename_custom_param_plus_legacy(ufo_module):
     assert ds.instances[0].filename == "bbb.ufo"
 
 
-def test_ufo_filename_custom_param_instance_empty(ufo_module):
+def test_ufo_filename_with_instance_empty(ufo_module):
     font = glyphsLib.GSFont(os.path.join(DATA, "UFOFilenameTest.glyphs"))
     font.masters[0].customParameters[UFO_FILENAME_CUSTOM_PARAM] = "aaa.ufo"
     del font.instances[0].customParameters[UFO_FILENAME_CUSTOM_PARAM]
@@ -616,7 +616,7 @@ def test_ufo_filename_custom_param_instance_empty(ufo_module):
     assert ds.instances[0].filename == "instance_ufos/NewFont-Regular.ufo"
 
 
-def test_ufo_instance_parameters():
+def test_ufo_opentype_name_records():
     from glyphsLib.interpolation import apply_instance_data_to_ufo
 
     file = glyphsLib.GSFont(os.path.join(DATA, "UFOInstanceParametersTest.glyphs"))
@@ -639,7 +639,7 @@ def test_ufo_instance_parameters():
     assert len(space.instances) == 3
     for instance, name in zip(space.instances, ["Thin", "Regular", "Black"]):
         actual = instance.lib[glyphsLib.builder.constants.CUSTOM_PARAMETERS_KEY]
-        expected = [("Name Table Entry", f"43 0 4 0;{name} Instance")]
+        expected = [("Name Table Entry", f"43 0 4 0; {name} Instance")]
         assert actual == expected
 
         source = copy.deepcopy(space.sources[0])

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -616,11 +616,13 @@ def test_ufo_filename_with_instance_empty(ufo_module):
     assert ds.instances[0].filename == "instance_ufos/NewFont-Regular.ufo"
 
 
-def test_ufo_opentype_name_preferred_family_name():
+def test_ufo_opentype_name_preferred_family_subfamily_name():
     from glyphsLib.interpolation import apply_instance_data_to_ufo
 
     filenames = [
         "UFOInstanceParametersTestV2.glyphs",
+        # NOTE: In the format of version 3, the preferred family and subfamily
+        # names are not actually saved in custom paramters but properties.
         "UFOInstanceParametersTestV3.glyphs",
     ]
 
@@ -628,14 +630,17 @@ def test_ufo_opentype_name_preferred_family_name():
         file = glyphsLib.GSFont(os.path.join(DATA, filename))
         space = glyphsLib.to_designspace(file, minimal=True)
 
-        assert len(space.sources) == 2
-        assert len(space.instances) == 3
-        for instance in space.instances:
+        assert len(space.sources) == 2, filename
+        assert len(space.instances) == 3, filename
+        for instance, name in zip(space.instances, ["Thin", "Regular", "Black"]):
             source = copy.deepcopy(space.sources[0])
             apply_instance_data_to_ufo(source.font, instance, space)
 
             actual = source.font.info.openTypeNamePreferredFamilyName
             assert actual == "Typographic New Font", filename
+
+            actual = source.font.info.openTypeNamePreferredSubfamilyName
+            assert actual == f"Typographic {name}", filename
 
 
 def test_ufo_opentype_name_records():
@@ -650,7 +655,7 @@ def test_ufo_opentype_name_records():
         file = glyphsLib.GSFont(os.path.join(DATA, filename))
         space = glyphsLib.to_designspace(file, minimal=True)
 
-        assert len(space.sources) == 2
+        assert len(space.sources) == 2, filename
         for source in space.sources:
             actual = list(map(dict, source.font.info.openTypeNameRecords))
             expected = [
@@ -664,7 +669,7 @@ def test_ufo_opentype_name_records():
             ]
             assert actual == expected, filename
 
-        assert len(space.instances) == 3
+        assert len(space.instances) == 3, filename
         for instance, name in zip(space.instances, ["Thin", "Regular", "Black"]):
             source = copy.deepcopy(space.sources[0])
             apply_instance_data_to_ufo(source.font, instance, space)

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -616,20 +616,26 @@ def test_ufo_filename_with_instance_empty(ufo_module):
     assert ds.instances[0].filename == "instance_ufos/NewFont-Regular.ufo"
 
 
-def test_ufo_opentype_name_preferred_family_name_v2():
+def test_ufo_opentype_name_preferred_family_name():
     from glyphsLib.interpolation import apply_instance_data_to_ufo
 
-    file = glyphsLib.GSFont(os.path.join(DATA, "UFOInstanceParametersTestV2.glyphs"))
-    space = glyphsLib.to_designspace(file, minimal=True)
+    filenames = [
+        "UFOInstanceParametersTestV2.glyphs",
+        "UFOInstanceParametersTestV3.glyphs",
+    ]
 
-    assert len(space.sources) == 2
-    assert len(space.instances) == 3
-    for instance in space.instances:
-        source = copy.deepcopy(space.sources[0])
-        apply_instance_data_to_ufo(source.font, instance, space)
+    for filename in filenames:
+        file = glyphsLib.GSFont(os.path.join(DATA, filename))
+        space = glyphsLib.to_designspace(file, minimal=True)
 
-        actual = source.font.info.openTypeNamePreferredFamilyName
-        assert actual == "Typographic New Font"
+        assert len(space.sources) == 2
+        assert len(space.instances) == 3
+        for instance in space.instances:
+            source = copy.deepcopy(space.sources[0])
+            apply_instance_data_to_ufo(source.font, instance, space)
+
+            actual = source.font.info.openTypeNamePreferredFamilyName
+            assert actual == "Typographic New Font", filename
 
 
 def test_ufo_opentype_name_records_v2():

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -616,10 +616,26 @@ def test_ufo_filename_with_instance_empty(ufo_module):
     assert ds.instances[0].filename == "instance_ufos/NewFont-Regular.ufo"
 
 
-def test_ufo_opentype_name_records():
+def test_ufo_opentype_name_preferred_family_name_v2():
     from glyphsLib.interpolation import apply_instance_data_to_ufo
 
-    file = glyphsLib.GSFont(os.path.join(DATA, "UFOInstanceParametersTest.glyphs"))
+    file = glyphsLib.GSFont(os.path.join(DATA, "UFOInstanceParametersTestV2.glyphs"))
+    space = glyphsLib.to_designspace(file, minimal=True)
+
+    assert len(space.sources) == 2
+    assert len(space.instances) == 3
+    for instance in space.instances:
+        source = copy.deepcopy(space.sources[0])
+        apply_instance_data_to_ufo(source.font, instance, space)
+
+        actual = source.font.info.openTypeNamePreferredFamilyName
+        assert actual == "Typographic New Font"
+
+
+def test_ufo_opentype_name_records_v2():
+    from glyphsLib.interpolation import apply_instance_data_to_ufo
+
+    file = glyphsLib.GSFont(os.path.join(DATA, "UFOInstanceParametersTestV2.glyphs"))
     space = glyphsLib.to_designspace(file, minimal=True)
 
     assert len(space.sources) == 2
@@ -638,10 +654,6 @@ def test_ufo_opentype_name_records():
 
     assert len(space.instances) == 3
     for instance, name in zip(space.instances, ["Thin", "Regular", "Black"]):
-        actual = instance.lib[glyphsLib.builder.constants.CUSTOM_PARAMETERS_KEY]
-        expected = [("Name Table Entry", f"43 0 4 0; {name} Instance")]
-        assert actual == expected
-
         source = copy.deepcopy(space.sources[0])
         apply_instance_data_to_ufo(source.font, instance, space)
 

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -638,46 +638,52 @@ def test_ufo_opentype_name_preferred_family_name():
             assert actual == "Typographic New Font", filename
 
 
-def test_ufo_opentype_name_records_v2():
+def test_ufo_opentype_name_records():
     from glyphsLib.interpolation import apply_instance_data_to_ufo
 
-    file = glyphsLib.GSFont(os.path.join(DATA, "UFOInstanceParametersTestV2.glyphs"))
-    space = glyphsLib.to_designspace(file, minimal=True)
+    filenames = [
+        "UFOInstanceParametersTestV2.glyphs",
+        "UFOInstanceParametersTestV3.glyphs",
+    ]
 
-    assert len(space.sources) == 2
-    for source in space.sources:
-        actual = list(map(dict, source.font.info.openTypeNameRecords))
-        expected = [
-            {
-                "nameID": 42,
-                "platformID": 0,
-                "encodingID": 4,
-                "languageID": 0,
-                "string": "File",
-            },
-        ]
-        assert actual == expected
+    for filename in filenames:
+        file = glyphsLib.GSFont(os.path.join(DATA, filename))
+        space = glyphsLib.to_designspace(file, minimal=True)
 
-    assert len(space.instances) == 3
-    for instance, name in zip(space.instances, ["Thin", "Regular", "Black"]):
-        source = copy.deepcopy(space.sources[0])
-        apply_instance_data_to_ufo(source.font, instance, space)
+        assert len(space.sources) == 2
+        for source in space.sources:
+            actual = list(map(dict, source.font.info.openTypeNameRecords))
+            expected = [
+                {
+                    "nameID": 42,
+                    "platformID": 0,
+                    "encodingID": 4,
+                    "languageID": 0,
+                    "string": "File",
+                },
+            ]
+            assert actual == expected, filename
 
-        actual = list(map(dict, source.font.info.openTypeNameRecords))
-        expected = [
-            {
-                "nameID": 42,
-                "platformID": 0,
-                "encodingID": 4,
-                "languageID": 0,
-                "string": "File",
-            },
-            {
-                "nameID": 43,
-                "platformID": 0,
-                "encodingID": 4,
-                "languageID": 0,
-                "string": f"{name} Instance",
-            },
-        ]
-        assert actual == expected
+        assert len(space.instances) == 3
+        for instance, name in zip(space.instances, ["Thin", "Regular", "Black"]):
+            source = copy.deepcopy(space.sources[0])
+            apply_instance_data_to_ufo(source.font, instance, space)
+
+            actual = list(map(dict, source.font.info.openTypeNameRecords))
+            expected = [
+                {
+                    "nameID": 42,
+                    "platformID": 0,
+                    "encodingID": 4,
+                    "languageID": 0,
+                    "string": "File",
+                },
+                {
+                    "nameID": 43,
+                    "platformID": 0,
+                    "encodingID": 4,
+                    "languageID": 0,
+                    "string": f"{name} Instance",
+                },
+            ]
+            assert actual == expected, filename

--- a/tests/data/UFOInstanceParametersTest.glyphs
+++ b/tests/data/UFOInstanceParametersTest.glyphs
@@ -3,7 +3,7 @@
 customParameters = (
 {
 name = "Name Table Entry";
-value = "42 0 4 0;File";
+value = "42 0 4 0; File";
 },
 {
 name = Axes;
@@ -80,7 +80,7 @@ instances = (
 customParameters = (
 {
 name = "Name Table Entry";
-value = "43 0 4 0;Thin Instance";
+value = "43 0 4 0; Thin Instance";
 }
 );
 interpolationWeight = 0;
@@ -94,7 +94,7 @@ weightClass = Thin;
 customParameters = (
 {
 name = "Name Table Entry";
-value = "43 0 4 0;Regular Instance";
+value = "43 0 4 0; Regular Instance";
 }
 );
 interpolationWeight = 500;
@@ -108,7 +108,7 @@ name = Regular;
 customParameters = (
 {
 name = "Name Table Entry";
-value = "43 0 4 0;Black Instance";
+value = "43 0 4 0; Black Instance";
 }
 );
 interpolationWeight = 1000;

--- a/tests/data/UFOInstanceParametersTestV2.glyphs
+++ b/tests/data/UFOInstanceParametersTestV2.glyphs
@@ -81,6 +81,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Thin Instance";
+},
+{
+name = preferredFamilyName;
+value = "Typographic New Font";
 }
 );
 interpolationWeight = 0;
@@ -95,6 +99,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Regular Instance";
+},
+{
+name = preferredFamilyName;
+value = "Typographic New Font";
 }
 );
 interpolationWeight = 500;
@@ -109,6 +117,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Black Instance";
+},
+{
+name = preferredFamilyName;
+value = "Typographic New Font";
 }
 );
 interpolationWeight = 1000;

--- a/tests/data/UFOInstanceParametersTestV2.glyphs
+++ b/tests/data/UFOInstanceParametersTestV2.glyphs
@@ -85,6 +85,10 @@ value = "43 0 4 0; Thin Instance";
 {
 name = preferredFamilyName;
 value = "Typographic New Font";
+},
+{
+name = preferredSubfamilyName;
+value = "Typographic Thin";
 }
 );
 interpolationWeight = 0;
@@ -103,6 +107,10 @@ value = "43 0 4 0; Regular Instance";
 {
 name = preferredFamilyName;
 value = "Typographic New Font";
+},
+{
+name = preferredSubfamilyName;
+value = "Typographic Regular";
 }
 );
 interpolationWeight = 500;
@@ -121,6 +129,10 @@ value = "43 0 4 0; Black Instance";
 {
 name = preferredFamilyName;
 value = "Typographic New Font";
+},
+{
+name = preferredSubfamilyName;
+value = "Typographic Black";
 }
 );
 interpolationWeight = 1000;

--- a/tests/data/UFOInstanceParametersTestV3.glyphs
+++ b/tests/data/UFOInstanceParametersTestV3.glyphs
@@ -129,6 +129,15 @@ language = dflt;
 value = "Typographic New Font";
 }
 );
+},
+{
+key = preferredSubfamilyNames;
+values = (
+{
+language = dflt;
+value = "Typographic Thin";
+}
+);
 }
 );
 weightClass = 100;
@@ -157,6 +166,15 @@ language = dflt;
 value = "Typographic New Font";
 }
 );
+},
+{
+key = preferredSubfamilyNames;
+values = (
+{
+language = dflt;
+value = "Typographic Regular";
+}
+);
 }
 );
 },
@@ -181,6 +199,15 @@ values = (
 {
 language = dflt;
 value = "Typographic New Font";
+}
+);
+},
+{
+key = preferredSubfamilyNames;
+values = (
+{
+language = dflt;
+value = "Typographic Black";
 }
 );
 }

--- a/tests/data/UFOInstanceParametersTestV3.glyphs
+++ b/tests/data/UFOInstanceParametersTestV3.glyphs
@@ -1,0 +1,214 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Name Table Entry";
+value = "42 0 4 0; File";
+}
+);
+date = "2019-08-15 11:39:54 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+axesValues = (
+0
+);
+id = "F8C94C2E-1D94-453C-B1DE-0473CD97C963";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = Thin;
+userData = {
+com.schriftgestaltung.Glyphs.ufoFilename = MyFontMaster.ufo;
+};
+},
+{
+axesValues = (
+1000
+);
+id = m002;
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = Black;
+userData = {
+com.schriftgestaltung.Glyphs.ufoFilename = MyFontMaster.ufo;
+};
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2023-02-27 11:53:34 +0000";
+layers = (
+{
+layerId = "F8C94C2E-1D94-453C-B1DE-0473CD97C963";
+width = 600;
+},
+{
+layerId = m002;
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = space;
+lastChange = "2023-02-27 11:53:34 +0000";
+layers = (
+{
+layerId = "F8C94C2E-1D94-453C-B1DE-0473CD97C963";
+width = 600;
+},
+{
+layerId = m002;
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+0
+);
+customParameters = (
+{
+name = "Name Table Entry";
+value = "43 0 4 0; Thin Instance";
+}
+);
+instanceInterpolations = {
+"F8C94C2E-1D94-453C-B1DE-0473CD97C963" = 1;
+};
+name = Thin;
+properties = (
+{
+key = preferredFamilyNames;
+values = (
+{
+language = dflt;
+value = "Typographic New Font";
+}
+);
+}
+);
+weightClass = 100;
+},
+{
+axesValues = (
+500
+);
+customParameters = (
+{
+name = "Name Table Entry";
+value = "43 0 4 0; Regular Instance";
+}
+);
+instanceInterpolations = {
+"F8C94C2E-1D94-453C-B1DE-0473CD97C963" = 0.5;
+m002 = 0.5;
+};
+name = Regular;
+properties = (
+{
+key = preferredFamilyNames;
+values = (
+{
+language = dflt;
+value = "Typographic New Font";
+}
+);
+}
+);
+},
+{
+axesValues = (
+1000
+);
+customParameters = (
+{
+name = "Name Table Entry";
+value = "43 0 4 0; Black Instance";
+}
+);
+instanceInterpolations = {
+m002 = 1;
+};
+name = Black;
+properties = (
+{
+key = preferredFamilyNames;
+values = (
+{
+language = dflt;
+value = "Typographic New Font";
+}
+);
+}
+);
+weightClass = 900;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Given that `properties` always exists in `GSInstance`s, the conversion to UFO never considers `customParameters` as a source for preferred family names among others. Custom parameters, however, are the primary mechanism in version 2, which means the current code does not work for version 2.

This pull request proposes to always fall back to custom parameters.