### PR TITLE
Add GSGlyph.locked property parsing and serialization

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -4138,6 +4138,7 @@ class GSGlyph(GSBase):
             )
         writer.writeObjectKeyValue(self, "lastChange")
         writer.writeObjectKeyValue(self, "layers", "if_true")
+        writer.writeObjectKeyValue(self, "locked", "if_true")
         if writer.format_version > 2:
             writer.writeObjectKeyValue(self, "metricLeft", "if_true")
             writer.writeObjectKeyValue(self, "metricRight", "if_true")
@@ -4230,6 +4231,7 @@ class GSGlyph(GSBase):
         self.lastChange = self._defaultsForName["lastChange"]
         self.leftKerningGroup = self._defaultsForName["leftKerningGroup"]
         self.leftKerningKey = ""
+        self.locked = False
         self.metricLeft = self._defaultsForName["metricLeft"]
         self.name = name
         self.note = self._defaultsForName["note"]
@@ -4428,6 +4430,7 @@ GSGlyph._add_parsers(
         {"plist_name": "kernLeft", "object_name": "leftKerningGroup"},  # V3
         {"plist_name": "kernRight", "object_name": "rightKerningGroup"},  # V3
         {"plist_name": "leftMetricsKey", "object_name": "metricLeft"},  # V2
+        {"plist_name": "locked", "converter": bool},
         {"plist_name": "rightMetricsKey", "object_name": "metricRight"},  # V2
         {"plist_name": "widthMetricsKey", "object_name": "metricWidth"},  # V2
         {"plist_name": "vertWidthMetricsKey", "object_name": "metricVertWidth"},  # V2

--- a/tests/data/Locked.glyphs
+++ b/tests/data/Locked.glyphs
@@ -1,0 +1,86 @@
+{
+.appVersion = "3507";
+.formatVersion = 3;
+DisplayStrings = (
+A
+);
+date = "2026-01-15 13:01:44 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2026-01-15 13:02:02 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,114,l),
+(372,114,l),
+(372,368,l),
+(197,368,l)
+);
+}
+);
+width = 600;
+}
+);
+locked = 1;
+unicode = 65;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/glyphs3_test.py
+++ b/tests/glyphs3_test.py
@@ -201,3 +201,12 @@ def test_glyphs3_shape_order(datadir, ufo_module):
     glyph_b = round_trip.glyphs["B"].layers[0]
     assert isinstance(glyph_a.shapes[0], GSPath)
     assert isinstance(glyph_b.shapes[0], GSComponent)
+
+
+def test_glyph_locked(datadir):
+    font = glyphsLib.load(str(datadir.join("Locked.glyphs")))
+    assert font.glyphs["A"].locked is True
+
+    # Round trip
+    round_trip = glyphsLib.loads(glyphsLib.dumps(font))
+    assert round_trip.glyphs["A"].locked is True


### PR DESCRIPTION
The locked property on GSGlyph was not being parsed or serialized, causing it to be lost on round-trip. Added initialization, parser, and serializer for the property.

Fixes loading/saving of .glyphs files with locked glyphs.