### PR TITLE
[align_alternate_layers] must not skip non-export glyphs when collecting alternate layers

### DIFF
--- a/Lib/glyphsLib/builder/transformations/align_alternate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/align_alternate_layers.py
@@ -48,7 +48,7 @@ def align_alternate_layers(font, glyph_data=None):
                         for layer in alternate_layers[master][comp.name]
                     }
                     if my_bracket_layers != components_bracket_layers:
-                        # Find what we need to add, and make them hashable
+                        # Find what we need to add
                         needed = components_bracket_layers - my_bracket_layers
                         if needed:
                             problematic_glyphs[(glyph_name, master)] |= needed
@@ -74,7 +74,18 @@ def align_alternate_layers(font, glyph_data=None):
                     "not be applied. Consider fixing the source instead."
                 )
             # Just copy the master layer for each thing we need.
-            for axis_rules in needed_brackets:
+            # Insert the new layers in a predictable, deterministic order based on
+            # the bracket layers' axis values.
+            for axis_rules in sorted(
+                needed_brackets,
+                key=lambda rules: tuple(
+                    (
+                        float("-inf") if r[0] is None else r[0],
+                        float("inf") if r[1] is None else r[1],
+                    )
+                    for r in rules
+                ),
+            ):
                 new_layer = synthesize_bracket_layer(
                     master_layers[master][glyph_name], axis_rules
                 )

--- a/Lib/glyphsLib/builder/transformations/align_alternate_layers.py
+++ b/Lib/glyphsLib/builder/transformations/align_alternate_layers.py
@@ -21,8 +21,6 @@ def align_alternate_layers(font, glyph_data=None):
     master_ids = set(master.id for master in font.masters)
 
     for glyph in font.glyphs:
-        if not glyph.export:
-            continue
         for layer in glyph.layers:
             if layer.layerId in master_ids:
                 master_layers[layer.layerId][glyph.name] = layer


### PR DESCRIPTION
I noticed what looks like a regression with glyphsLib v6.11.2, specifically after https://github.com/googlefonts/glyphsLib/pull/1092 got merged

the previous `find_component_use` code in `bracket_layers.py` was considering alternate layers inside glyphs marked as non-exportable whereas in the new align_alternate_layers.py that replaced it, I thought I might skip those but turns out it's possible for composite glyphs to reference component glyphs that are in turn marked as export=False and the code still needs to be able to align alternate layers definitions across these. At least that's my current understanding..

This is reproducible with the following ttx_diff.py command

```
python3 resources/scripts/ttx_diff.py 'https://github.com/googlefonts/Playfair?a49f9f9dc9#sources/Playfair.glyphspackage'
```