### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,15 @@ jobs:
       - lint
       - test
     runs-on: ubuntu-latest
-    # This is required to create a release using Github integration token
-    # https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions
+    environment:
+      name: publish-to-pypi
+      url: https://pypi.org/p/glyphsLib
     permissions:
+      # This is required to create a release using Github integration token
+      # https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions
       contents: write
+      # IMPORTANT: mandatory for trusted publishing:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
       with:
@@ -105,9 +110,6 @@ jobs:
         draft: false
         prerelease: ${{ env.IS_PRERELEASE }}
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         if [ "$IS_PRERELEASE" == true ]; then
           echo "DEBUG: This is a pre-release"


### PR DESCRIPTION
In light of the recent npm supply chain attacks and also https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/, I'm combing through our font stack to see if all them Py projects are using the trusted publisher mechanism as recommended by PyPI. See https://docs.pypi.org/trusted-publishers/ and https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi.

Someone needs to do two things for this PR to work:

* Create an environment called "publish-to-pypi" in this GitHub repository under Settings -> Environments. Creating alone is probably enough, no configuration needed I think.
* Follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to set up the other side on PyPI.

I'm not sure if one needs to do anything to make twine pick up the new creds, trusted publishing should be supported in v6.1.0.