### PR TITLE
tox: Use py3.9 and up

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py37, py38, py39, py310, htmlcov
+envlist = lint, py39, py310, py311, py312, htmlcov
 ; if any of the requested python interpreters is unavailable (e.g. on the local dev
 ; workstation), the tests are skipped and tox won't return an error
 skip_missing_interpreters = true


### PR DESCRIPTION
Python 3.8 is passed end-of-life.
See https://devguide.python.org/versions/