### PR TITLE
Handle point identifiers (Glyphs 3)

### DIFF
--- a/Lib/glyphsLib/builder/paths.py
+++ b/Lib/glyphsLib/builder/paths.py
@@ -40,6 +40,7 @@ def to_ufo_paths(self, ufo_glyph, layer):
                 best_repr_list(tuple(node.position)),
                 segmentType="move",
                 name=node.userData.get("name"),
+                identifier=node.userData.get("UFO.identifier"),
             )
         else:
             # In Glyphs.app, the starting node of a closed contour is always
@@ -53,14 +54,19 @@ def to_ufo_paths(self, ufo_glyph, layer):
                 segmentType=node_type,
                 smooth=node.smooth,
                 name=node.userData.get("name"),
+                identifier=node.userData.get("UFO.identifier"),
             )
             # NOTE: Can't do path_index, node_index through enumeration here because we
             # might have changed node order.
             # A node's name will be stored as a UFO point's name attribute, so filter
             # it from the Glyph node user data to avoid storing duplicate information.
             if node.userData:
-                node_user_data = {k: v for k, v in node.userData.items() if k != "name"}
-                self.to_ufo_node_user_data(ufo_glyph, node, node_user_data)
+                node_user_data = {
+                    k: v
+                    for k, v in node.userData.items()
+                    if k not in ("UFO.identifier", "name")
+                }
+            self.to_ufo_node_user_data(ufo_glyph, node, node_user_data)
         pen.endPath()
 
 
@@ -75,6 +81,8 @@ def to_glyphs_paths(self, ufo_glyph, layer):
             node.type = _to_glyphs_node_type(point.segmentType)
             node.smooth = point.smooth
             node.name = point.name
+            if point.identifier is not None:
+                node.userData["UFO.identifier"] = point.identifier
             path.nodes.append(node)
         path.closed = not contour.open
         if not contour.open:

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -403,9 +403,11 @@ def test_node_user_data_into_glif_lib():
     layer.paths.append(path)
     node1 = classes.GSNode()
     node1.userData["nodeUserDataKey1"] = "nodeUserDataValue1"
+    node1.userData["UFO.identifier"] = "id1"
     node1.name = "node1"
     node2 = classes.GSNode()
     node2.userData["nodeUserDataKey2"] = "nodeUserDataValue2"
+    node2.userData["UFO.identifier"] = "id2"
     node2.name = "node2"
     path.nodes.append(classes.GSNode())
     path.nodes.append(node1)
@@ -419,18 +421,22 @@ def test_node_user_data_into_glif_lib():
         "nodeUserDataKey1": "nodeUserDataValue1"
     }
     assert ufo["a"][0][2].name == "node1"
+    assert ufo["a"][0][2].identifier == "id1"
     assert ufo["a"].lib[GLYPHLIB_PREFIX + "nodeUserData.0.4"] == {
         "nodeUserDataKey2": "nodeUserDataValue2"
     }
     assert ufo["a"][0][0].name == "node2"
+    assert ufo["a"][0][0].identifier == "id2"
 
     font = to_glyphs([ufo])
 
     path = font.glyphs["a"].layers["M1"].paths[0]
     assert path.nodes[1].userData["nodeUserDataKey1"] == "nodeUserDataValue1"
     assert path.nodes[1].name == "node1"
+    assert path.nodes[1].userData["UFO.identifier"] == "id1"
     assert path.nodes[4].userData["nodeUserDataKey2"] == "nodeUserDataValue2"
     assert path.nodes[4].name == "node2"
+    assert path.nodes[4].userData["UFO.identifier"] == "id2"
 
 
 def test_lib_data_types(tmpdir, ufo_module):


### PR DESCRIPTION
Roundtrip point identifiers from GSNode.userData["UFO.identifier"] to UFO Point.identifier and back, as described in #1049.

Same as #1054, but for the Glyphs3-merge branch.