### PR TITLE
Fix duplicate postscript names for color layer glyphs

### DIFF
--- a/Lib/glyphsLib/builder/color_layers.py
+++ b/Lib/glyphsLib/builder/color_layers.py
@@ -36,10 +36,7 @@ def _to_ufo_color_palette_layers(builder, master, layerMapping):
                 layerGlyphName = f"{glyph.name}.color{i}"
                 ufo_layer = builder.to_ufo_layer(glyph, masterLayer)
                 ufo_glyph = ufo_layer.newGlyph(layerGlyphName)
-                builder.to_ufo_glyph(ufo_glyph, layer, glyph)
-                # Remove Unicode mapping from each color layer to avoid
-                # duplicate entries.
-                ufo_glyph.unicodes = []
+                builder.to_ufo_glyph(ufo_glyph, layer, glyph, is_color_layer_glyph=True)
             colorLayers.append((layerGlyphName, colorId))
         layerMapping[glyph.name] = colorLayers
 
@@ -194,10 +191,13 @@ def _to_ufo_color_layers(builder, ufo, master, layerMapping):
                 layerGlyphName = f"{glyph.name}.color{i}"
                 ufo_layer = builder.to_ufo_layer(glyph, masterLayer)
                 ufo_glyph = ufo_layer.newGlyph(layerGlyphName)
-                builder.to_ufo_glyph(ufo_glyph, layer, glyph, do_color_layers=False)
-                # Remove Unicode mapping from each color layer to avoid
-                # duplicate entries.
-                ufo_glyph.unicodes = []
+                builder.to_ufo_glyph(
+                    ufo_glyph,
+                    layer,
+                    glyph,
+                    do_color_layers=False,
+                    is_color_layer_glyph=True,
+                )
 
             attributes = layer.paths[0].attributes if layer.paths else {}
             if "gradient" in attributes:

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -69,14 +69,19 @@ USV_MAP = {
 USV_EXTENSIONS = tuple(USV_MAP.keys())
 
 
-def to_ufo_glyph(self, ufo_glyph, layer, glyph, do_color_layers=True):  # noqa: C901
+def to_ufo_glyph(  # noqa: C901
+    self, ufo_glyph, layer, glyph, do_color_layers=True, is_color_layer_glyph=False
+):
     """Add .glyphs metadata, paths, components, and anchors to a glyph."""
     ufo_font = self._sources[layer.associatedMasterId or layer.layerId].font
 
     if layer.layerId == layer.associatedMasterId and do_color_layers:
         self.to_ufo_glyph_color(ufo_glyph, layer, glyph)
 
-    ufo_glyph.unicodes = [int(uval, 16) for uval in glyph.unicodes]
+    # Color layer glyphs (e.g., "Acaron.color0") should not get unicode values
+    # from their parent glyph to avoid duplicate unicode mappings.
+    if not is_color_layer_glyph:
+        ufo_glyph.unicodes = [int(uval, 16) for uval in glyph.unicodes]
 
     export = glyph.export
     if not export:


### PR DESCRIPTION
Color layer glyphs (e.g., "Acaron.color0", "Acaron.color1") were getting duplicate postscript names instead of unique ones with the .colorN suffix preserved.

The bug occurred because when creating color layer glyphs, to_ufo_glyph() was copying unicode values from the parent glyph. This caused glyphdata.get_glyph() to return the base glyph's production name via unicode lookup, losing the .colorN suffix:

Before:
```
  Acaron          -> uni01CD
  Acaron.color0   -> uni01CD
  Acaron.color1   -> uni01CD
```

After:
```
  Acaron          -> uni01CD
  Acaron.color0   -> uni01CD.color0
  Acaron.color1   -> uni01CD.color1
```