### PR TITLE
treat disabled custom parameters as missing when getting them by name

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -168,6 +168,7 @@ def to_designspace_axes(self):
         {v["Axis"]: v["Location"] for v in cp.value}
         for cp in self.font.customParameters
         if cp.name == "Virtual Master"
+        if not cp.disabled
     ]
 
     for axis_def in get_axis_definitions(self.font):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1157,12 +1157,15 @@ class CustomParametersProxy(ListDictionaryProxy):
         length = super().__len__()
         return length + 1 if self._should_add_axes() else length
 
-    def _get_by_name(self, name):
+    def _get_by_name(self, name, skip_disabled=True):
         if name == "Axes" and isinstance(self._owner, GSFont):
             return self._owner._get_custom_parameter_from_axes()
-        if name == "Name Table Entry":
+        if name == "Name Table Entry":  # WTH is this?!
             return None
-        return super()._get_by_name(name)
+        item = super()._get_by_name(name)
+        if skip_disabled and item is not None and item.disabled:
+            return None
+        return item
 
     def _should_add_axes(self):
         if isinstance(self._owner, GSFont) and self._owner.format_version < 3:

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -25,6 +25,7 @@ import pytest
 
 import glyphsLib
 from glyphsLib import to_designspace, to_glyphs
+from glyphsLib.builder.constants import CUSTOM_PARAMETERS_KEY
 from glyphsLib.util import open_ufo
 from glyphsLib.types import Point
 
@@ -562,3 +563,23 @@ def test_designspace_generation_multiaxis_bracket(datadir, ufo_module):
     assert designspace.rules[0].subs == [
         ("v", "v.BRACKET.varAlt01"),
     ]
+
+
+@pytest.mark.parametrize("minimal", [True, False])
+def test_designspace_generation_instances_disabled_custom_params(
+    datadir, ufo_module, minimal
+):
+    with open(str(datadir.join("GlyphsUnitTestSans.glyphs"))) as f:
+        font = glyphsLib.load(f)
+
+    designspace = to_designspace(font, ufo_module=ufo_module, minimal=minimal)
+
+    regular_instance = next(
+        (i for i in designspace.instances if i.name.endswith("Regular"))
+    )
+    if minimal:
+        assert len(regular_instance.lib) == 0
+    else:
+        assert len(regular_instance.lib) == 1
+        assert CUSTOM_PARAMETERS_KEY in regular_instance.lib
+        assert regular_instance.lib[CUSTOM_PARAMETERS_KEY] == [("fsType", [])]

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -477,6 +477,25 @@ class GSFontFromFileTest(GSObjectsTestCase):
 
     def test_customParameters(self):
         font = self.font
+
+        # disabled custom parameters are ignored by getters-by-name
+        assert font.customParameters["Axis Mappings"] is None
+        assert font.customParameters.get("Axis Mappings") is None
+        assert "Axis Mappings" not in font.customParameters
+        # ... however this test font actually contains one
+        cp = font.customParameters._get_by_name("Axis Mappings", skip_disabled=False)
+        assert cp.disabled
+        assert cp.value == {"wght": {}}
+        # On the other hand, __iter__, __len__ or get-by-index still take into account
+        # the presence of the disabled parameter. Yeah it's weird, but Glyphs.app
+        # also does the same...
+        assert cp in list(font.customParameters)
+        assert font.customParameters[0] == cp
+        assert len(font.customParameters) == 2
+
+        assert font.customParameters[1].name == "note"
+        assert font.customParameters[1].value == "Bla bla"
+
         font.customParameters["trademark"] = "ThisFont is a trademark by MyFoundry.com"
         self.assertIn(
             font.customParameters["trademark"],

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -2374,6 +2374,14 @@ name = Light;
 weightClass = Light;
 },
 {
+customParameters = (
+{
+disabled = 1;
+name = fsType;
+value = (
+);
+}
+);
 interpolationWeight = 90;
 instanceInterpolations = {
 "3E7589AA-8194-470F-8E2F-13C1C581BE24" = 1;

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -27,6 +27,14 @@ name = smcp_target;
 );
 customParameters = (
 {
+disabled = 1;
+name = "Axis Mappings";
+value = {
+wght = {
+};
+};
+},
+{
 name = note;
 value = "Bla bla";
 }


### PR DESCRIPTION
This matches Glyphs.app's behavior.

Fixes https://github.com/googlefonts/glyphsLib/issues/905


