### PR TITLE
[anchor_propagation] the last component's anchor wins for non-liga composites (e.g. DZ)

### DIFF
--- a/Lib/glyphsLib/builder/anchor_propagation.py
+++ b/Lib/glyphsLib/builder/anchor_propagation.py
@@ -24,12 +24,14 @@ def _is_ligature_sub_category(glyph):
     return subCategory == "Ligature"
 
 
-def _propagate_glyph_anchors(self, ufo, parent, processed):
+def _propagate_glyph_anchors(self, ufo, parent, processed, parent_is_liga=False):
     """Propagate anchors for a single parent glyph."""
 
     if parent.name in processed:
         return
     processed.add(parent.name)
+
+    parent_is_liga |= _is_ligature_sub_category(parent)
 
     base_components = []
     mark_components = []
@@ -45,7 +47,7 @@ def _propagate_glyph_anchors(self, ufo, parent, processed):
                 )
             )
         else:
-            _propagate_glyph_anchors(self, ufo, glyph, processed)
+            _propagate_glyph_anchors(self, ufo, glyph, processed, parent_is_liga)
             if any(a.name.startswith("_") for a in glyph.anchors):
                 mark_components.append(component)
             else:
@@ -72,7 +74,6 @@ def _propagate_glyph_anchors(self, ufo, parent, processed):
         # don't add if parent already contains this anchor OR any associated
         # ligature anchors (e.g. "top_1, top_2" for "top")
         if not any(a.name.startswith(anchor_name) for a in parent.anchors):
-            parent_is_liga = _is_ligature_sub_category(parent)
             _get_anchor_data(to_add, ufo, base_components, anchor_name, parent_is_liga)
 
     for component in mark_components:

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -136,7 +136,8 @@ def test_propagate_anchors_on(ufo_module):
         ("dad", [("sad", 0, 0), ("dotabove", 50, 50)], []),
         ("dadDotbelow", [("dad", 0, 0), ("dotbelow", 50, -50)], []),
         ("yod", [], [("bottom", 50, -50)]),
-        ("yodyod", [("yod", 0, 0), ("yod", 100, 0)], []),
+        ("yod_yod", [("yod", 0, 0), ("yod", 100, 0)], []),  # ligature
+        ("yodyod", [("yod", 0, 0), ("yod", 100, 0)], []),  # not a ligature
     )
     for name, component_data, anchor_data in glyphs:
         add_glyph(font, name)
@@ -160,7 +161,20 @@ def test_propagate_anchors_on(ufo_module):
             assert anchor.name == "top"
             assert anchor.y == 200
 
+    # 'yodyod' isn't explicitly classified as a 'ligature' hence it will NOT
+    # inherit two 'bottom_1' and 'bottom_2' anchors from each 'yod' component,
+    # but only one 'bottom' anchor from the last component.
+    # https://github.com/googlefonts/glyphsLib/issues/368#issuecomment-2103376997
     glyph = ufo["yodyod"]
+    assert len(glyph.anchors) == 1
+    for anchor in glyph.anchors:
+        assert anchor.name == "bottom"
+        assert anchor.y == -50
+        assert anchor.x == 150
+
+    # 'yod_yod' is a ligature hence will inherit two 'bottom_{1,2}' anchors
+    # from each 'yod' component
+    glyph = ufo["yod_yod"]
     assert len(glyph.anchors) == 2
     for anchor in glyph.anchors:
         assert anchor.y == -50


### PR DESCRIPTION
https://github.com/googlefonts/glyphsLib/issues/368#issuecomment-2103376997

> For non-ligature glyphs, you should get the anchors from the last component they show up. I just tried the DZ in Glyphs. The D and Z have a "top" anchor so you get the one from the Z. The D has a center anchor (for the bar to make a "Eth"). As the Z doesn’t have a center have it, you get the one from the D.