### PR TITLE
[builder] Use variablePostscriptFontName from instances if present

### DIFF
--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -116,7 +116,8 @@ def _to_designspace_instance(self, instance):
     ufo_instance.familyName = instance.familyName
     ufo_instance.styleName = instance.name
     ufo_instance.postScriptFontName = (
-        instance.properties.get("postscriptFontName")
+        instance.properties.get("variablePostscriptFontName")
+        or instance.properties.get("postscriptFontName")
         or instance.customParameters["postscriptFontName"]
     )
     ufo_instance.filename = _to_filename(self, instance, ufo_instance)

--- a/tests/builder/interpolation_test.py
+++ b/tests/builder/interpolation_test.py
@@ -279,6 +279,26 @@ class DesignspaceTest(unittest.TestCase):
 
         self.expect_designspace_roundtrip(designspace)
 
+    def test_variablePostscriptFontNameProperty(self):
+        master = makeMaster("Master")
+        thin, black = makeInstance("Thin"), makeInstance("Black")
+        black.properties.append(
+            GSFontInfoValue("variablePostscriptFontName", "PSNameTest-Superfat")
+        )
+        font = makeFont([master], [thin, black], "PSNameTest")
+        designspace = to_designspace(font, instance_dir="out")
+        path = self.write_to_tmp_path(designspace, "psname.designspace")
+        d = etree.parse(path)
+
+        def psname(doc, style):
+            inst = doc.find('instances/instance[@stylename="%s"]' % style)
+            return inst.attrib.get("postscriptfontname")
+
+        self.assertIsNone(psname(d, "Thin"))
+        self.assertEqual(psname(d, "Black"), "PSNameTest-Superfat")
+
+        self.expect_designspace_roundtrip(designspace)
+
     def test_instanceOrder(self):
         # The generated *.designspace file should place instances
         # in the same order as they appear in the original source.


### PR DESCRIPTION
This seems to be the new property specifically for fvar instance postscript name, so try it first:
https://handbook.glyphsapp.com/custom-parameter-descriptions/#custom-parameter/variablePostscriptFontName https://github.com/googlefonts/fontc/pull/1525