### PR TITLE
Fix the order of feature writers

### DIFF
--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -206,13 +206,13 @@ UFO2FT_COLOR_LAYERS_KEY = "com.github.googlei18n.ufo2ft.colorLayers"
 UFO2FT_META_TABLE_KEY = PUBLIC_PREFIX + "openTypeMeta"
 
 DEFAULT_FEATURE_WRITERS = [
+    {"class": "CursFeatureWriter"},
     {"class": "KernFeatureWriter"},
     {
         "module": "glyphsLib.featureWriters.markFeatureWriter",
         "class": "ContextualMarkFeatureWriter",
     },
     {"class": "GdefFeatureWriter"},
-    {"class": "CursFeatureWriter"},
 ]
 
 DEFAULT_LAYER_NAME = PUBLIC_PREFIX + "default"


### PR DESCRIPTION
We want curs feature lookups to come first, then kerning, then mark/mkmk, but we currently are calling CursFeatureWriter last which causes its lookups to be also written last. The lookup order does not matter for HarfBuzz, but it matters for other implementations, see: https://github.com/harfbuzz/harfbuzz/issues/4596#issuecomment-2220558649