### PR TITLE
localized properties: also support familyNames, licenses and trademarks

### DIFF
--- a/Lib/glyphsLib/builder/font.py
+++ b/Lib/glyphsLib/builder/font.py
@@ -77,11 +77,14 @@ INFO_FIELDS = (
 
 PROPERTIES_FIELDS = (
     ("copyright", "copyrights", 0),
-    ("openTypeNameDesigner", "designers", 9),
-    ("openTypeNameDesignerURL", "designerURL", None),
+    ("familyName", "familyNames", 1),
+    ("trademark", "trademarks", 7),
     ("openTypeNameManufacturer", "manufacturers", 8),
     ("openTypeNameManufacturerURL", "manufacturerURL", None),
+    ("openTypeNameDesigner", "designers", 9),
+    ("openTypeNameDesignerURL", "designerURL", None),
     ("openTypeNameDescription", "descriptions", 10),
+    ("openTypeNameLicense", "licenses", 13),
     ("openTypeNameSampleText", "sampleTexts", 19),
 )
 


### PR DESCRIPTION
This is a continuation of https://github.com/googlefonts/glyphsLib/pull/1108

I believe these are the remaining ones left as far as I can tell.