### PR TITLE
Consider unicodes when zeroing mark glyph widths

### DIFF
--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -131,14 +131,14 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
             glyph.script,
         )
 
+    production_name = production_name or glyphinfo.production_name
+
     if production_name:
         # Make sure production names of bracket glyphs also get a BRACKET suffix.
         bracket_glyph_name = BRACKET_GLYPH_RE.match(ufo_glyph.name)
         prod_bracket_glyph_name = BRACKET_GLYPH_RE.match(production_name)
         if bracket_glyph_name and not prod_bracket_glyph_name:
             production_name += BRACKET_GLYPH_SUFFIX_RE.match(ufo_glyph.name).group(1)
-    else:
-        production_name = glyphinfo.production_name
     if production_name and production_name != ufo_glyph.name:
         postscriptNamesKey = PUBLIC_PREFIX + "postscriptNames"
         if postscriptNamesKey not in ufo_font.lib:

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -99,10 +99,16 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: 
             USV_KEY = PUBLIC_PREFIX + "unicodeVariationSequences"
             ufo_font.lib.setdefault(USV_KEY, {}).setdefault(usv, {})[uni] = glyph.name
 
+    # we can't use use the glyphs.unicodes values since they aren't always
+    # correctly padded
+    unicodes = [f"{c:04X}" for c in ufo_glyph.unicodes]
     # FIXME: (jany) next line should be an API of GSGlyph?
-    glyphinfo = glyphsLib.glyphdata.get_glyph(ufo_glyph.name)
+    glyphinfo = glyphsLib.glyphdata.get_glyph(ufo_glyph.name, unicodes=unicodes)
+
     if self.glyphdata is not None:
-        custom = glyphsLib.glyphdata.get_glyph(ufo_glyph.name, self.glyphdata)
+        custom = glyphsLib.glyphdata.get_glyph(
+            ufo_glyph.name, self.glyphdata, unicodes=unicodes
+        )
         production_name = glyph.production or (
             custom.production_name
             if custom.production_name != glyphinfo.production_name

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -353,6 +353,19 @@ def test_mark_nonspacing_zero_width(ufo_module):
     assert originalWidth_key not in ufo["bar"].lib
 
 
+# with an unknown glyph name we should get the correct category/subcategory
+# using the unicode value, and so should zero the width of the glyph
+# https://github.com/googlefonts/glyphsLib/issues/1059
+def test_nonspacing_zero_width_from_unicode(ufo_module):
+    font = generate_minimal_font()
+    glyph = add_glyph(font, "unknownName")
+    glyph.layers[0].width = 200
+    glyph.unicodes = ["0315"]  # combining comma above, a nonspacing mark
+    ufo = to_ufos(font, ufo_module=ufo_module)[0]
+    ufo_glyph = ufo["unknownName"]
+    assert ufo_glyph.width == 0
+
+
 def test_GDEF(ufo_module):
     font = generate_minimal_font()
     for glyph in (


### PR DESCRIPTION
A nice win for crater.

- fixes #1059 