### PR TITLE
Fix multiple custom parameters with the same name on GSFont

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1163,6 +1163,14 @@ class CustomParametersProxy(ListDictionaryProxy):
                 return self._owner.axes
         return super().__contains__(item)
 
+    def __setter__(self, items):
+        axes_params = [i for i in items if i.name == "Axes"]
+        for param in axes_params:
+            self._owner._set_axes_from_custom_parameter(param.value)
+
+        params = [i for i in items if i.name != "Axes"]
+        super().__setter__(params)
+
     def __iter__(self):
         for item in super().__iter__():
             yield item
@@ -4345,7 +4353,6 @@ class GSFont(GSBase):
         "classes": [],
         "features": [],
         "featurePrefixes": [],
-        "customParameters": [],
         "disablesAutomaticAlignment": False,
         "disablesNiceNames": False,
         "gridLength": 1,
@@ -4439,11 +4446,6 @@ class GSFont(GSBase):
             self.glyphs.append(l)
         return 0
 
-    def _parse_customParameters_dict(self, parser, value):
-        _customParameters = parser._parse(value, GSCustomParameter)
-        for cp in _customParameters:
-            self.customParameters[cp.name] = cp.value  # This will intercept axes
-
     def _parse_settings_dict(self, parser, settings):
         self.disablesAutomaticAlignment = bool(
             settings.get("disablesAutomaticAlignment", False)
@@ -4474,7 +4476,7 @@ class GSFont(GSBase):
         self.classes = copy.deepcopy(self._defaultsForName["classes"])
         self.features = copy.deepcopy(self._defaultsForName["features"])
         self.featurePrefixes = copy.deepcopy(self._defaultsForName["featurePrefixes"])
-        self.customParameters = copy.deepcopy(self._defaultsForName["customParameters"])
+        self.customParameters = []
         self.date = None
         self.disablesAutomaticAlignment = self._defaultsForName[
             "disablesAutomaticAlignment"
@@ -4826,6 +4828,7 @@ class GSFont(GSBase):
 
 GSFont._add_parsers(
     [
+        {"plist_name": "customParameters", "type": GSCustomParameter},
         {"plist_name": "unitsPerEm", "object_name": "upm"},
         {"plist_name": "gridLength", "object_name": "grid"},
         {"plist_name": "gridSubDivisions", "object_name": "gridSubDivision"},

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -727,3 +727,11 @@ def test_mutiple_params(ufo_module):
     assert font.customParameters[0].value == [{"Axis": "Spacing", "Location": 0}]
     assert font.customParameters[1].value == [{"Axis": "Spacing", "Location": -100}]
     assert font.customParameters[2].value == [{"Axis": "Spacing", "Location": 100}]
+
+    instance = font.instances[0]
+    assert len(instance.customParameters) == 2
+
+    assert all("Replace Feature" == c.name for c in instance.customParameters)
+
+    assert instance.customParameters[0].value == "ccmp;sub space by space;"
+    assert instance.customParameters[1].value == "liga;sub space space by space;"

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -714,3 +714,16 @@ def test_ufo_opentype_os2_selection():
 
             actual = source.font.info.openTypeOS2Selection
             assert actual == [7, 8], filename
+
+
+def test_mutiple_params(ufo_module):
+    """Test multiple custom parameters with the same name on GSFont."""
+
+    font = GSFont(os.path.join(DATA, "CustomPrametersTest.glyphs"))
+    assert len(font.customParameters) == 3
+
+    assert all("Virtual Master" == c.name for c in font.customParameters)
+
+    assert font.customParameters[0].value == [{"Axis": "Spacing", "Location": 0}]
+    assert font.customParameters[1].value == [{"Axis": "Spacing", "Location": -100}]
+    assert font.customParameters[2].value == [{"Axis": "Spacing", "Location": 100}]

--- a/tests/data/CustomPrametersTest.glyphs
+++ b/tests/data/CustomPrametersTest.glyphs
@@ -1,0 +1,65 @@
+{
+.appVersion = "3192";
+.formatVersion = 3;
+axes = (
+{
+name = Spacing;
+tag = SPAC;
+}
+);
+customParameters = (
+{
+name = "Virtual Master";
+value = (
+{
+Axis = Spacing;
+Location = 0;
+}
+);
+},
+{
+name = "Virtual Master";
+value = (
+{
+Axis = Spacing;
+Location = -100;
+}
+);
+},
+{
+name = "Virtual Master";
+value = (
+{
+Axis = Spacing;
+Location = 100;
+}
+);
+}
+);
+date = "2023-05-15 18:23:31 +0000";
+familyName = "Custom Prameters Test";
+fontMaster = (
+{
+axesValues = (
+0
+);
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/data/CustomPrametersTest.glyphs
+++ b/tests/data/CustomPrametersTest.glyphs
@@ -38,6 +38,24 @@ Location = 100;
 );
 date = "2023-05-15 18:23:31 +0000";
 familyName = "Custom Prameters Test";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+code = "";
+tag = ccmp;
+},
+{
+code = "";
+tag = liga;
+}
+);
 fontMaster = (
 {
 axesValues = (
@@ -57,6 +75,27 @@ width = 200;
 }
 );
 unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+0
+);
+customParameters = (
+{
+name = "Replace Feature";
+value = "ccmp;sub space by space;";
+},
+{
+name = "Replace Feature";
+value = "liga;sub space space by space;";
+}
+);
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
 }
 );
 unitsPerEm = 1000;


### PR DESCRIPTION
GSFont with multiple custom parameters with the same name would lose all of them except the last one. It seems some of the code introduced in f7b1e07b63e5a51a59eedbfd31d1df4b8af7f64f handles customParameters as a dictionary, but it is this GlyphsApp hybrid list/dictionary and can have multiple entries with the same name.

This fix restores setting custom parameters using
CustomParametersProxy.__setter__() and introduces the special handling of axes custom parameter to this function.