### PR TITLE
[anchor_propagation] fix issue adjusting mark component anchor

### DIFF
--- a/Lib/glyphsLib/builder/anchor_propagation.py
+++ b/Lib/glyphsLib/builder/anchor_propagation.py
@@ -110,10 +110,17 @@ def _adjust_anchors(anchor_data, ufo, parent, component):
     t = Transform(*component.transformation)
     _componentAnchor = _componentAnchorFromLib(parent, component)
     for anchor in glyph.anchors:
+        if anchor.name.startswith("_"):
+            # only base anchors should get propagated
+            continue
         # adjust either if component is attached to a specific named anchor
         # (e.g. top_2 for a ligature glyph)
         # rather than to the standard anchors (top/bottom)
-        if _componentAnchor and _componentAnchor in anchor_data:
+        if (
+            _componentAnchor is not None
+            and _componentAnchor.startswith(anchor.name + "_")
+            and _componentAnchor in anchor_data
+        ):
             anchor_data[_componentAnchor] = t.transformPoint((anchor.x, anchor.y))
         # ... or this anchor has data and the component also contains
         # the associated mark anchor (e.g. "_top" for "top") ...

--- a/Lib/glyphsLib/builder/anchor_propagation.py
+++ b/Lib/glyphsLib/builder/anchor_propagation.py
@@ -101,32 +101,33 @@ def _componentAnchorFromLib(_glyph, _targetComponent):
                 and _anchorLib["name"] == _targetComponent.baseGlyph
                 and _anchorLib["index"] == _glyph.components.index(_targetComponent)
             ):
-                return _anchorLib["anchor"]
+                return _anchorLib["anchor"] or None
+    return None
 
 
 def _adjust_anchors(anchor_data, ufo, parent, component):
     """Adjust anchors to which a mark component may have been attached."""
     glyph = ufo[component.baseGlyph]
+    anchor_names = {a.name for a in glyph.anchors}
     t = Transform(*component.transformation)
-    _componentAnchor = _componentAnchorFromLib(parent, component)
-    for anchor in glyph.anchors:
-        if anchor.name.startswith("_"):
-            # only base anchors should get propagated
-            continue
+    component_anchor = _componentAnchorFromLib(parent, component)
+    # ignore the component's named anchor if we don't have it
+    if component_anchor not in anchor_data:
+        component_anchor = None
+    # For each base anchor in the mark component glyph
+    for anchor in (a for a in glyph.anchors if not a.name.startswith("_")):
         # adjust either if component is attached to a specific named anchor
         # (e.g. top_2 for a ligature glyph)
         # rather than to the standard anchors (top/bottom)
         if (
-            _componentAnchor is not None
-            and _componentAnchor.startswith(anchor.name + "_")
-            and _componentAnchor in anchor_data
+            component_anchor
+            and component_anchor.startswith(anchor.name + "_")
+            and "_" + anchor.name in anchor_names
         ):
-            anchor_data[_componentAnchor] = t.transformPoint((anchor.x, anchor.y))
+            anchor_data[component_anchor] = t.transformPoint((anchor.x, anchor.y))
         # ... or this anchor has data and the component also contains
         # the associated mark anchor (e.g. "_top" for "top") ...
-        elif anchor.name in anchor_data and any(
-            a.name == "_" + anchor.name for a in glyph.anchors
-        ):
+        elif anchor.name in anchor_data and "_" + anchor.name in anchor_names:
             anchor_data[anchor.name] = t.transformPoint((anchor.x, anchor.y))
 
 

--- a/tests/data/AnchorPropagation.glyphs
+++ b/tests/data/AnchorPropagation.glyphs
@@ -1371,13 +1371,13 @@ layers = (
 {
 anchors = (
 {
+name = top;
+position = "{129, 252}";
+},
+{
 name = _top;
 position = "{130, -70}";
 },
-{
-name = top;
-position = "{129, 252}";
-}
 );
 components = (
 {


### PR DESCRIPTION
In anchor_propagation.py, we have code (added by @yanone in https://github.com/googlefonts/glyphsLib/pull/617) to adjust propagated anchor position when a mark component is anchored to a specific named anchor as specified in the ComponentInfo lib key (this can be used to specify which of the seveal ligature anchors the given component is supposed to be attached to e.g. top_1, top_2 etc). 

The code indiscriminately applies the adjustment inside a for loop, without checking the anchor names match the expected component anchor.

I modified one of the AnchorPropagation.glyphs test file by changing the order of anchors in a mark glyph used as component in order to trigger a failure (anchor order is itself meaningless, it only happened to work before because the last anchor was the right one).
I will follow up with a fix