### PR TITLE
Fix edge case in open corner erasure logic

### DIFF
--- a/Lib/glyphsLib/filters/eraseOpenCorners.py
+++ b/Lib/glyphsLib/filters/eraseOpenCorners.py
@@ -52,7 +52,8 @@ class EraseOpenCornersPen(BasePen):
             )
             logger.debug("Segments: %s", segs)
 
-        while ix < len(segs):
+        # we need at least two segments to find a corner
+        while len(segs) > 2 and ix < len(segs):
             next_ix = (ix + 1) % len(segs)
 
             # Am I a line segment?

--- a/tests/eraseOpenCorners_test.py
+++ b/tests/eraseOpenCorners_test.py
@@ -158,6 +158,19 @@ from glyphsLib.filters.eraseOpenCorners import EraseOpenCornersFilter
                         ("closePath", ()),
                     ],
                 },
+                # a pathological case, where a curve has two segments.
+                # the naive logic treats this as an open corner, treating the
+                # same curve segment as the 'prev' and 'next'.
+                {
+                    "name": "justTwoSegments",
+                    "width": 600,
+                    "outline": [
+                        ("moveTo", ((10, 10),)),
+                        ("lineTo", ((13, 10),)),
+                        ("curveTo", ((11, 8), (11, 8), (10, 10))),
+                        ("closePath", ()),
+                    ],
+                },
             ]
         }
     ]
@@ -319,6 +332,11 @@ def test_large_crossing(font):
     assert philter(font)
     newcontour = font["largeCrossing"][0]
     assert len(newcontour) == 3
+
+
+def test_only_two_segments(font):
+    philter = EraseOpenCornersFilter(include={"justTwoSegments"})
+    assert not philter(font)
 
 
 def structure(contour):


### PR DESCRIPTION
Specifically if a curve contains only two segments, we should not ever be erasing a corner.

A curve like this exists in the `K.ss02` glyph of [Estonia Pro](https://github.com/googlefonts/estonia).