### PR TITLE
Send anchor userdata to objectlib

### DIFF
--- a/Lib/glyphsLib/builder/anchors.py
+++ b/Lib/glyphsLib/builder/anchors.py
@@ -16,7 +16,7 @@
 from glyphsLib.types import Point
 import uuid
 
-from ufo2ft.constants import OBJECT_LIBS_KEY
+from glyphsLib.builder.constants import OBJECT_LIBS_KEY
 
 __all__ = [
     "to_ufo_glyph_anchors",

--- a/Lib/glyphsLib/builder/anchors.py
+++ b/Lib/glyphsLib/builder/anchors.py
@@ -16,6 +16,8 @@
 from glyphsLib.types import Point
 import uuid
 
+from ufo2ft.constants import OBJECT_LIBS_KEY
+
 __all__ = [
     "to_ufo_glyph_anchors",
     "to_glyphs_glyph_anchors",
@@ -31,7 +33,9 @@ def to_ufo_glyph_anchors(self, glyph, anchors):
         if anchor.userData:
             identifier = str(uuid.uuid4()).upper()
             anchor_dict["identifier"] = identifier
-            glyph.lib.setdefault("public.objectLibs", {})[identifier] = dict(anchor.userData)
+            glyph.lib.setdefault(OBJECT_LIBS_KEY, {})[identifier] = dict(
+                anchor.userData
+            )
         glyph.appendAnchor(anchor_dict)
 
 

--- a/Lib/glyphsLib/builder/anchors.py
+++ b/Lib/glyphsLib/builder/anchors.py
@@ -14,6 +14,7 @@
 
 
 from glyphsLib.types import Point
+import uuid
 
 __all__ = [
     "to_ufo_glyph_anchors",
@@ -27,6 +28,10 @@ def to_ufo_glyph_anchors(self, glyph, anchors):
     for anchor in anchors:
         x, y = anchor.position
         anchor_dict = {"name": anchor.name, "x": x, "y": y}
+        if anchor.userData:
+            identifier = str(uuid.uuid4()).upper()
+            anchor_dict["identifier"] = identifier
+            glyph.lib.setdefault("public.objectLibs", {})[identifier] = dict(anchor.userData)
         glyph.appendAnchor(anchor_dict)
 
 

--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -16,6 +16,7 @@ import re
 
 PUBLIC_PREFIX = "public."
 GLYPH_ORDER_KEY = PUBLIC_PREFIX + "glyphOrder"
+OBJECT_LIBS_KEY = PUBLIC_PREFIX + "objectLibs"
 
 GLYPHS_PREFIX = "com.schriftgestaltung."
 GLYPHLIB_PREFIX = GLYPHS_PREFIX + "Glyphs."

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2830,6 +2830,7 @@ class GSAnchor(GSBase):
 
     def __init__(self, name=None, position=None):
         self.name = "" if name is None else name
+        self._userData = None
         if position is None:
             self.position = copy.deepcopy(self._defaultsForName["position"])
         else:
@@ -2844,10 +2845,16 @@ class GSAnchor(GSBase):
     def parent(self):
         return self._parent
 
+    userData = property(
+        lambda self: UserDataProxy(self),
+        lambda self, value: UserDataProxy(self).setter(value),
+    )
+
 
 GSAnchor._add_parsers(
     [
         {"plist_name": "pos", "object_name": "position", "converter": Point},
+        {"plist_name": "userData", "object_name": "_userData", "type": dict},
         {"plist_name": "position", "converter": Point},
     ]
 )


### PR DESCRIPTION
This goes part of the way to fixing #910. It saves any userData on an anchor to the glyph's objectlib dictionary. This allows us to later get at the contextual user data attached to the anchor and generate contextual mark lookups for it.

Ideally we should (a) allow userData on anything which can take a userData on the Glyphs side and serialise it, and (b) convert the UFO objectlibs back to Glyphs objects. But I don't need that today, and I am in a hurry. :-/