### PR TITLE
Sort bracket layers by glyph id

### DIFF
--- a/Lib/glyphsLib/builder/bracket_layers.py
+++ b/Lib/glyphsLib/builder/bracket_layers.py
@@ -253,6 +253,11 @@ def find_component_use(self):
                 self.bracket_layers.append(new_layer)
                 alternate_layers[master][glyph_name].append(new_layer)
 
+    # any components have now just been appended to the end; let's sort bracket
+    # layers by glyph order to maintain a consistent, understandable order.
+    glyphOrder = {g.name: i for (i, g) in enumerate(self.font.glyphs)}
+    self.bracket_layers.sort(key=lambda layer: glyphOrder.get(layer.parent.name))
+
 
 def synthesize_bracket_layer(old_layer, box, axes):
     new_layer = copy.copy(old_layer)  # We don't need a deep copy of everything


### PR DESCRIPTION
Bracket layers are added in two phases: first we add layers as they exist in glyphs, in the order that glyphs are listed in the font; and then later on we go and add layers for any component glyphs that have components with bracket layers.

This means the layers end up in a funny order, and then this order can impact the rules that we generate in the final font.

This tries to standardize this, by sorting the layers by glyph order after the components are added.

At a higher level I find it odd that order matters at all here, and I wonder if there could be a better approach? But for the time being this will at least give us something reasonable that fontc can replicate.