### PR TITLE
Support glyph property tokens

### DIFF
--- a/tests/data/TokenTest.glyphs
+++ b/tests/data/TokenTest.glyphs
@@ -19,7 +19,9 @@ name = Languagesystems;
 );
 features = (
 {
-code = "pos A A.sc ${padding*2};";
+code = "pos A A.sc ${padding*2};
+
+pos A Sacute ${Sacute:width/2};";
 tag = dist;
 }
 );
@@ -82,13 +84,41 @@ glyphs = (
 glyphname = A;
 kernLeft = H;
 kernRight = L;
-lastChange = "2021-01-14 12:22:21 +0000";
+lastChange = "2023-04-28 17:12:34 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (300,0);
+},
+{
+name = ogonek;
+pos = (540,10);
+},
+{
+name = top;
+pos = (300,700);
+}
+);
 layerId = m01;
 width = 600;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (300,0);
+},
+{
+name = ogonek;
+pos = (540,10);
+},
+{
+name = top;
+pos = (300,700);
+}
+);
 layerId = "11119B89-ADF6-486B-9172-E51437C3592A";
 width = 600;
 }
@@ -114,11 +144,11 @@ note = "I love it!";
 {
 category = Separator;
 glyphname = Sacute;
-lastChange = "2021-01-14 12:22:48 +0000";
+lastChange = "2023-04-28 17:52:32 +0000";
 layers = (
 {
 layerId = m01;
-width = 600;
+width = 300;
 },
 {
 layerId = "11119B89-ADF6-486B-9172-E51437C3592A";

--- a/tests/tokens_test.py
+++ b/tests/tokens_test.py
@@ -37,6 +37,26 @@ expander = TokenExpander(TESTFONT, master)
         (r"pos a ${padding + padding} b;", "pos a 500 b;", False),
         (r"pos a ${padding + (padding/2)} b;", "pos a 375 b;", False),
         ("pos a $xxx b;", "", True),
+        (r"pos A ${A.sc:width};", "pos A 600;", False),
+        (r"pos A ${A:width+1};", "pos A 601;", False),
+        (r"pos A ${A:width*-1};", "pos A -600;", False),
+        (r"pos A -${A:width};", "pos A -600;", False),
+        (r"pos A ${A:width*10};", "pos A 6000;", False),
+        (r"pos A ${A:width/10};", "pos A 60;", False),
+        (r"pos A ${A:width-10};", "pos A 590;", False),
+        (r"pos A ${A:width+width};", "pos A 1200;", False),
+        (r"pos A ${A:width+padding};", "pos A 850;", False),
+        (r"pos A ${A:length};", "", True),
+        # (r"pos A ${A:LSB}", "pos A 600;", False),
+        (r"pos A ${A:anchors.top.x};", "pos A 300;", False),
+        (r"pos A ${A:anchors.ogonek.y};", "pos A 10;", False),
+        (
+            r"pos A <${A:anchors.top.x} ${A:anchors.top.y} 0 0>;",
+            "pos A <300 700 0 0>;",
+            False,
+        ),
+        (r"pos A ${A:anchors.ogonek.z};", "", True),
+        (r"pos A ${A:anchors.center.x};", "", True),
         # Tests from Glyphs tutorial
         (
             "$[name endswith '.sc']",
@@ -103,3 +123,6 @@ def test_end_to_end():
 
     assert "pos A A.sc 100" in ufos[0].features.text
     assert "pos A A.sc 500" in ufos[1].features.text
+
+    assert "pos A Sacute 150" in ufos[0].features.text
+    assert "pos A Sacute 300" in ufos[1].features.text


### PR DESCRIPTION
See Glyphs 3 handbook.

Currently only width and anchors properties work, if our GSLayer starts supporting LSB, RSB, TSB, and BSB, they should magically work here as well.