### PR TITLE
Fixup handling of some custom params

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -426,8 +426,6 @@ GLYPHS_UFO_CUSTOM_PARAMS_NO_SHORT_NAME = (
     "openTypeVheaCaretOffset",
     "openTypeHeadLowestRecPPEM",
     "openTypeHeadFlags",
-    "openTypeNameVersion",
-    "openTypeNameUniqueID",
     "openTypeOS2FamilyClass",
     "postscriptSlantAngle",
     "postscriptUniqueID",


### PR DESCRIPTION
Specifically there were a number of 'long' param names that were already covered (with the appropriate short name alias) above.