### PR TITLE
Drop disabled prefixes, classes, and features in minimal mode

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -58,6 +58,7 @@ def to_ufo_master_features(self, ufo, master):
             generate_GDEF=self.generate_GDEF,
             master=master,
             expand_includes=self.expand_includes,
+            minimal=self.minimal,
         )
 
 
@@ -84,6 +85,7 @@ def _to_ufo_features(  # noqa: C901
     generate_GDEF: bool = False,
     master: GSFontMaster | None = None,
     expand_includes: bool = False,
+    minimal: bool = False,
 ) -> str:
     """Convert GSFont features, including prefixes and classes, to UFO.
 
@@ -118,6 +120,8 @@ def _to_ufo_features(  # noqa: C901
 
     feature_defs = []
     for feature in font.features:
+        if feature.disabled and minimal:
+            continue
         code = expander.expand(feature.code)
         lines = ["feature %s {" % feature.name]
         notes = feature.notes

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -98,6 +98,8 @@ def _to_ufo_features(  # noqa: C901
 
     prefixes = []
     for prefix in font.featurePrefixes:
+        if prefix.disabled and minimal:
+            continue
         strings = []
         if prefix.name != ANONYMOUS_FEATURE_PREFIX_NAME:
             strings.append("# Prefix: %s\n" % prefix.name)
@@ -109,6 +111,8 @@ def _to_ufo_features(  # noqa: C901
 
     class_defs = []
     for class_ in font.classes:
+        if class_.disabled and minimal:
+            continue
         prefix = "@" if not class_.name.startswith("@") else ""
         name = prefix + class_.name
         class_defs.append(

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -600,6 +600,25 @@ def test_roundtrip_feature_prefix_with_only_a_comment(ufo_module):
     assert prefix_r.code == "#include(../family.fea)"
 
 
+def test_drop_disabled_feature(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
+    feature = classes.GSFeature(name="ccmp", code="sub a by a.ccmp1 a.ccmp2;")
+    feature.disabled = True
+    font.features.append(feature)
+
+    feature = classes.GSFeature(name="liga", code="sub f i by f_i;")
+    font.features.append(feature)
+
+    (ufo,) = to_ufos(font, ufo_module=ufo_module, minimal=True)
+    assert ufo.features.text == dedent(
+        """\
+        feature liga {
+        sub f i by f_i;
+        } liga;
+    """
+    )
+
+
 @pytest.fixture
 def ufo_with_GDEF(ufo_module):
     ufo = ufo_module.Font()

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -600,6 +600,42 @@ def test_roundtrip_feature_prefix_with_only_a_comment(ufo_module):
     assert prefix_r.code == "#include(../family.fea)"
 
 
+def test_drop_disabled_class(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
+    class_ = classes.GSClass(name="Class1", code="a b")
+    class_.disabled = True
+    font.classes.append(class_)
+
+    class_ = classes.GSClass(name="Class2", code="c d")
+    font.classes.append(class_)
+
+    (ufo,) = to_ufos(font, ufo_module=ufo_module, minimal=True)
+    assert ufo.features.text == dedent(
+        """\
+        @Class2 = [ c d
+        ];
+    """
+    )
+
+
+def test_drop_disabled_prefix(ufo_module):
+    font = to_glyphs([ufo_module.Font()])
+    prefix = classes.GSFeaturePrefix(name="Prefix1", code="# test 1")
+    prefix.disabled = True
+    font.featurePrefixes.append(prefix)
+
+    prefix = classes.GSFeaturePrefix(name="Prefix2", code="# test 2")
+    font.featurePrefixes.append(prefix)
+
+    (ufo,) = to_ufos(font, ufo_module=ufo_module, minimal=True)
+    assert ufo.features.text == dedent(
+        """\
+        # Prefix: Prefix2
+        # test 2
+    """
+    )
+
+
 def test_drop_disabled_feature(ufo_module):
     font = to_glyphs([ufo_module.Font()])
     feature = classes.GSFeature(name="ccmp", code="sub a by a.ccmp1 a.ccmp2;")


### PR DESCRIPTION
Partially addresses #761, #763, and #1026 by handling the `minimal=True` case only.