### PR TITLE
Merge font selection flags from the font and instance

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -818,14 +818,14 @@ class OS2SelectionParamHandler(AbstractParamHandler):
         if not use_typo_metrics and not has_wws_name and unsupported_bits is None:
             return
 
-        selection_bits = []
+        selection_bits = ufo.get_info_value("openTypeOS2Selection") or []
         if use_typo_metrics:
             selection_bits.append(7)
         if has_wws_name:
             selection_bits.append(8)
         if unsupported_bits:
             selection_bits.extend(unsupported_bits)
-        ufo.set_info_value("openTypeOS2Selection", sorted(selection_bits))
+        ufo.set_info_value("openTypeOS2Selection", sorted(set(selection_bits)))
 
 
 register(OS2SelectionParamHandler())

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -692,3 +692,25 @@ def test_ufo_opentype_name_records():
                 },
             ]
             assert actual == expected, filename
+
+
+def test_ufo_opentype_os2_selection():
+    from glyphsLib.interpolation import apply_instance_data_to_ufo
+
+    filenames = [
+        "UFOInstanceParametersTestV2.glyphs",
+        "UFOInstanceParametersTestV3.glyphs",
+    ]
+
+    for filename in filenames:
+        file = glyphsLib.GSFont(os.path.join(DATA, filename))
+        space = glyphsLib.to_designspace(file, minimal=True)
+
+        assert len(space.sources) == 2, filename
+        assert len(space.instances) == 3, filename
+        for instance in space.instances:
+            source = copy.deepcopy(space.sources[0])
+            apply_instance_data_to_ufo(source.font, instance, space)
+
+            actual = source.font.info.openTypeOS2Selection
+            assert actual == [7, 8], filename

--- a/tests/data/UFOInstanceParametersTestV2.glyphs
+++ b/tests/data/UFOInstanceParametersTestV2.glyphs
@@ -1,9 +1,13 @@
 {
-.appVersion = "3151";
+.appVersion = "3186";
 customParameters = (
 {
 name = "Name Table Entry";
 value = "42 0 4 0; File";
+},
+{
+name = "Use Typo Metrics";
+value = 1;
 },
 {
 name = Axes;
@@ -83,6 +87,10 @@ name = "Name Table Entry";
 value = "43 0 4 0; Thin Instance";
 },
 {
+name = "Has WWS Names";
+value = 1;
+},
+{
 name = preferredFamilyName;
 value = "Typographic New Font";
 },
@@ -105,6 +113,10 @@ name = "Name Table Entry";
 value = "43 0 4 0; Regular Instance";
 },
 {
+name = "Has WWS Names";
+value = 1;
+},
+{
 name = preferredFamilyName;
 value = "Typographic New Font";
 },
@@ -125,6 +137,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Black Instance";
+},
+{
+name = "Has WWS Names";
+value = 1;
 },
 {
 name = preferredFamilyName;

--- a/tests/data/UFOInstanceParametersTestV3.glyphs
+++ b/tests/data/UFOInstanceParametersTestV3.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3151";
+.appVersion = "3186";
 .formatVersion = 3;
 axes = (
 {
@@ -11,6 +11,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "42 0 4 0; File";
+},
+{
+name = "Use Typo Metrics";
+value = 1;
 }
 );
 date = "2019-08-15 11:39:54 +0000";
@@ -114,6 +118,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Thin Instance";
+},
+{
+name = "Has WWS Names";
+value = 1;
 }
 );
 instanceInterpolations = {
@@ -150,6 +158,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Regular Instance";
+},
+{
+name = "Has WWS Names";
+value = 1;
 }
 );
 instanceInterpolations = {
@@ -186,6 +198,10 @@ customParameters = (
 {
 name = "Name Table Entry";
 value = "43 0 4 0; Black Instance";
+},
+{
+name = "Has WWS Names";
+value = 1;
 }
 );
 instanceInterpolations = {


### PR DESCRIPTION
When font selection flags are specified on the level of both the font (the tab) and instance, the ones in the former get discarded. This pull request switches from resetting to merging (union).