### PR TITLE
Support new codepage ranges syntax #530

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -492,7 +492,7 @@ class OS2CodePageRangesParamHandler(AbstractParamHandler):
             if codepages is None:
                 return
 
-        ufo_codepage_bits = [CODEPAGE_RANGES[v] for v in codepages]
+        ufo_codepage_bits = self._convert_to_bits(codepages)
         unsupported_codepage_bits = glyphs.get_custom_value(
             "codePageRangesUnsupportedBits"
         )
@@ -500,6 +500,34 @@ class OS2CodePageRangesParamHandler(AbstractParamHandler):
             ufo_codepage_bits.extend(unsupported_codepage_bits)
 
         ufo.set_info_value("openTypeOS2CodePageRanges", sorted(ufo_codepage_bits))
+
+    @staticmethod
+    def _convert_to_bits(codepages):
+        ufo_codepage_bits = []
+        for codepage in codepages:
+            if isinstance(codepage, int):
+                ufo_codepage_bits.append(CODEPAGE_RANGES[codepage])
+
+            elif isinstance(codepage, str):
+                if codepage.isdigit():
+                    ufo_codepage_bits.append(CODEPAGE_RANGES[int(codepage)])
+                elif codepage.startswith("bit "):
+                    try:
+                        ufo_codepage_bits.append(int(codepage[4:]))
+                    except ValueError as err:
+                        raise ValueError(
+                            f"'{codepage}' is not in correct format. "
+                            "A number must follow after 'bit '."
+                        ) from err
+                else:
+                    raise ValueError(
+                        f"'{codepage}'is neither a number nor 'bit ' format."
+                    )
+
+            else:
+                raise TypeError(f"Unsupported type: {type(codepage)}")
+
+        return ufo_codepage_bits
 
 
 register(OS2CodePageRangesParamHandler())

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1357,14 +1357,12 @@ class GSCustomParameter(GSBase):
     _CUSTOM_INTLIST_PARAMS = frozenset(
         (
             "fsType",
-            "openTypeOS2CodePageRanges",
             "openTypeOS2FamilyClass",
             "openTypeOS2Panose",
             "openTypeOS2Type",
             "openTypeOS2UnicodeRanges",
             "panose",
             "unicodeRanges",
-            "codePageRanges",
             "openTypeHeadFlags",
         )
     )

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -208,6 +208,21 @@ class SetCustomParamsTestBase(object):
             self.font.customParameters["codePageRangesUnsupportedBits"], [15]
         )
 
+    def test_set_codePageRanges_with_various_types(self):
+        self.font.customParameters["openTypeOS2CodePageRanges"] = [
+            1252,
+            "1250",
+            "bit 29",
+        ]
+        self.font.customParameters["codePageRangesUnsupportedBits"] = [15]
+        self.set_custom_params()
+        self.assertEqual(self.ufo.info.openTypeOS2CodePageRanges, [0, 1, 15, 29])
+        self.font = glyphsLib.to_glyphs([self.ufo], minimize_ufo_diffs=True)
+        self.assertEqual(self.font.customParameters["codePageRanges"], [1252, 1250])
+        self.assertEqual(
+            self.font.customParameters["codePageRangesUnsupportedBits"], [15, 29]
+        )
+
     def test_set_openTypeOS2CodePageRanges(self):
         self.font.customParameters["openTypeOS2CodePageRanges"] = [1252, 1250]
         self.font.customParameters["codePageRangesUnsupportedBits"] = [15]


### PR DESCRIPTION
Currently the problem is occurring in the parser. #807
```
File "/Users/etunni/venv/lib/python3.7/site-packages/glyphsLib/parser.py", line 81, in _parse_dict
self._parse_dict_into_object(res, text)
File "/Users/etunni/venv/lib/python3.7/site-packages/glyphsLib/parser.py", line 98, in _parse_dict_into_object
res[name] = d[name]
File "/Users/etunni/venv/lib/python3.7/site-packages/glyphsLib/classes.py", line 336, in setitem
setattr(self, key, value)
File "/Users/etunni/venv/lib/python3.7/site-packages/glyphsLib/classes.py", line 1366, in setValue
value = readIntlist(value)
File "/Users/etunni/venv/lib/python3.7/site-packages/glyphsLib/types.py", line 349, in readIntlist
return _mutate_list(int, src)
File "/Users/etunni/venv/lib/python3.7/site-packages/glyphsLib/types.py", line 344, in _mutate_list
l[i] = fn(l[i])
ValueError: invalid literal for int() with base 10: 'bit 29'
```

Therefore, pre-classify into `codePageRanges` and `codePageRangesUnsupportedBits`,
https://github.com/googlefonts/glyphsLib/blob/b0fc3bcc14ba0311a7b9a6e699010aeb01899ac2/Lib/glyphsLib/builder/custom_params.py#L467-L502

For `codePageRangesUnsupportedBits`, just use the number with the `bit ` prefix removed.
https://github.com/googlefonts/glyphsLib/blob/b0fc3bcc14ba0311a7b9a6e699010aeb01899ac2/Lib/glyphsLib/builder/constants.py#L157-L196


Note: The error occurs before handling `custom_params`, so it should be fixed in the parser.