### PR TITLE
Add additional license text for GlyphData

### DIFF
--- a/Lib/glyphsLib/data/GlyphData_AGL_LICENSE
+++ b/Lib/glyphsLib/data/GlyphData_AGL_LICENSE
@@ -1,0 +1,39 @@
+Excerpted from
+https://github.com/schriftgestalt/GlyphsInfo/raw/refs/tags/1193/README.md:
+
+## Notices
+
+### Contains Information for the `Adobe AGL`:
+Copyright 2002, 2010, 2015 Adobe Systems Incorporated. All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the
+following conditions are met:
+
+Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer.
+
+Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+Neither the name of Adobe Systems Incorporated nor the names
+of its contributors may be used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ defcon = defcon >= 0.6.0
 colr = skia-pathops
 
 [options.package_data]
-glyphsLib.data = *.xml, GlyphData_LICENSE
+glyphsLib.data = *.xml, GlyphData_LICENSE, GlyphData_AGL_LICENSE
 
 [options.packages.find]
 where = Lib


### PR DESCRIPTION
The main `LICENSE` in https://github.com/schriftgestalt/GlyphsInfo/ is MIT and is already reproduced here as `GlyphData_LICENSE`; however, the `README.md` for `GlyphsInfo` attributes the data in part to the Adobe AGL, with BSD-3-Clause terms. This commit adds that license text to a new file `GlyphData_AGL_LICENSE`.