### PR TITLE
propagate_anchors: fix handling of contextual anchors

### DIFF
--- a/Lib/glyphsLib/builder/transformations/propagate_anchors.py
+++ b/Lib/glyphsLib/builder/transformations/propagate_anchors.py
@@ -211,9 +211,6 @@ def anchors_traversing_components(
         component_transform = Transform(*component.transform)
         xscale, yscale = get_xy_rotation(component_transform)
         for anchor in anchors:
-            # skip contextual anchors
-            if anchor.name.startswith("*") and "GPOS_Context" in anchor.userData:
-                continue
             new_has_underscore = anchor.name.startswith("_")
             if (component_idx > 0 or has_underscore) and new_has_underscore:
                 continue

--- a/Lib/glyphsLib/builder/transformations/propagate_anchors.py
+++ b/Lib/glyphsLib/builder/transformations/propagate_anchors.py
@@ -211,6 +211,9 @@ def anchors_traversing_components(
         component_transform = Transform(*component.transform)
         xscale, yscale = get_xy_rotation(component_transform)
         for anchor in anchors:
+            # skip contextual anchors
+            if anchor.name.startswith("*") and "GPOS_Context" in anchor.userData:
+                continue
             new_has_underscore = anchor.name.startswith("_")
             if (component_idx > 0 or has_underscore) and new_has_underscore:
                 continue
@@ -299,6 +302,7 @@ def origin_adjusted_anchors(anchors: list[GSAnchor]) -> Iterable[GSAnchor]:
         GSAnchor(
             name=a.name,
             position=Point(a.position.x - origin.x, a.position.y - origin.y),
+            userData=dict(a.userData),
         )
         for a in anchors
         if a.name != "*origin"
@@ -398,7 +402,11 @@ def get_component_layer_anchors(
     if layer_anchors is not None:
         # return a copy as they may be modified in place
         layer_anchors = [
-            GSAnchor(name=a.name, position=Point(a.position.x, a.position.y))
+            GSAnchor(
+                name=a.name,
+                position=Point(a.position.x, a.position.y),
+                userData=dict(a.userData),
+            )
             for a in layer_anchors
         ]
     return layer_anchors

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2787,13 +2787,15 @@ class GSAnchor(GSBase):
     _parent = None
     _defaultsForName = {"position": Point(0, 0)}
 
-    def __init__(self, name=None, position=None):
+    def __init__(self, name=None, position=None, userData=None):
         self.name = "" if name is None else name
-        self._userData = None
         if position is None:
             self.position = copy.deepcopy(self._defaultsForName["position"])
         else:
             self.position = position
+        self._userData = None
+        if userData is not None:
+            self.userData = userData
 
     def __repr__(self):
         return '<{} "{}" x={:.1f} y={:.1f}>'.format(

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -112,8 +112,13 @@ class GlyphBuilder:
         component.anchor = name
         return self
 
-    def add_anchor(self, name: str, pos: tuple[float, float]) -> Self:
-        anchor = GSAnchor(name, Point(*pos))
+    def add_anchor(
+        self,
+        name: str,
+        pos: tuple[float, float],
+        userData: dict | None = None,
+    ) -> Self:
+        anchor = GSAnchor(name, Point(*pos), userData=userData)
         self.current_layer.anchors.append(anchor)
         return self
 
@@ -193,6 +198,7 @@ def assert_anchors(actual, expected):
     for a, e in zip(actual, expected):
         assert a.name == e[0]
         assert a.position == Point(*e[1])
+        assert dict(a.userData) == (e[2] if len(e) > 2 else {})
 
 
 def test_no_components_anchors_are_unchanged():
@@ -607,6 +613,59 @@ def test_origin_anchor():
             ("bottom", (262, 7)),
             ("ogonek", (422, 9)),
             ("top", (286, 760)),
+        ],
+    )
+
+
+def test_contextual_anchors():
+    glyphs = (
+        GlyphSetBuilder()
+        .add_glyph(
+            "behDotless-ar.init",
+            lambda glyph: (
+                glyph.add_anchor("bottom", (50, 0))
+                .add_anchor(
+                    "*bottom",
+                    (95, 0),
+                    userData={"GPOS_Context": "* behDotless-ar.medi"},
+                )
+                .add_anchor("top", (35, 229))
+            ),
+        )
+        .add_glyph(
+            "behDotless-ar.medi",
+            lambda glyph: (
+                glyph.add_component("behDotless-ar.init", (0, 0)).add_anchor(
+                    "*bottom",
+                    (95, 0),
+                    userData={"GPOS_Context": "* behDotless-ar.fina"},
+                )
+            ),
+        )
+        .add_glyph(
+            "behDotless-ar.fina",
+            lambda glyph: glyph.add_component("behDotless-ar.init", (0, 0)),
+        )
+        .build()
+    )
+    propagate_all_anchors_impl(glyphs)
+
+    new_glyph = glyphs["behDotless-ar.medi"]
+    assert_anchors(
+        new_glyph.layers[0].anchors,
+        [
+            ("bottom", (50, 0)),
+            ("top", (35, 229)),
+            ("*bottom", (95, 0), {"GPOS_Context": "* behDotless-ar.fina"}),
+        ],
+    )
+
+    new_glyph = glyphs["behDotless-ar.fina"]
+    assert_anchors(
+        new_glyph.layers[0].anchors,
+        [
+            ("bottom", (50, 0)),
+            ("top", (35, 229)),
         ],
     )
 

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -655,8 +655,8 @@ def test_contextual_anchors():
         new_glyph.layers[0].anchors,
         [
             ("bottom", (50, 0)),
-            ("top", (35, 229)),
             ("*bottom", (95, 0), {"GPOS_Context": "* behDotless-ar.fina"}),
+            ("top", (35, 229)),
         ],
     )
 
@@ -665,6 +665,7 @@ def test_contextual_anchors():
         new_glyph.layers[0].anchors,
         [
             ("bottom", (50, 0)),
+            ("*bottom", (95, 0), {"GPOS_Context": "* behDotless-ar.medi"}),
             ("top", (35, 229)),
         ],
     )


### PR DESCRIPTION
- ~~Don’t propagate contextual anchors, GlyphsApp does not propagate them.~~ It actually does, so this part is later reverted.
- When copying anchors, copy also userData, otherwise the context of contextual anchors of any processed glyph will be dropped. This is a regression from https://github.com/googlefonts/glyphsLib/pull/1011