### PR TITLE
Build intermediate layers with non-intermediate components

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -28,6 +28,7 @@ from .constants import (
     FONT_CUSTOM_PARAM_PREFIX,
 )
 from .axes import WEIGHT_AXIS_DEF, WIDTH_AXIS_DEF, find_base_style, class_to_value
+from .transformations import TRANSFORMATIONS
 from glyphsLib.util import LoggerMixin
 
 
@@ -86,7 +87,7 @@ class UFOBuilder(LoggerMixin):
                    production, and unnecessary steps will be skipped.
         glyph_data -- A list of GlyphData.
         """
-        self.font = font
+        self.font = preflight_glyphs(font)
 
         if ufo_module is None:
             import ufoLib2 as ufo_module
@@ -409,6 +410,18 @@ class UFOBuilder(LoggerMixin):
         to_ufo_layer_user_data,
         to_ufo_node_user_data,
     )
+
+
+def preflight_glyphs(font):
+    # Run a set of transformations over a GSFont object to make
+    # it easier to convert to UFO; resolve all the "smart stuff".
+
+    # We could "font = copy.deepcopy(font)" here, since we'll be
+    # modifying the original. But that's a pain and we won't do it
+    # until someone complains.
+    for transform in TRANSFORMATIONS:
+        transform(font)
+    return font
 
 
 def filter_instances_by_family(instances, family_name=None):

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -28,7 +28,6 @@ from .constants import (
     FONT_CUSTOM_PARAM_PREFIX,
 )
 from .axes import WEIGHT_AXIS_DEF, WIDTH_AXIS_DEF, find_base_style, class_to_value
-from .transformations import TRANSFORMATIONS
 from glyphsLib.util import LoggerMixin
 
 
@@ -55,7 +54,9 @@ class UFOBuilder(LoggerMixin):
         """Create a builder that goes from Glyphs to UFO + designspace.
 
         Keyword arguments:
-        font -- The GSFont object to transform into UFOs
+        font -- The GSFont object to transform into UFOs. We expect this GSFont
+                object to have been pre-processed with
+                ``glyphsLib.builder.preflight_glyphs``.
         ufo_module -- A Python module to use to build UFO objects (you can pass
                       a custom module that has the same classes as ufoLib2 or
                       defcon to get instances of your own classes). Default: ufoLib2
@@ -87,7 +88,7 @@ class UFOBuilder(LoggerMixin):
                    production, and unnecessary steps will be skipped.
         glyph_data -- A list of GlyphData.
         """
-        self.font = preflight_glyphs(font)
+        self.font = font
 
         if ufo_module is None:
             import ufoLib2 as ufo_module
@@ -410,18 +411,6 @@ class UFOBuilder(LoggerMixin):
         to_ufo_layer_user_data,
         to_ufo_node_user_data,
     )
-
-
-def preflight_glyphs(font):
-    # Run a set of transformations over a GSFont object to make
-    # it easier to convert to UFO; resolve all the "smart stuff".
-
-    # We could "font = copy.deepcopy(font)" here, since we'll be
-    # modifying the original. But that's a pain and we won't do it
-    # until someone complains.
-    for transform in TRANSFORMATIONS:
-        transform(font)
-    return font
 
 
 def filter_instances_by_family(instances, family_name=None):

--- a/Lib/glyphsLib/builder/transformations/__init__.py
+++ b/Lib/glyphsLib/builder/transformations/__init__.py
@@ -1,0 +1,4 @@
+from .intermediate_layers import resolve_intermediate_components
+
+
+TRANSFORMATIONS = [resolve_intermediate_components]

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -4,6 +4,7 @@ import uuid
 from fontTools.varLib.models import VariationModel, normalizeValue
 
 from glyphsLib.classes import GSLayer, GSNode, GSPath
+from glyphsLib.builder.axes import get_regular_master
 
 
 logger = logging.getLogger(__name__)
@@ -30,11 +31,14 @@ def simple_variation_model(font):
     locations = [x.axes for x in font.masters]
     limits = {tag: (min(x), max(x)) for tag, x in zip(tags, (zip(*locations)))}
     master_locations = []
+    default_location = get_regular_master(font).axes
     for loc in locations:
         this_loc = {}
         for ix, axisTag in enumerate(tags):
             axismin, axismax = limits[axisTag]
-            this_loc[axisTag] = normalizeValue(loc[ix], (axismin, axismin, axismax))
+            this_loc[axisTag] = normalizeValue(
+                loc[ix], (axismin, default_location[ix], axismax)
+            )
         master_locations.append(this_loc)
     return VariationModel(master_locations, axisOrder=tags), limits
 

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -24,28 +24,6 @@ def resolve_intermediate_components(font):
                 components_with_intermediate_layers.add(glyph.name)
                 all_intermediate_locations.add(tuple(layer.attributes["coordinates"]))
 
-    # It's not clear to me that this is needed... (See #954)
-
-    # for glyph in font.glyphs:
-    #     # Just peek at first layer, assume compatibility
-    #     if not any(c.name in components_with_intermediate_layers for c in glyph.layers[0].components):
-    #         continue
-    #     for location in all_intermediate_locations:
-    #         if not any(list(location) == l.attributes.get("coordinates") for l in glyph.layers):
-    #             import IPython; IPython.embed()
-    #             logger.info("Adding intermediate layer at %s to %s", location, glyph.name)
-    #             layer = GSLayer()
-    #             layer.attributes["coordinates"] = location
-    #             layer.layerId = str(uuid.uuid4())
-    #             layer.associatedMasterId = glyph.layers[0].associatedMasterId
-    #             layer.name = glyph.layers[0].name
-    #             for ix, shape in enumerate(glyph.layers[0].shapes):
-    #                 if isinstance(shape, GSPath):
-    #                     layer.shapes.append(shape.clone())
-    #                 else:
-    #                     layer.shapes.append(shape.clone())
-    #             glyph.layers.append(layer)
-
 
 def simple_variation_model(font):
     tags = [axis.axisTag for axis in font.axes]

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -18,7 +18,7 @@ def resolve_intermediate_components(font):
                 # First, let's find glyphs with intermediate layers
                 # which have components which don't have intermediate layers
                 for shape in layer.components:
-                    check_component_has_sparse_layer(font, shape, layer)
+                    ensure_component_has_sparse_layer(font, shape, layer)
                 # Later we will check if everyone who uses me as a component
                 # has the same intermediate layers as I do
                 components_with_intermediate_layers.add(glyph.name)
@@ -39,7 +39,7 @@ def simple_variation_model(font):
     return VariationModel(master_locations, axisOrder=tags), limits
 
 
-def check_component_has_sparse_layer(font, component, parent_layer):
+def ensure_component_has_sparse_layer(font, component, parent_layer):
     tags = [axis.axisTag for axis in font.axes]
     model, limits = simple_variation_model(font)
     location = parent_layer.attributes["coordinates"]
@@ -82,8 +82,7 @@ def check_component_has_sparse_layer(font, component, parent_layer):
                 interpolate_path(all_shapes, model, normalized_location)
             )
         else:
-            # We should really interpolate the transformation matrix here
-            check_component_has_sparse_layer(font, shape, parent_layer)
+            ensure_component_has_sparse_layer(font, shape, parent_layer)
             layer.shapes.append(
                 interpolate_component(all_shapes, model, normalized_location)
             )

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -71,6 +71,8 @@ def check_component_has_sparse_layer(font, component, parent_layer):
     layer.layerId = str(uuid.uuid4())
     layer.associatedMasterId = parent_layer.associatedMasterId
     layer.name = parent_layer.name
+    all_widths = [l.width for l in componentglyph.layers if l._is_master_layer]
+    layer.width = model.interpolateFromMasters(normalized_location, all_widths)
     for ix, shape in enumerate(componentglyph.layers[0].shapes):
         all_shapes = [l.shapes[ix] for l in componentglyph.layers if l._is_master_layer]
         assert len(all_shapes) == len(font.masters)

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -11,8 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_intermediate_components(font):
-    components_with_intermediate_layers = set()
-    all_intermediate_locations = set()
     for glyph in font.glyphs:
         for layer in glyph.layers:
             if layer._is_brace_layer():
@@ -20,10 +18,6 @@ def resolve_intermediate_components(font):
                 # which have components which don't have intermediate layers
                 for shape in layer.components:
                     ensure_component_has_sparse_layer(font, shape, layer)
-                # Later we will check if everyone who uses me as a component
-                # has the same intermediate layers as I do
-                components_with_intermediate_layers.add(glyph.name)
-                all_intermediate_locations.add(tuple(layer._brace_coordinates()))
 
 
 def variation_model(font, locations):

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -41,9 +41,10 @@ def ensure_component_has_sparse_layer(font, component, parent_layer):
     master_locations = [x.axes for x in font.masters]
     _, limits = variation_model(font, master_locations)
     location = tuple(parent_layer._brace_coordinates())
+    default_location = get_regular_master(font).axes
     normalized_location = {
         axisTag: normalizeValue(
-            location[ix], (limits[axisTag][0], limits[axisTag][0], limits[axisTag][1])
+            location[ix], (limits[axisTag][0], default_location[ix], limits[axisTag][1])
         )
         for ix, axisTag in enumerate(tags)
     }

--- a/Lib/glyphsLib/builder/transformations/intermediate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/intermediate_layers.py
@@ -1,0 +1,135 @@
+import logging
+import uuid
+
+from fontTools.varLib.models import VariationModel, normalizeValue
+
+from glyphsLib.classes import GSLayer, GSNode, GSPath
+
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_intermediate_components(font):
+    components_with_intermediate_layers = set()
+    all_intermediate_locations = set()
+    for glyph in font.glyphs:
+        for layer in glyph.layers:
+            if "coordinates" in layer.attributes:
+                # First, let's find glyphs with intermediate layers
+                # which have components which don't have intermediate layers
+                for shape in layer.components:
+                    check_component_has_sparse_layer(font, shape, layer)
+                # Later we will check if everyone who uses me as a component
+                # has the same intermediate layers as I do
+                components_with_intermediate_layers.add(glyph.name)
+                all_intermediate_locations.add(tuple(layer.attributes["coordinates"]))
+
+    # It's not clear to me that this is needed... (See #954)
+
+    # for glyph in font.glyphs:
+    #     # Just peek at first layer, assume compatibility
+    #     if not any(c.name in components_with_intermediate_layers for c in glyph.layers[0].components):
+    #         continue
+    #     for location in all_intermediate_locations:
+    #         if not any(list(location) == l.attributes.get("coordinates") for l in glyph.layers):
+    #             import IPython; IPython.embed()
+    #             logger.info("Adding intermediate layer at %s to %s", location, glyph.name)
+    #             layer = GSLayer()
+    #             layer.attributes["coordinates"] = location
+    #             layer.layerId = str(uuid.uuid4())
+    #             layer.associatedMasterId = glyph.layers[0].associatedMasterId
+    #             layer.name = glyph.layers[0].name
+    #             for ix, shape in enumerate(glyph.layers[0].shapes):
+    #                 if isinstance(shape, GSPath):
+    #                     layer.shapes.append(shape.clone())
+    #                 else:
+    #                     layer.shapes.append(shape.clone())
+    #             glyph.layers.append(layer)
+
+
+def simple_variation_model(font):
+    tags = [axis.axisTag for axis in font.axes]
+    locations = [x.axes for x in font.masters]
+    limits = {tag: (min(x), max(x)) for tag, x in zip(tags, (zip(*locations)))}
+    master_locations = []
+    for loc in locations:
+        this_loc = {}
+        for ix, axisTag in enumerate(tags):
+            axismin, axismax = limits[axisTag]
+            this_loc[axisTag] = normalizeValue(loc[ix], (axismin, axismin, axismax))
+        master_locations.append(this_loc)
+    return VariationModel(master_locations, axisOrder=tags), limits
+
+
+def check_component_has_sparse_layer(font, component, parent_layer):
+    tags = [axis.axisTag for axis in font.axes]
+    model, limits = simple_variation_model(font)
+    location = parent_layer.attributes["coordinates"]
+    normalized_location = {
+        axisTag: normalizeValue(
+            location[ix], (limits[axisTag][0], limits[axisTag][0], limits[axisTag][1])
+        )
+        for ix, axisTag in enumerate(tags)
+    }
+    componentglyph = component.component
+    for layer in componentglyph.layers:
+        if layer.layerId == parent_layer.layerId:
+            return
+        if (
+            "coordinates" in layer.attributes
+            and layer.attributes["coordinates"] == location
+        ):
+            return
+
+    # We'll add the appropriate intermediate layer to the component, that'll fix it
+    logger.info(
+        "Adding intermediate layer to %s to support %s %s",
+        componentglyph.name,
+        parent_layer.parent.name,
+        parent_layer.name,
+    )
+    layer = GSLayer()
+    layer.attributes["coordinates"] = location
+    layer.layerId = str(uuid.uuid4())
+    layer.associatedMasterId = parent_layer.associatedMasterId
+    layer.name = parent_layer.name
+    for ix, shape in enumerate(componentglyph.layers[0].shapes):
+        all_shapes = [l.shapes[ix] for l in componentglyph.layers if l._is_master_layer]
+        assert len(all_shapes) == len(font.masters)
+        if isinstance(shape, GSPath):
+            # We are making big assumptions about compatibility here
+            layer.shapes.append(
+                interpolate_path(all_shapes, model, normalized_location)
+            )
+        else:
+            # We should really interpolate the transformation matrix here
+            check_component_has_sparse_layer(font, shape, parent_layer)
+            layer.shapes.append(
+                interpolate_component(all_shapes, model, normalized_location)
+            )
+    componentglyph.layers.append(layer)
+
+
+def interpolate_path(paths, model, location):
+    path = GSPath()
+    for master_nodes in zip(*[p.nodes for p in paths]):
+        node = GSNode()
+        node.type = master_nodes[0].type
+        node.smooth = master_nodes[0].smooth
+        xs = [n.position.x for n in master_nodes]
+        ys = [n.position.y for n in master_nodes]
+        node.position.x = model.interpolateFromMasters(location, xs)
+        node.position.y = model.interpolateFromMasters(location, ys)
+        path.nodes.append(node)
+    return path
+
+
+def interpolate_component(components, model, location):
+    component = components[0].clone()
+    if all(c.transform == component.transform for c in components):
+        return component
+    transforms = [c.transform for c in components]
+    for element in range(6):
+        values = [t[element] for t in transforms]
+        component.transform[element] = model.interpolateFromMasters(location, values)
+    return component

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3699,7 +3699,7 @@ class GSLayer(GSBase):
         return f'<{self.__class__.__name__} "{name}" ({parent})>'
 
     def __lt__(self, other):
-        if self.master and other.master and self.associatedMasterId == self.layerId:
+        if self.master and other.master and self._is_master_layer:
             return (
                 self.master.weightValue < other.master.weightValue
                 or self.master.widthValue < other.master.widthValue
@@ -3735,12 +3735,12 @@ class GSLayer(GSBase):
             return master
 
     @property
+    def _is_master_layer(self):
+        return self.associatedMasterId == self.layerId
+
+    @property
     def name(self):
-        if (
-            self.associatedMasterId
-            and self.associatedMasterId == self.layerId
-            and self.parent
-        ):
+        if self.associatedMasterId and self._is_master_layer and self.parent:
             master = self.parent.parent.masterForId(self.associatedMasterId)
             if master:
                 return master.name

--- a/tests/builder/preflight_test.py
+++ b/tests/builder/preflight_test.py
@@ -1,0 +1,9 @@
+import glyphsLib
+from glyphsLib.builder.transformations import resolve_intermediate_components
+
+
+def test_intermediates_with_components_without_intermediates(datadir):
+    font = glyphsLib.GSFont(str(datadir.join("ComponentsWithIntermediates.glyphs")))
+    assert len(font.glyphs["A"].layers) != len(font.glyphs["Astroke"].layers)
+    resolve_intermediate_components(font)
+    assert len(font.glyphs["A"].layers) == len(font.glyphs["Astroke"].layers)

--- a/tests/data/ComponentsWithIntermediates.glyphs
+++ b/tests/data/ComponentsWithIntermediates.glyphs
@@ -1,0 +1,359 @@
+{
+.appVersion = "3227";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+date = "2021-10-04 15:53:11 +0000";
+familyName = ComponentsWithIntermediates;
+fontMaster = (
+{
+axesValues = (
+90
+);
+id = "9FF96064-8718-4A86-A5C8-73C592101F67";
+metricValues = (
+{
+over = 6;
+pos = 760;
+},
+{
+over = 12;
+pos = 714;
+},
+{
+over = 11;
+pos = 536;
+},
+{
+over = -15;
+},
+{
+over = -16;
+pos = -240;
+},
+{
+over = -15;
+},
+{
+}
+);
+name = Regular;
+stemValues = (
+79,
+90
+);
+},
+{
+axesValues = (
+190
+);
+iconName = Bold;
+id = "0A718E2F-231D-484E-9433-16A5230D2CE8";
+metricValues = (
+{
+over = 6;
+pos = 760;
+},
+{
+over = 11;
+pos = 714;
+},
+{
+over = 10;
+pos = 553;
+},
+{
+over = -15;
+},
+{
+over = -16;
+pos = -240;
+},
+{
+over = -15;
+},
+{
+}
+);
+name = Bold;
+stemValues = (
+158,
+194
+);
+userData = {
+GSOffsetHorizontal = 16;
+GSOffsetKeepCompatible = 1;
+GSOffsetVertical = 9;
+com.github.googlei18n.ufo2ft.filters = (
+{
+name = flattenComponents;
+pre = 1;
+}
+);
+};
+}
+);
+glyphs = (
+{
+category = Letter;
+glyphname = A;
+kernLeft = A.right;
+kernRight = A.left;
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (363,0);
+},
+{
+name = center;
+pos = (363,358);
+},
+{
+name = top;
+pos = (363,714);
+},
+{
+name = topright;
+pos = (636,714);
+}
+);
+layerId = "0A718E2F-231D-484E-9433-16A5230D2CE8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(726,0,l),
+(490,717,l),
+(233,717,l),
+(0,0,l),
+(212,0,l),
+(248,134,l),
+(480,134,l),
+(515,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,292,l),
+(288,292,l),
+(319,409,ls),
+(331,456,o),
+(354,550,o),
+(363,599,c),
+(372,550,o),
+(399,447,o),
+(409,409,cs)
+);
+}
+);
+width = 726;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (324,0);
+},
+{
+name = center;
+pos = (319,358);
+},
+{
+name = top;
+pos = (318,714);
+},
+{
+name = topright;
+pos = (519,714);
+}
+);
+layerId = "9FF96064-8718-4A86-A5C8-73C592101F67";
+shapes = (
+{
+closed = 1;
+nodes = (
+(638,0,l),
+(360,717,l),
+(279,717,l),
+(0,0,l),
+(91,0,l),
+(176,221,l),
+(459,221,l),
+(545,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,301,l),
+(206,301,l),
+(287,517,ls),
+(295,540,o),
+(308,583,o),
+(318,624,c),
+(325,599,o),
+(346,533,o),
+(352,517,cs)
+);
+}
+);
+width = 639;
+}
+);
+script = latin;
+subCategory = Uppercase;
+unicode = 65;
+},
+{
+category = Letter;
+color = 10;
+glyphname = Astroke;
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (324,0);
+},
+{
+name = top;
+pos = (318,714);
+}
+);
+layerId = "9FF96064-8718-4A86-A5C8-73C592101F67";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,760,l),
+(142,-75,l),
+(209,-75,l),
+(499,760,l)
+);
+},
+{
+alignment = -1;
+ref = A;
+}
+);
+width = 639;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (345,0);
+},
+{
+name = top;
+pos = (345,714);
+}
+);
+associatedMasterId = "9FF96064-8718-4A86-A5C8-73C592101F67";
+attr = {
+coordinates = (
+151
+);
+};
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(457.52,760,l),
+(167.52,-75,l),
+(265.84,-75,l),
+(555.84,760,l)
+);
+}
+);
+};
+layerId = "05c7f3ac-c6d8-4d29-899b-2a10de32f922";
+name = "SemiBold (intermediate)";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,760,l),
+(156,-75,l),
+(253,-75,l),
+(543,760,l)
+);
+},
+{
+alignment = -1;
+ref = A;
+}
+);
+width = 690;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (363,0);
+},
+{
+name = top;
+pos = (363,714);
+}
+);
+layerId = "0A718E2F-231D-484E-9433-16A5230D2CE8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,760,l),
+(186,-75,l),
+(307,-75,l),
+(597,760,l)
+);
+},
+{
+alignment = -1;
+ref = A;
+}
+);
+width = 730;
+}
+);
+script = latin;
+subCategory = Uppercase;
+unicode = 570;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+filter = "case == 3";
+type = "x-height";
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 2;
+versionMinor = 13;
+}


### PR DESCRIPTION
This is kind of the inverse of #954. If an ~alternate~ intermediate layer references a component, and that component does not have a matching intermediate layer, glyphsLib currently generates a "too sparse" master. In the test file in this PR, `Aslash` has an intermediate layer but it uses a component glyph `A` which does not have that intermediate layer. Sometimes the resulting UFO file for the sparse master can't be compiled, because the referenced component `A` is missing; sometimes it can be compiled but there is no variation:

```
INFO:ufo2ft.filters:Running DecomposeComponentsFilter on ComponentsWithIntermediates-Regular-{151}
WARNING:ufo2ft.util:dropping non-existent component 'A' in glyph 'Astroke'
...
WARNING:fontTools.varLib:glyph Astroke has incompatible masters; skipping
```

There are two ways this could be addressed - we could interpolate and decompose the component, or we could make the sparse master a bit less sparse by interpolating the referenced layer. I've taken the second approach because (a) it's simpler, and (b) keeping components where possible can lead to smaller file sizes.

This also introduces a new way of preparing Glyphs files for Glyphs->UFO translation; we now have a `preflight_glyphs` function which runs a list of translations, progressively "dumbifying" all the smart stuff in the `GSFont` object. Currently this is only used for the current job (de-sparsifying overly sparse masters), but in the future, we could use this to simplify some of the more gnarly translations we do in compilation, especially those requiring Glyphs-specific ufo2ft plugins. (i.e. EraseOpenCorners, CornerComponents, etc.)