### PR TITLE
features: Do not include empty labels

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -78,7 +78,7 @@ def _is_manual_kern_feature(feature):
     return feature.name == "kern" and not feature.automatic
 
 
-def _to_ufo_features(
+def _to_ufo_features(  # noqa: C901
     font: GSFont,
     ufo: Font | None = None,
     generate_GDEF: bool = False,
@@ -143,9 +143,9 @@ def _to_ufo_features(
             for label in feature.labels:
                 langID = _to_name_langID(label["language"])
                 name = label["value"]
-                name = name.replace("\\", r"\005c").replace('"', r"\0022")
                 if name == "":
                     continue
+                name = name.replace("\\", r"\005c").replace('"', r"\0022")
                 if langID is None:
                     feature_names.append(f'  name "{name}";')
                 else:

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -140,16 +140,19 @@ def _to_ufo_features(
                     feature_names = ["featureNames {", f'  name "{name}";', "};"]
         elif font.format_version == 3 and feature.labels:
             feature_names = []
-            feature_names.append("featureNames {")
             for label in feature.labels:
                 langID = _to_name_langID(label["language"])
                 name = label["value"]
                 name = name.replace("\\", r"\005c").replace('"', r"\0022")
+                if name == "":
+                    continue
                 if langID is None:
                     feature_names.append(f'  name "{name}";')
                 else:
                     feature_names.append(f'  name 3 1 0x{langID:X} "{name}";')
-            feature_names.append("};")
+            if feature_names:
+                feature_names.insert(0, "featureNames {")
+                feature_names.append("};")
         if notes:
             lines.append("# notes:")
             lines.extend("# " + line for line in notes.splitlines())


### PR DESCRIPTION
In Glyphsapp, users can define names for Stylistic Sets.

<img width="1135" alt="Screenshot 2024-01-09 at 11 23 56" src="https://github.com/googlefonts/glyphsLib/assets/7525512/6b8acdb0-fec1-4432-b3d4-603ec1c911f3">


Currently, if a user doesn't add a name, GlyphsLib will export the stylistic set with an empty name.

This PR won't add empty names which mimics the behaviour of GlyphsApp's exporter.

I discovered this issue while checking https://github.com/google/fonts/pull/7104. Fontbakery is reporting that the font is missing nameIDs 256, 257 etc which stem from this issue, https://github.com/fonttools/fontbakery/issues/3671#issuecomment-1882830352