### PR TITLE
Normalize file format 3 brace layer names to legacy layer name format for writing to UFO

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -277,6 +277,11 @@ class UFOBuilder(LoggerMixin):
 
         # And sublayers (brace, bracket, ...) second.
         for glyph, layer in supplementary_layer_data:
+
+            # Normalize layer names from v3 attributes for writing to UFO
+            if "coordinates" in layer.attributes and layer._is_brace_layer():
+                layer.name = "{%s}" % ", ".join([str(v) for v in layer.attributes["coordinates"]])
+
             if (
                 layer.layerId not in master_layer_ids
                 and layer.associatedMasterId not in master_layer_ids


### PR DESCRIPTION
Possible fix for #851

I'm happy to refactor this bit of layer name normalizing to somewhere more appropriate, if there is such a spot. As mentioned in the issue, I reckon the same might be needed for other secondary layer types, e.g. brace.