### PR TITLE
[builder] Handle “hidden” axis attribute

### DIFF
--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -759,3 +759,19 @@ def test_axis_location_cp_uses_floats(ufo_module, datadir):
     assert len(ds.sources) == 1
     assert ds.axes[0].name == "Weight"
     assert ds.axes[0].map == [(400.75, 0)]
+
+
+def test_hidden_axis(ufo_module):
+    font = to_glyphs([ufo_module.Font(), ufo_module.Font()])
+    axes = [
+        {"Tag": "opsz", "Name": "Optical"},
+        {"Tag": "TEST", "Name": "Test Axis", "Hidden": 1},
+    ]
+    font.customParameters["Axes"] = axes
+    doc = to_designspace(font, ufo_module=ufo_module)
+    assert len(doc.axes) == 2
+    assert not doc.axes[0].hidden
+    assert doc.axes[1].hidden
+
+    font = to_glyphs(doc)
+    assert font.customParameters["Axes"] == axes


### PR DESCRIPTION
When converting Glyphs axes to DS ones, the hidden attribute was ignored, and the fvar HIDDEN_AXIS flag would not be set as it should.

Also handle the attribute when doing the reverse conversion.