### PR TITLE
Store shape indices

### DIFF
--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -60,6 +60,7 @@ UFO_KERN_GROUP_PATTERN = re.compile("^public\\.kern([12])\\.(.*)$")
 LOCKED_GUIDE_NAME_SUFFIX = " [locked]"
 
 HINTS_LIB_KEY = GLYPHS_PREFIX + "hints"
+SHAPE_SIGNATURE_LIB_KEY = GLYPHLIB_PREFIX + "shapeSignature"
 
 SMART_COMPONENT_AXES_LIB_KEY = GLYPHS_PREFIX + "smartComponentAxes"
 

--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -60,7 +60,7 @@ UFO_KERN_GROUP_PATTERN = re.compile("^public\\.kern([12])\\.(.*)$")
 LOCKED_GUIDE_NAME_SUFFIX = " [locked]"
 
 HINTS_LIB_KEY = GLYPHS_PREFIX + "hints"
-SHAPE_SIGNATURE_LIB_KEY = GLYPHLIB_PREFIX + "shapeSignature"
+SHAPE_ORDER_LIB_KEY = GLYPHLIB_PREFIX + "shapeOrder"
 
 SMART_COMPONENT_AXES_LIB_KEY = GLYPHS_PREFIX + "smartComponentAxes"
 

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -18,7 +18,7 @@ import logging
 
 import glyphsLib.glyphdata
 
-from .. import GSLayer
+from .. import GSLayer, GSPath
 from .common import from_loose_ufo_time, to_ufo_time
 from .constants import (
     GLYPHLIB_PREFIX,
@@ -28,6 +28,7 @@ from .constants import (
     BRACKET_GLYPH_RE,
     BRACKET_GLYPH_SUFFIX_RE,
     SCRIPT_LIB_KEY,
+    SHAPE_SIGNATURE_LIB_KEY,
     ORIGINAL_WIDTH_KEY,
     BACKGROUND_WIDTH_KEY,
 )
@@ -162,6 +163,11 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
     self.to_ufo_hints(ufo_glyph, layer)  # .hints
     self.to_ufo_paths(ufo_glyph, layer)  # .paths
     self.to_ufo_components(ufo_glyph, layer)  # .components
+    # Store shape order for mixed glyphs
+    if layer.paths and layer.components:
+        ufo_glyph.lib[SHAPE_SIGNATURE_LIB_KEY] = "".join(
+            [("P" if isinstance(x, GSPath) else "C") for x in layer.shapes]
+        )
     self.to_ufo_glyph_anchors(ufo_glyph, layer.anchors)  # .anchors
     if self.is_vertical:
         self.to_ufo_glyph_height_and_vertical_origin(ufo_glyph, layer)  # below

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -488,6 +488,21 @@ def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):  # noqa: C901
 
     self.to_glyphs_paths(ufo_glyph, layer)
     self.to_glyphs_components(ufo_glyph, layer)
+
+    if SHAPE_SIGNATURE_LIB_KEY in ufo_glyph.lib:
+        # Reshuffle shapes array to match original shape order
+        new_shapes = []
+        path_counter = 0
+        comp_counter = 0
+        for sign in ufo_glyph.lib[SHAPE_SIGNATURE_LIB_KEY]:
+            if sign == "P":
+                new_shapes.append(layer.paths[path_counter])
+                path_counter += 1
+            else:
+                new_shapes.append(layer.components[comp_counter])
+                comp_counter += 1
+        layer.shapes = new_shapes
+
     self.to_glyphs_glyph_anchors(ufo_glyph, layer)
     self.to_glyphs_glyph_height_and_vertical_origin(ufo_glyph, master, layer)
 

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -28,7 +28,7 @@ from .constants import (
     BRACKET_GLYPH_RE,
     BRACKET_GLYPH_SUFFIX_RE,
     SCRIPT_LIB_KEY,
-    SHAPE_SIGNATURE_LIB_KEY,
+    SHAPE_ORDER_LIB_KEY,
     ORIGINAL_WIDTH_KEY,
     BACKGROUND_WIDTH_KEY,
 )
@@ -165,7 +165,7 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
     self.to_ufo_components(ufo_glyph, layer)  # .components
     # Store shape order for mixed glyphs
     if layer.paths and layer.components:
-        ufo_glyph.lib[SHAPE_SIGNATURE_LIB_KEY] = "".join(
+        ufo_glyph.lib[SHAPE_ORDER_LIB_KEY] = "".join(
             [("P" if isinstance(x, GSPath) else "C") for x in layer.shapes]
         )
     self.to_ufo_glyph_anchors(ufo_glyph, layer.anchors)  # .anchors
@@ -489,12 +489,12 @@ def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):  # noqa: C901
     self.to_glyphs_paths(ufo_glyph, layer)
     self.to_glyphs_components(ufo_glyph, layer)
 
-    if SHAPE_SIGNATURE_LIB_KEY in ufo_glyph.lib:
+    if SHAPE_ORDER_LIB_KEY in ufo_glyph.lib:
         # Reshuffle shapes array to match original shape order
         new_shapes = []
         path_counter = 0
         comp_counter = 0
-        for sign in ufo_glyph.lib[SHAPE_SIGNATURE_LIB_KEY]:
+        for sign in ufo_glyph.lib[SHAPE_ORDER_LIB_KEY]:
             if sign == "P":
                 new_shapes.append(layer.paths[path_counter])
                 path_counter += 1

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1105,16 +1105,24 @@ class LayerShapesProxy(IndexedObjectsProxy):
             raise KeyError
 
     def setter(self, values):
-        newvalues = list(
-            filter(lambda s: not isinstance(s, self._filter), self._owner._shapes)
-        )
+        if self._filter:
+            newvalues = list(
+                filter(lambda s: not isinstance(s, self._filter), self._owner._shapes)
+            )
+        else:
+            newvalues = []
         newvalues.extend(list(values))
         self._owner._shapes = newvalues
         for value in newvalues:
             value._parent = self._owner
 
     def values(self):
-        return list(filter(lambda s: isinstance(s, self._filter), self._owner._shapes))
+        if self._filter:
+            return list(
+                filter(lambda s: isinstance(s, self._filter), self._owner._shapes)
+            )
+        else:
+            return self._owner._shapes[:]
 
 
 class LayerHintsProxy(IndexedObjectsProxy):
@@ -3786,6 +3794,11 @@ class GSLayer(GSBase):
     components = property(
         lambda self: LayerComponentsProxy(self),
         lambda self, value: LayerComponentsProxy(self).setter(value),
+    )
+
+    shapes = property(
+        lambda self: LayerShapesProxy(self),
+        lambda self, value: LayerShapesProxy(self).setter(value),
     )
 
     guides = property(

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -636,7 +636,6 @@ class FontFontMasterProxy(Proxy):
                 glyph.layers.append(newLayer)
 
     def remove(self, FontMaster):
-
         # First remove all layers in all glyphs that reference this master
         for glyph in self._owner.glyphs:
             for layer in glyph.layers:
@@ -923,7 +922,7 @@ class GlyphLayerProxy(Proxy):
                 newLayers[layer.layerId] = layer
         else:
             raise TypeError
-        for (key, layer) in newLayers.items():
+        for key, layer in newLayers.items():
             self._owner._setupLayer(layer, key)
         self._owner._layers = newLayers
 
@@ -3837,7 +3836,6 @@ class GSLayer(GSBase):
         left, bottom, right, top = None, None, None, None
 
         for item in self.paths.values() + self.components.values():
-
             newLeft, newBottom, newWidth, newHeight = item.bounds
             newRight = newLeft + newWidth
             newTop = newBottom + newHeight

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -19,7 +19,7 @@ from fontTools.misc.transform import Transform
 from ufo2ft.filters import BaseFilter
 from ufoLib2.objects import Glyph
 
-from glyphsLib.builder.constants import HINTS_LIB_KEY
+from glyphsLib.builder.constants import HINTS_LIB_KEY, SHAPE_SIGNATURE_LIB_KEY
 
 
 try:
@@ -477,7 +477,19 @@ class CornerComponentsFilter(BaseFilter):
         todo_list = []
 
         for glyphs_cc in corner_components:
-            path_idx, node_idx = glyphs_cc["origin"]
+            shape_index, node_idx = glyphs_cc["origin"]
+            path_indices = {}
+            if SHAPE_SIGNATURE_LIB_KEY in glyph.lib:
+                # Map between shape index and path index
+                for ix, sign in enumerate(glyph.lib[SHAPE_SIGNATURE_LIB_KEY]):
+                    if sign == "P":
+                        path_indices[ix] = len(path_indices.keys())
+                if shape_index not in path_indices:
+                    raise ValueError(
+                        f"Could not find shape number {shape_index} in {glyph.name}"
+                    )
+            path_idx = path_indices.get(shape_index, shape_index)
+
             # We use font, not .glyphSet here because corner components
             # aren't normally exported
             if glyphs_cc["name"] not in self.context.font:

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -160,6 +160,8 @@ def point_on_seg_at_distance(seg, distance):
     else:
         start, end = aligned_seg
         if math.isclose(end[0], start[0]):
+            if math.isclose(end[1], start[1]):
+                return 0
             return distance / (end[1] - start[1])
         else:
             return distance / (end[0] - start[0])
@@ -428,6 +430,10 @@ class CornerComponentApplier:
             self.path,
             (self.target_node_ix + len(self.corner_path) - 1) % len(self.path),
         )
+
+        if not intersection:
+            # Something's probably wrong...
+            return
 
         if len(outstroke) == 2:
             (outstroke[0].x, outstroke[0].y) = otRound(intersection[0]), otRound(

--- a/Lib/glyphsLib/filters/cornerComponents.py
+++ b/Lib/glyphsLib/filters/cornerComponents.py
@@ -19,7 +19,7 @@ from fontTools.misc.transform import Transform
 from ufo2ft.filters import BaseFilter
 from ufoLib2.objects import Glyph
 
-from glyphsLib.builder.constants import HINTS_LIB_KEY, SHAPE_SIGNATURE_LIB_KEY
+from glyphsLib.builder.constants import HINTS_LIB_KEY, SHAPE_ORDER_LIB_KEY
 
 
 try:
@@ -485,9 +485,9 @@ class CornerComponentsFilter(BaseFilter):
         for glyphs_cc in corner_components:
             shape_index, node_idx = glyphs_cc["origin"]
             path_indices = {}
-            if SHAPE_SIGNATURE_LIB_KEY in glyph.lib:
+            if SHAPE_ORDER_LIB_KEY in glyph.lib:
                 # Map between shape index and path index
-                for ix, sign in enumerate(glyph.lib[SHAPE_SIGNATURE_LIB_KEY]):
+                for ix, sign in enumerate(glyph.lib[SHAPE_ORDER_LIB_KEY]):
                     if sign == "P":
                         path_indices[ix] = len(path_indices.keys())
                 if shape_index not in path_indices:

--- a/tests/data/ShapeOrder.glyphs
+++ b/tests/data/ShapeOrder.glyphs
@@ -1,0 +1,115 @@
+{
+.appVersion = "3195";
+.formatVersion = 3;
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(39,0,l),
+(239,0,l),
+(239,500,l),
+(39,500,l)
+);
+},
+{
+ref = _comp;
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+ref = _comp;
+},
+{
+closed = 1;
+nodes = (
+(39,0,l),
+(239,0,l),
+(239,500,l),
+(39,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 66;
+},
+{
+glyphname = _comp;
+lastChange = "2023-06-08 11:25:23 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-2,o),
+(441,81,o),
+(441,185,cs),
+(441,288,o),
+(358,371,o),
+(255,371,cs),
+(151,371,o),
+(68,288,o),
+(68,185,cs),
+(68,81,o),
+(151,-2,o),
+(255,-2,cs)
+);
+}
+);
+width = 600;
+}
+);
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -168,12 +168,12 @@ def test_glyphs3_shape_order(datadir, ufo_module):
 
     designspace = glyphsLib.to_designspace(original_glyphs_font, ufo_module=ufo_module)
     ufo = designspace.sources[0].font
-    assert "com.schriftgestaltung.Glyphs.shapeSignature" in ufo["A"].lib
-    assert "com.schriftgestaltung.Glyphs.shapeSignature" in ufo["B"].lib
-    assert "com.schriftgestaltung.Glyphs.shapeSignature" not in ufo["_comp"].lib
+    assert "com.schriftgestaltung.Glyphs.shapeOrder" in ufo["A"].lib
+    assert "com.schriftgestaltung.Glyphs.shapeOrder" in ufo["B"].lib
+    assert "com.schriftgestaltung.Glyphs.shapeOrder" not in ufo["_comp"].lib
 
-    assert ufo["A"].lib["com.schriftgestaltung.Glyphs.shapeSignature"] == "PC"
-    assert ufo["B"].lib["com.schriftgestaltung.Glyphs.shapeSignature"] == "CP"
+    assert ufo["A"].lib["com.schriftgestaltung.Glyphs.shapeOrder"] == "PC"
+    assert ufo["B"].lib["com.schriftgestaltung.Glyphs.shapeOrder"] == "CP"
 
     # Round trip
     round_trip = glyphsLib.to_glyphs([ufo])

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -1,6 +1,6 @@
 import glyphsLib
 import pytest
-from glyphsLib.classes import GSFont, GSFontMaster, GSAlignmentZone
+from glyphsLib.classes import GSFont, GSFontMaster, GSAlignmentZone, GSPath, GSComponent
 
 
 def test_metrics():
@@ -159,3 +159,25 @@ def test_glyphs3_rtl_kerning(datadir, ufo_module):
     # Check that groups within one font are identical after pruning
     assert first_derivative_ufos[0].groups == first_derivative_ufos[1].groups
     assert second_derivative_ufos[0].groups == second_derivative_ufos[1].groups
+
+
+def test_glyphs3_shape_order(datadir, ufo_module):
+    file = "ShapeOrder.glyphs"
+    with open(str(datadir.join(file)), encoding="utf-8") as f:
+        original_glyphs_font = glyphsLib.load(f)
+
+    designspace = glyphsLib.to_designspace(original_glyphs_font, ufo_module=ufo_module)
+    ufo = designspace.sources[0].font
+    assert "com.schriftgestaltung.Glyphs.shapeSignature" in ufo["A"].lib
+    assert "com.schriftgestaltung.Glyphs.shapeSignature" in ufo["B"].lib
+    assert "com.schriftgestaltung.Glyphs.shapeSignature" not in ufo["_comp"].lib
+
+    assert ufo["A"].lib["com.schriftgestaltung.Glyphs.shapeSignature"] == "PC"
+    assert ufo["B"].lib["com.schriftgestaltung.Glyphs.shapeSignature"] == "CP"
+
+    # Round trip
+    round_trip = glyphsLib.to_glyphs([ufo])
+    glyph_a = round_trip.glyphs["A"].layers[0]
+    glyph_b = round_trip.glyphs["B"].layers[0]
+    assert isinstance(glyph_a.shapes[0], GSPath)
+    assert isinstance(glyph_b.shapes[0], GSComponent)


### PR DESCRIPTION
This fixes #895. We do this by:

1) Providing a `.shapes` accessor on the GSLayer object, similar to Glyphs 3 API.
2) Storing a "shapes signature" in the UFO lib for mixed path/component glyphs. For example, if the shape order is "path 1, component 1, path 2, path 3, component 2", a signature will be stored in the layer's lib dictionary with the value `"PCPPC"`. 
3) Using this signature to re-arrange the `.shapes` array when loading UFOs back into Glyphs objects.
4) When processing a corner component, mapping the "shape index" (stored in the hints array) to the "path index" using the signature.