### PR TITLE
[propagate_anchors] detect component cycles, fix infinite loop

### DIFF
--- a/Lib/glyphsLib/builder/transformations/propagate_anchors.py
+++ b/Lib/glyphsLib/builder/transformations/propagate_anchors.py
@@ -60,10 +60,10 @@ def propagate_all_anchors_impl(
     # anchors, but we only *set* those anchors on glyphs that have components.
     # to make this work, we write the anchors to a separate data structure, and
     # then only update the actual glyphs after we've done all the work.
-    all_anchors: dict[str, list[list[GSAnchor]]] = {}
+    all_anchors: dict[str, dict[str, list[GSAnchor]]] = {}
     for name in todo:
         glyph = glyphs[name]
-        for layer in glyph.layers:
+        for layer in _interesting_layers(glyph):
             anchors = anchors_traversing_components(
                 glyph,
                 layer,
@@ -73,15 +73,14 @@ def propagate_all_anchors_impl(
                 glyph_data,
             )
             maybe_log_new_anchors(anchors, glyph, layer)
-            all_anchors.setdefault(name, []).append(anchors)
+            all_anchors.setdefault(name, {})[layer.layerId] = anchors
 
     # finally update our glyphs with the new anchors, where appropriate
     for name, layers in all_anchors.items():
         glyph = glyphs[name]
         if _has_components(glyph):
-            assert len(layers) == len(glyph.layers)
-            for i, layer_anchors in enumerate(layers):
-                glyph.layers[i].anchors = layer_anchors
+            for layer_id, layer_anchors in layers.items():
+                glyph.layers[layer_id].anchors = layer_anchors
 
 
 def maybe_log_new_anchors(
@@ -100,8 +99,21 @@ def maybe_log_new_anchors(
         )
 
 
+def _interesting_layers(glyph):
+    # only master layers are currently supported for anchor propagation:
+    # https://github.com/googlefonts/glyphsLib/issues/1017
+    return (
+        l
+        for l in glyph.layers
+        if l._is_master_layer
+        # or l._is_brace_layer
+        # or l._is_bracket_layer
+        # etc.
+    )
+
+
 def _has_components(glyph: GSGlyph) -> bool:
-    return any(layer.components for layer in glyph.layers if layer._is_master_layer)
+    return any(layer.components for layer in _interesting_layers(glyph))
 
 
 def _get_category(
@@ -132,7 +144,7 @@ def anchors_traversing_components(
     glyph: GSGlyph,
     layer: GSLayer,
     glyphs: dict[str, GSGlyph],
-    done_anchors: dict[str, list[list[GSAnchor]]],
+    done_anchors: dict[str, dict[str, list[GSAnchor]]],
     base_glyph_counts: dict[(str, str), int],
     glyph_data: glyphdata.GlyphData | None = None,
 ) -> list[GSAnchor]:
@@ -370,7 +382,7 @@ def get_component_layer_anchors(
     component: GSComponent,
     layer: GSLayer,
     glyphs: dict[str, GSGlyph],
-    anchors: dict[str, list[list[GSAnchor]]],
+    anchors: dict[str, dict[str, list[GSAnchor]]],
 ) -> list[GSAnchor] | None:
     glyph = glyphs.get(component.name)
     if glyph is None:
@@ -379,12 +391,12 @@ def get_component_layer_anchors(
     # if it is missing. glyphsLib does not have that yet, so for now we
     # only support the corresponding 'master' layer of a component's base glyph.
     layer_anchors = None
-    for layer_idx, comp_layer in enumerate(glyph.layers):
+    for comp_layer in _interesting_layers(glyph):
         if comp_layer.layerId == layer.layerId and component.name in anchors:
             try:
-                layer_anchors = anchors[component.name][layer_idx]
+                layer_anchors = anchors[component.name][comp_layer.layerId]
                 break
-            except IndexError:
+            except KeyError:
                 if component.name == layer.parent.name:
                     # cyclic reference? ignore
                     break
@@ -419,7 +431,9 @@ def depth_sorted_composite_glyphs(glyphs: dict[str, GSGlyph]) -> list[str]:
         component_buf.clear()
         component_buf.extend(
             comp.name
-            for comp in chain.from_iterable(l.components for l in next_glyph.layers)
+            for comp in chain.from_iterable(
+                l.components for l in _interesting_layers(next_glyph)
+            )
             if comp.name in glyphs  # ignore missing components
         )
         if not component_buf:

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -489,10 +489,8 @@ def test_propagate_across_layers_with_circular_reference(caplog):
         propagate_all_anchors_impl(glyphs)
 
     assert len(caplog.records) == 2
-    assert (
-        caplog.records[0].message == "Cycle detected in composite glyph 'acutecomb.alt'"
-    )
-    assert caplog.records[1].message == "Cycle detected in composite glyph 'gravecomb'"
+    assert caplog.records[0].message == "glyph 'acutecomb.alt' has cyclical components"
+    assert caplog.records[1].message == "glyph 'gravecomb' has cyclical components"
 
 
 def test_remove_exit_anchor_on_component():

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -381,9 +381,10 @@ def test_propagate_across_layers():
                 glyph.add_component("acutecomb", (0, 0))
                 .add_master_layer()
                 .add_component("acutecomb", (0, 0))
-                # this backup layer contains a cyclical component reference
+                # this backup layer contains a potentially cyclical reference
                 # as the component's base glyph in turn points back at self;
-                # this should not trigger an infinite loop!
+                # this doesn't trigger an infinite loop because backup layers
+                # are skipped when propagating anchors
                 .add_backup_layer()
                 .add_component("acute", (0, 0))
             ),

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -375,6 +375,27 @@ def test_propagate_across_layers():
                 .add_component("acutecomb", (-45, 188))
             ),
         )
+        .add_glyph(
+            "acutecomb.case",
+            lambda glyph: (
+                glyph.add_component("acutecomb", (0, 0))
+                .add_master_layer()
+                .add_component("acutecomb", (0, 0))
+                # this backup layer contains a cyclical component reference
+                # as the component's base glyph in turn points back at self;
+                # this should not trigger an infinite loop!
+                .add_backup_layer()
+                .add_component("acute", (0, 0))
+            ),
+        )
+        .add_glyph(
+            "acute",
+            lambda glyph: (
+                glyph.add_component("acutecomb.case", (0, 0))
+                .add_master_layer()
+                .add_component("acutecomb.case", (0, 0))
+            ),
+        )
         .build()
     )
     propagate_all_anchors_impl(glyphs)


### PR DESCRIPTION
Fixes #1022 

cyclical composites with infinite component depth are now correctly detected and skipped with a warning (they will probably just error out down the pipeline anyway).

~~We traverse the component trees in depth-first order while keeping track of the glyphs that we are currently visiting so we can detect cycles as they happen.~~

EDIT: I now copied @cmyr's solution from https://github.com/googlefonts/fontc/pull/907
We now keep track of the composites that are waiting for their components as we process the queue, as well as the length of the queue at that point, and if we encounter the same glyph twice without the queue having gotten smaller it means we aren't making any more progress, thus we have a cycle.

Also, since we currently can only resolve component refs between master layers, for now we skip processing the other layers (fontc propagate_anchors.rs similarly only does master layers, see #1017).
