### PR TITLE
[builder] Reorder .notdef and space glyphs in public.glyphOrder

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -21,13 +21,13 @@ from glyphsLib.util import bin_to_int_list, int_list_to_bin
 from .filters import parse_glyphs_filter
 from .common import to_ufo_color
 from .constants import (
+    GLYPH_ORDER_KEY,
     GLYPHS_PREFIX,
     UFO2FT_COLOR_PALETTES_KEY,
     UFO2FT_FILTERS_KEY,
     UFO2FT_USE_PROD_NAMES_KEY,
     CODEPAGE_RANGES,
     REVERSE_CODEPAGE_RANGES,
-    PUBLIC_PREFIX,
     UFO_FILENAME_CUSTOM_PARAM,
     UFO2FT_META_TABLE_KEY,
 )
@@ -842,7 +842,7 @@ class GlyphOrderParamHandler(AbstractParamHandler):
 
     def to_glyphs(self, glyphs, ufo):
         if glyphs.is_font():
-            ufo_glyphOrder = ufo.get_lib_value(PUBLIC_PREFIX + "glyphOrder")
+            ufo_glyphOrder = ufo.get_lib_value(GLYPH_ORDER_KEY)
             if ufo_glyphOrder:
                 glyphs.set_custom_value("glyphOrder", ufo_glyphOrder)
 
@@ -850,13 +850,13 @@ class GlyphOrderParamHandler(AbstractParamHandler):
         if glyphs.is_font():
             glyphs_glyphOrder = glyphs.get_custom_value("glyphOrder")
             if glyphs_glyphOrder:
-                ufo_glyphOrder = ufo.get_lib_value(PUBLIC_PREFIX + "glyphOrder")
+                ufo_glyphOrder = ufo.get_lib_value(GLYPH_ORDER_KEY)
                 # If the custom parameter provides partial coverage we want to
                 # append the original glyph order for uncovered glyphs.
                 glyphs_glyphOrder += [
                     g for g in ufo_glyphOrder if g not in glyphs_glyphOrder
                 ]
-                ufo.set_lib_value(PUBLIC_PREFIX + "glyphOrder", glyphs_glyphOrder)
+                ufo.set_lib_value(GLYPH_ORDER_KEY, glyphs_glyphOrder)
 
 
 register(GlyphOrderParamHandler())

--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -858,6 +858,26 @@ class GlyphOrderParamHandler(AbstractParamHandler):
                 ]
                 ufo.set_lib_value(GLYPH_ORDER_KEY, glyphs_glyphOrder)
 
+            # if "Keep GlyphOrder" is not set, we reorder ".notdef"
+            # and "space" to the beginning of the glyph order.
+            #
+            # There is an older "TrueType Keep GlyphOrder" that is specific to
+            # TrueType export, but we don't know what the export format is so we
+            # treat it the same as "Keep GlyphOrder".
+            keep_glyphOrder = glyphs.get_custom_value(
+                "Keep GlyphOrder"
+            ) or glyphs.get_custom_value("TrueType Keep GlyphOrder")
+            ufo_glyphOrder = ufo.get_lib_value(GLYPH_ORDER_KEY)
+            if not keep_glyphOrder and ufo_glyphOrder:
+                space_index = 0
+                if ".notdef" in ufo_glyphOrder:
+                    ufo_glyphOrder.remove(".notdef")
+                    ufo_glyphOrder.insert(0, ".notdef")
+                    space_index = 1
+                if "space" in ufo_glyphOrder:
+                    ufo_glyphOrder.remove("space")
+                    ufo_glyphOrder.insert(space_index, "space")
+
 
 register(GlyphOrderParamHandler())
 

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -2758,3 +2758,64 @@ class TestGlyphOrder:
         ufo = self.from_glyphs(ufo_module)
         assert ["xxx1", "f", "xxx2", "c", "a"] == ufo.lib["public.glyphOrder"]
         assert GLYPHS_PREFIX + "glyphOrder" not in ufo.lib
+
+    def test_glyphs_to_ufo_with_keepGlyphOrder(self, ufo_module):
+        self.prepare(ufo_module)
+        self.font.glyphs.append(GSGlyph("space"))
+
+        # If "Keep GlyphOrder" is True, no reordering happens
+        self.font.customParameters["Keep GlyphOrder"] = True
+        ufo = self.from_glyphs(ufo_module)
+        assert ["c", "a", "f", "space"] == ufo.lib["public.glyphOrder"]
+
+        # If "Keep GlyphOrder" is False, space is reordered
+        self.font.customParameters["Keep GlyphOrder"] = False
+        ufo = self.from_glyphs(ufo_module)
+        assert ["space", "c", "a", "f"] == ufo.lib["public.glyphOrder"]
+
+        # Absence of "Keep GlyphOrder" is equivalent to False
+        del self.font.customParameters["Keep GlyphOrder"]
+        ufo = self.from_glyphs(ufo_module)
+        assert ["space", "c", "a", "f"] == ufo.lib["public.glyphOrder"]
+
+    def test_glyphs_to_ufo_with_keepGlyphOrder_and_notdef(self, ufo_module):
+        self.prepare(ufo_module)
+        self.font.glyphs.append(GSGlyph("space"))
+        self.font.glyphs.append(GSGlyph(".notdef"))
+
+        # If "Keep GlyphOrder" is True, no reordering happens
+        self.font.customParameters["Keep GlyphOrder"] = True
+        ufo = self.from_glyphs(ufo_module)
+        assert ["c", "a", "f", "space", ".notdef"] == ufo.lib["public.glyphOrder"]
+
+        # If "Keep GlyphOrder" is False, space is reordered
+        self.font.customParameters["Keep GlyphOrder"] = False
+        ufo = self.from_glyphs(ufo_module)
+        assert [".notdef", "space", "c", "a", "f"] == ufo.lib["public.glyphOrder"]
+
+        # Absence of "Keep GlyphOrder" is equivalent to False
+        del self.font.customParameters["Keep GlyphOrder"]
+        ufo = self.from_glyphs(ufo_module)
+        assert [".notdef", "space", "c", "a", "f"] == ufo.lib["public.glyphOrder"]
+
+    def test_glyphs_to_ufo_with_keepGlyphOrder_and_explicit_glyphOrder(
+        self, ufo_module
+    ):
+        self.prepare(ufo_module)
+        self.font.glyphs.append(GSGlyph("space"))
+        self.font.customParameters["glyphOrder"] = ["c", "a", "space", "f"]
+
+        # If "Keep GlyphOrder" is True, no reordering happens
+        self.font.customParameters["Keep GlyphOrder"] = True
+        ufo = self.from_glyphs(ufo_module)
+        assert ["c", "a", "space", "f"] == ufo.lib["public.glyphOrder"]
+
+        # If "Keep GlyphOrder" is False, space is reordered
+        self.font.customParameters["Keep GlyphOrder"] = False
+        ufo = self.from_glyphs(ufo_module)
+        assert ["space", "c", "a", "f"] == ufo.lib["public.glyphOrder"]
+
+        # Absence of "Keep GlyphOrder" is equivalent to False
+        del self.font.customParameters["Keep GlyphOrder"]
+        ufo = self.from_glyphs(ufo_module)
+        assert ["space", "c", "a", "f"] == ufo.lib["public.glyphOrder"]


### PR DESCRIPTION
Unless "Keep GlyphOrder" (or the older "TrueType Keep GlyphOrder") custom parameter is set to True.