### PR TITLE
glyphdata: strip unused script -suffix from ligature production name

### DIFF
--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -392,7 +392,8 @@ def _construct_production_name(glyph_name, data=None):
     # If all parts are in the AGLFN list, the glyph name is our production
     # name already.
     if all(part in fontTools.agl.AGL2UV for part in base_name_parts):
-        return _agl_compliant_name(glyph_name)
+        production_name = "_".join(base_name_parts) + dot + suffix
+        return _agl_compliant_name(production_name)
 
     # Turn all parts of the ligature into production names.
     _character_outside_BMP = False

--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -404,6 +404,7 @@ PRODUCTION_NAMES = {
     "ya_uMatra-tamil": "uni0BAF0BC1",
     "ya_uuMatra-tamil": "uni0BAF0BC2",
     "yoYing_underscore-thai": "uni0E0D005F",  # uni0E0D_uni005F
+    "one_one-han.paren": "one_one.paren",  # not 'one_onehan.paren'
 }
 
 


### PR DESCRIPTION
E.g. a ligature glyph named "one_one-han.paren" (as found in ButTaiwan/iansui) gets renamed "one_one.paren" in Glyphs.app whereas in glyphsLib it was keeping the original name including the script suffix (stripped of hyphen) but the script itself is not used by any of the ligature components.