### PR TITLE
remove spurious continue in _bracket_info()

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3948,9 +3948,6 @@ class GSLayer(GSBase):
                     axis_min = float(axis_min)
                 if isinstance(axis_max, str):
                     axis_max = float(axis_max)
-                if axis_max == axis.minimum and axis_max == axis.maximum:
-                    # It's full range, ignore it.
-                    continue
                 info[axis.tag] = (axis_min, axis_max)
             return info
 


### PR DESCRIPTION
this `if` branch was never true because of a typo (the author probably meant to compare axis.minimum with 'axis_min'  instead of 'axis_max'); but besides that, even if we did fix the typo, it would be incorrect to ignore such an explict always-true axis rule where both min and max are explicitly declared and are equal to the axis min/max. Glyphs.app exports a GSUB with a FeatureVariation table with an empty condition set (which means always apply), and fontmake does the same.

The PR doesn't change anything, only removes code that's never evaluated so no functional change.