### PR TITLE
Use fnmatch for LIKE comparison in tokens

### DIFF
--- a/Lib/glyphsLib/builder/tokens.py
+++ b/Lib/glyphsLib/builder/tokens.py
@@ -1,12 +1,11 @@
 import re
+import fnmatch
 from collections import OrderedDict
 
 
 def _like(got, expected):
-    expected = expected.replace("?", ".")
-    expected = expected.replace("*", ".*")
-    # Technically we should be a bit stricter than this
-    return re.match(expected, str(got))
+    # LIKE is similar to Unix shell-style wildcards supported by fnmatch
+    return fnmatch.fnmatch(str(got), expected)
 
 
 class TokenExpander:

--- a/tests/tokens_test.py
+++ b/tests/tokens_test.py
@@ -66,6 +66,10 @@ expander = TokenExpander(TESTFONT, master)
         ("$[not name endswith '.sc']", "A Sacute", False),
         ("$[name endswith '.sc' or not name endswith '.sc']", "A.sc A Sacute", False),
         ("$[name endswith '.sc' and not name endswith '.sc']", "", False),
+        ("$[name like 'A']", "A", False),
+        ("$[name like 'Sacut']", "", False),
+        ("$[name like 'S?cute']", "Sacute", False),
+        ("$[name like 'S*']", "Sacute", False),
         # ('$[layer0.width < 500]', "", False), # layer0 = first master
         # ('$[layers.count > 1]', "", False), # compare numbers with: == != <= >= < >
         # ('$[direction == 2]', "", False), # 0=LTR, 1=BiDi, 2=RTL


### PR DESCRIPTION
Using re.match() is too greedy, but fnmatch supports Unix shell-style wildcards that is similar to LIKE. The only difference is that fnmatch supports also [seq] and [!seq], but we can’t have square brackets in predicates anyway.