### PR TITLE
Do not set Unicode values for each layer in a color glyph.

### DIFF
--- a/Lib/glyphsLib/builder/color_layers.py
+++ b/Lib/glyphsLib/builder/color_layers.py
@@ -37,6 +37,9 @@ def _to_ufo_color_palette_layers(builder, master, layerMapping):
                 ufo_layer = builder.to_ufo_layer(glyph, masterLayer)
                 ufo_glyph = ufo_layer.newGlyph(layerGlyphName)
                 builder.to_ufo_glyph(ufo_glyph, layer, glyph)
+                # Remove Unicode mapping from each color layer to avoid
+                # duplicate entries.
+                ufo_glyph.unicodes = []
             colorLayers.append((layerGlyphName, colorId))
         layerMapping[glyph.name] = colorLayers
 

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1188,6 +1188,28 @@ def test_glyph_color_layers_components(ufo_module):
     assert len(ufo.layers["color.3"]["a"]) == 0
 
 
+def test_glyph_color_palette_layers_no_unicode_mapping(ufo_module):
+    font = generate_minimal_font()
+    glypha = add_glyph(font, "a")
+
+    glypha.unicode = "0061"
+
+    color0 = GSLayer()
+    color1 = GSLayer()
+    color0.name = "Color 0"
+    color1.name = "Color 1"
+
+    glypha.layers.append(color0)
+    glypha.layers.append(color1)
+
+    ds = to_designspace(font, ufo_module=ufo_module, minimal=True)
+    ufo = ds.sources[0].font
+
+    assert ufo["a"].unicode == 97
+    assert ufo["a.color0"].unicode is None
+    assert ufo["a.color1"].unicode is None
+
+
 def test_glyph_color_palette_layers_explode(ufo_module):
     font = generate_minimal_font()
     glypha = add_glyph(font, "a")


### PR DESCRIPTION
As described in #937, the current color layer implementation writes unicode values for each layer in a color glyph. Recent [fontmake fixes](https://github.com/googlefonts/ufo2ft/pull/739) now treat this as an error which prevents color fonts from building.

This changes `color_layers.py` to set the Unicode mapping on each layer-glyph in the color glyph to an empty list. It does this in `color_layers.py` rather than modifying the `builder.to_ufo_glyph` method because it seems highly specific to color layer-glyphs.

Fixes #937.