### PR TITLE
Fix color component layers

### DIFF
--- a/Lib/glyphsLib/builder/components.py
+++ b/Lib/glyphsLib/builder/components.py
@@ -58,6 +58,7 @@ def to_ufo_components(self, ufo_glyph, layer):
             component_glyph = font.glyphs[component_name]
             color_layers = [
                 l for l in component_glyph.layers if l._is_color_palette_layer()
+                and l.associatedMasterId == layer.associatedMasterId
             ]
             for i, l in enumerate(color_layers):
                 if l._color_palette_index() == layer._color_palette_index():


### PR DESCRIPTION
This is a tiny fix for #973. In `components.py` we gather a list of color layers and take the index to get the new component name, like so:

https://github.com/googlefonts/glyphsLib/blob/ed02363c5e2d53294fc7a49992df2da5006f5f2e/Lib/glyphsLib/builder/components.py#L59-L68

We do this because we do the same operation in `_to_ufo_color_palette_layers` to rename the glyphs:

https://github.com/googlefonts/glyphsLib/blob/ed02363c5e2d53294fc7a49992df2da5006f5f2e/Lib/glyphsLib/builder/color_layers.py#L184-L194

However, the list which we take the index from *there* is actually built here:

https://github.com/googlefonts/glyphsLib/blob/ed02363c5e2d53294fc7a49992df2da5006f5f2e/Lib/glyphsLib/builder/glyph.py#L257-L262

So in `components.py` we need to make sure we are building the same list by also testing for `l.associatedMasterId == layer.associatedMasterId`.