### PR TITLE
Export variable instances as DSv5 variable-fonts

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -1062,7 +1062,7 @@ class RenameGlyphsParamHandler(AbstractParamHandler):
 register(RenameGlyphsParamHandler())
 
 
-def to_ufo_custom_params(self, ufo, glyphs_object):
+def to_ufo_custom_params(self, ufo, glyphs_object, set_default_params=True):
     # glyphs_module=None because we shouldn't instanciate any Glyphs classes
     glyphs_proxy = GlyphsObjectProxy(glyphs_object, glyphs_module=None)
     ufo_proxy = UFOProxy(ufo)
@@ -1076,7 +1076,8 @@ def to_ufo_custom_params(self, ufo, glyphs_object):
         name = _normalize_custom_param_name(param.name)
         ufo.lib[CUSTOM_PARAM_PREFIX + glyphs_proxy.sub_key + name] = param.value
 
-    _set_default_params(ufo)
+    if set_default_params:
+        _set_default_params(ufo)
 
 
 def to_glyphs_custom_params(self, ufo, glyphs_object):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3372,6 +3372,8 @@ class GSInstance(GSBase):
 
     # v2 compatibility
     def _get_axis_value(self, index):
+        if self.type == InstanceType.VARIABLE:
+            return None
         if index < len(self.axes):
             return self.axes[index]
         if index < len(self._axis_defaults):

--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -667,10 +667,8 @@ def test_axis_with_no_mapping_does_not_error_in_roundtrip_with_2_axes(ufo_module
 
 
 def test_variable_instance(ufo_module):
-    """Glyphs 3 introduced a so-called "variable" instance which is a
-    pseudo-instance that holds various VF settings.
-    This messed with the instance_mapping creation as it would overwrite the designLoc
-    of a default instance of an axis back to 0.
+    """Glyphs 3 introduced a "variable" instance which is a special instance
+    that holds various VF settings. We export it to Design Space variable-font.
     """
     source_path = os.path.join("tests", "data", "VariableInstance.glyphs")
     font = GSFont(source_path)
@@ -680,6 +678,21 @@ def test_variable_instance(ufo_module):
     assert doc.axes[0].map[2] == (400, 80)
     assert doc.axes[0].default == 400
     assert len(doc.instances) == 27  # The VF setting should not be in the DS
+
+    assert len(doc.variableFonts) == 1
+
+    varfont = doc.variableFonts[0]
+    assert len(varfont.axisSubsets) == len(doc.axes)
+    assert "public.fontInfo" in varfont.lib
+
+    info = varfont.lib["public.fontInfo"]
+    assert len(info.get("openTypeNameRecords")) == 1
+    assert info["openTypeNameRecords"][0].string == "Variable"
+    assert info["openTypeNameRecords"][0].nameID == 1
+    assert info["openTypeNameRecords"][0].platformID == 1
+    assert info["openTypeNameRecords"][0].languageID == 0
+    assert info["openTypeNameRecords"][0].encodingID == 0
+    assert info.get("openTypeNamePreferredFamilyName") == "Cairo Variable"
 
 
 def test_virtual_masters_extend_min_max_for_unmapped_axis(ufo_module, datadir):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -40,6 +40,7 @@ from glyphsLib.classes import (
     GSPath,
     GSSmartComponentAxis,
     GSBackgroundImage,
+    InstanceType,
     segment,
     LayerComponentsProxy,
     LayerGuideLinesProxy,
@@ -185,6 +186,20 @@ class GSFontTest(unittest.TestCase):
         master = GSFontMaster()
         font.masters.append(master)
         self.assertEqual(master.font, font)
+
+
+class GSInstanceTest(unittest.TestCase):
+    def test_variable_instance(self):
+        instance = GSInstance()
+        instance.name = "Variable"
+        instance.type = InstanceType.VARIABLE
+
+        assert instance.weightValue is None
+        assert instance.widthValue is None
+        assert instance.customValue is None
+        assert instance.customValue1 is None
+        assert instance.customValue2 is None
+        assert instance.customValue3 is None
 
 
 class GSObjectsTestCase(unittest.TestCase):

--- a/tests/data/VariableInstance.glyphs
+++ b/tests/data/VariableInstance.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3139";
+.appVersion = "3234";
 .formatVersion = 3;
 axes = (
 {
@@ -777,13 +777,6 @@ name = "ExtraBlack Slant Left";
 weightClass = 1000;
 },
 {
-axesValues = (
-0,
-0
-);
-instanceInterpolations = {
-"459CA063-FA7D-4205-A795-7B6CE244EAAB" = 1;
-};
 name = Regular;
 type = variable;
 }
@@ -832,19 +825,6 @@ key = designerURL;
 value = "https://gaber.design";
 },
 {
-key = manufacturers;
-values = (
-{
-language = dflt;
-value = "Kief Type Foundry, Accademia di Belle Arti di Urbino";
-}
-);
-},
-{
-key = manufacturerURL;
-value = "https://gaber.design";
-},
-{
 key = licenses;
 values = (
 {
@@ -858,8 +838,21 @@ key = licenseURL;
 value = "http://scripts.sil.org/OFL";
 },
 {
+key = manufacturers;
+values = (
+{
+language = dflt;
+value = "Kief Type Foundry, Accademia di Belle Arti di Urbino";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "https://gaber.design";
+},
+{
 key = vendorID;
-value = "1KTF";
+value = 1KTF;
 }
 );
 settings = {

--- a/tests/data/VariableInstance.glyphs
+++ b/tests/data/VariableInstance.glyphs
@@ -777,7 +777,24 @@ name = "ExtraBlack Slant Left";
 weightClass = 1000;
 },
 {
-name = Regular;
+customParameters = (
+{
+name = "Name Table Entry";
+value = "1 1 0 0; Variable";
+}
+);
+name = Variable;
+properties = (
+{
+key = preferredFamilyNames;
+values = (
+{
+language = dflt;
+value = "Cairo Variable";
+}
+);
+}
+);
 type = variable;
 }
 );


### PR DESCRIPTION
Export Glyphs 3 as DesignSpace v5 variable-fonts, setting their custom parameters is the variable-font lib, mainly using the "public.fontInfo" key.