### PR TITLE
Fix reading GSPath attributes

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3221,6 +3221,7 @@ class GSInstance(GSBase):
             writer.writeObjectKeyValue(self, "properties", condition="if_true")
             if self.type != InstanceType.SINGLE:
                 writer.writeKeyValue("type", InstanceType.VARIABLE.name.lower())
+        writer.writeObjectKeyValue(self, "userData", "if_true")
         writer.writeObjectKeyValue(
             self, "weight", default="Regular", keyName="weightClass"
         )
@@ -3253,6 +3254,7 @@ class GSInstance(GSBase):
         self.manualInterpolation = False
         self.name = "Regular"
         self.properties = []
+        self._userData = None
         self.visible = True
         self.weight = self._defaultsForName["weightClass"]
         self.width = self._defaultsForName["widthClass"]
@@ -3266,6 +3268,11 @@ class GSInstance(GSBase):
     properties = property(
         lambda self: PropertiesProxy(self),
         lambda self, value: PropertiesProxy(self).setter(value),
+    )
+
+    userData = property(
+        lambda self: UserDataProxy(self),
+        lambda self, value: UserDataProxy(self).setter(value),
     )
 
     @property

--- a/tests/data/GlyphsFileFormatv3.diff
+++ b/tests/data/GlyphsFileFormatv3.diff
@@ -1616,9 +1616,9 @@
   value = www.designer.com;
   }
   );
-- userData = {
-- "Some Key" = "Some Value";
-- };
+  userData = {
+  "Some Key" = "Some Value";
+  };
   },
   {
 + active = 0;


### PR DESCRIPTION
We need to set the attributes type to dict, otherwise we will end up using the type of the last object read, which can be anything.

The other place that has attributes, GSLayer, already sets type to dict.

The diff update show that path attributes are now correctly round-tripped.

Fixes https://github.com/googlefonts/glyphsLib/issues/1124