### PR TITLE
Fix extra segment in eraseOpenCorners

### DIFF
--- a/Lib/glyphsLib/filters/eraseOpenCorners.py
+++ b/Lib/glyphsLib/filters/eraseOpenCorners.py
@@ -35,7 +35,9 @@ class EraseOpenCornersPen(BasePen):
     _qCurveTo = _curveTo = _lineTo = _qCurveToOne = _curveToOne = _operate
 
     def closePath(self):
-        self.segments.append((self._getCurrentPoint(), self.segments[0][0]))
+        # only add a line segment here if the current first and last point aren't equal
+        if self._getCurrentPoint() != self.segments[0][0]:
+            self.segments.append((self._getCurrentPoint(), self.segments[0][0]))
         self.is_closed = True
         self.endPath()
 

--- a/tests/eraseOpenCorners_test.py
+++ b/tests/eraseOpenCorners_test.py
@@ -158,6 +158,18 @@ from glyphsLib.filters.eraseOpenCorners import EraseOpenCornersFilter
                         ("closePath", ()),
                     ],
                 },
+                {
+                    "name": "curveAsLastSegment",
+                    "width": 600,
+                    "outline": [
+                        ("moveTo", ((100, 100),)),
+                        ("lineTo", ((10, 110),)),
+                        ("lineTo", ((15, 120),)),
+                        ("lineTo", ((60, 30),)),
+                        ("curveTo", ((80, 30), (100, 80), (100, 100))),
+                        ("closePath", ()),
+                    ],
+                },
             ]
         }
     ]
@@ -319,6 +331,15 @@ def test_large_crossing(font):
     assert philter(font)
     newcontour = font["largeCrossing"][0]
     assert len(newcontour) == 3
+
+
+# there was an issue where we would generate an extra lineto if we erased
+# corners on an outline where the last segment was a curve
+def test_curve_as_last_segment(font):
+    philter = EraseOpenCornersFilter(include={"curveAsLastSegment"})
+    assert philter(font)
+    newcontour = font["curveAsLastSegment"][0]
+    assert structure(newcontour) == ["curve", "line", "line", None, None]
 
 
 def structure(contour):

--- a/tests/eraseOpenCorners_test.py
+++ b/tests/eraseOpenCorners_test.py
@@ -345,7 +345,7 @@ def test_large_crossing(font):
     newcontour = font["largeCrossing"][0]
     assert len(newcontour) == 3
 
-    
+
 # there was an issue where we would generate an extra lineto if we erased
 # corners on an outline where the last segment was a curve
 def test_curve_as_last_segment(font):
@@ -354,7 +354,7 @@ def test_curve_as_last_segment(font):
     newcontour = font["curveAsLastSegment"][0]
     assert structure(newcontour) == ["curve", "line", "line", None, None]
 
-    
+
 def test_only_two_segments(font):
     philter = EraseOpenCornersFilter(include={"justTwoSegments"})
     assert not philter(font)


### PR DESCRIPTION
In the process of porting this functionality to Rust, I've run into a funny issue: in some cases, after erasing corners, the outline generated here contained an extra duplicate point at the beginning.

This error seems to be introduced only for contours where the last segment is a curve, and it is introduced early; even before we start processing, there is an extra segment in the segments list for these contours.

This patch addresses this by changing the logic of closePath to not emit a final line segment if it would be a duplicate, but I'm not totally confident that this is the right approach.

---

More detail: I believe that what is going on is an interaction between the logic for `closePath` in `eraseOpenContours` and the logic in the `PointToSegmentPen` that is [writing into it](https://github.com/fonttools/fonttools/blob/8d3b9900976b6c7/Lib/fontTools/pens/pointPen.py#L232-L240). That pen is skipping the last LineTo segment in a closed path, trusting `closePath` to handle it; but by _always_ adding a lineTo in `closePath` we're inserting extra segments when the last segment wasn't a lineTo.


Another note: this patch is causing a new fontmake failure on one crater font, based on a rounding issue; there's a case where the start/end points are off by an epsilon in one master and not the other, which leads us to add the extra segment in one case. I'm not sure how best I should check this case.. should I strictly be looking for epsilon difference, or would it be okay to check if the points are equal after otround?