### PR TITLE
Allow brace layers with the same coordinates to have different associatedMasterId

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -113,6 +113,10 @@ class UFOBuilder(LoggerMixin):
         # indexed by master ID, the same order as masters in the source GSFont.
         self._sources = OrderedDict()
 
+        # Where to actually put brace layers
+        # (key, associatedMasterId) -> masterId
+        self._where_to_put_brace_layers = {}
+
         # Map Glyphs layer IDs to UFO layer names.
         self._layer_map = {}
 
@@ -318,7 +322,9 @@ class UFOBuilder(LoggerMixin):
             ):
                 continue
             else:
-                ufo_layer = self.to_ufo_layer(glyph, layer)  # .layers
+                # Brace layer
+                key = (layer._brace_layer_name(), tuple(layer._brace_coordinates()))
+                ufo_layer = self.to_ufo_layer(glyph, layer, masterId=self._where_to_put_brace_layers[key, layer.associatedLayerId])  # .layers
                 ufo_glyph = ufo_layer.newGlyph(glyph.name)
                 self.to_ufo_glyph(ufo_glyph, layer, layer.parent)  # .glyph
 

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -14,6 +14,7 @@
 
 
 from collections import OrderedDict, defaultdict
+import collections
 import os
 from textwrap import dedent
 from typing import Dict
@@ -116,6 +117,39 @@ class UFOBuilder(LoggerMixin):
         # Where to actually put brace layers
         # (key, associatedMasterId) -> masterId
         self._where_to_put_brace_layers = {}
+        # To construct a source layer, we need
+        # 1. The Designspace source filename and font object which holds the layer.
+        # 2. The (brace) layer name itself.
+        # 3. The location of the intermediate master in the design space.
+        # (For logging purposes, it's nice to know which glyphs contain the layer.)
+        #
+        # Note that a brace layer can be associated with different master layers (e.g. the
+        # 'a' can have a '{400}' brace layer associated with 'Thin', and 'b''s can be
+        # associte with 'Black').
+        # Also note that if a brace layer name has less values than there are axes, they
+        # are supposed to take on the values from the associated master as the missing
+        # values.
+        # First, collect all brace layers in the font and which glyphs and which masters
+        # they belong to.
+        layer_to_master_ids = collections.defaultdict(set)
+        for glyph in self.font.glyphs:
+            for layer in glyph.layers:
+                if layer._is_brace_layer():
+                    key = (layer._brace_layer_name(), tuple(layer._brace_coordinates()))
+                    layer_to_master_ids[key].add(layer.associatedMasterId)
+
+        # Next, insert the brace layers in a defined location in the existing designspace.
+        for key, master_ids in layer_to_master_ids.items():
+            # In a designspace, we can't create the brace layers with the same
+            # location under different UFOs because that would lead to several
+            # <source> elements with the same location. Instead we'll pick the first
+            # (after sorting) master and stick all the brace layers with the same
+            # key = location there.
+            # Redirect other masters who have brace layers at the same location to
+            # the "chosen" one.
+            master_id = sorted(master_ids)[0]
+            for other_master_id in master_ids:
+                self._where_to_put_brace_layers[key, other_master_id] = master_id
 
         # Map Glyphs layer IDs to UFO layer names.
         self._layer_map = {}

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -324,7 +324,7 @@ class UFOBuilder(LoggerMixin):
             else:
                 # Brace layer
                 key = (layer._brace_layer_name(), tuple(layer._brace_coordinates()))
-                ufo_layer = self.to_ufo_layer(glyph, layer, masterId=self._where_to_put_brace_layers[key, layer.associatedLayerId])  # .layers
+                ufo_layer = self.to_ufo_layer(glyph, layer, masterId=self._where_to_put_brace_layers[key, layer.associatedMasterId])  # .layers
                 ufo_glyph = ufo_layer.newGlyph(glyph.name)
                 self.to_ufo_glyph(ufo_glyph, layer, layer.parent)  # .glyph
 

--- a/Lib/glyphsLib/builder/layers.py
+++ b/Lib/glyphsLib/builder/layers.py
@@ -29,8 +29,8 @@ def to_ufo_color_layer_names(self, master, ufo):
             ]
 
 
-def to_ufo_layer(self, glyph, layer):
-    ufo_font = self._sources[layer.associatedMasterId or layer.layerId].font
+def to_ufo_layer(self, glyph, layer, masterId=None):
+    ufo_font = self._sources[masterId or layer.associatedMasterId or layer.layerId].font
 
     layer_name = layer.name
     # Give color layers better names


### PR DESCRIPTION
Glyphs.app allows brace layers with the same coordinates to have different associatedMasterId. The same situation is not allowed in Designspace + UFO (because you can't have 2 sources with the same location), so the idea for a fix is: for each brace layer location, select one UFO = designspace source that will receive all the brace layers for that location.

Related issue: https://github.com/googlefonts/glyphsLib/issues/925

NOTE: the code is very ugly, I was just exploring ideas of how to fix this. I marked as Draft for now.

Example that works without this patch:
* dollar
  * Regular
    * {401, 100}
  * Bold
* cent
  * Regular
    * {401, 100} -- good because {401, 100} is always associated to Regular
  * Bold

Example that needs this patch to work:
* dollar
  * Regular
    * {401, 100}
  * Bold
* cent
  * Regular
  * Bold
    * {401, 100} -- bad because the brace layers for /dollar and /cent have the same coordinates {401, 100} but are associated to different masters

