### PR TITLE
[propagate_anchors] Interpolate smart component anchors

### DIFF
--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -129,8 +129,8 @@ def decompose_smart_components_in_layer(self, layer):
     return new_layer
 
 
-def instantiate_smart_component(self, layer, component, pen):
-    """Instantiate a smart component by interpolating and drawing to a pointPen."""
+def get_smart_component_variation_model(layer, component):
+    """Get the variation model for a smart component."""
     # Find the GSGlyph that is being used as a component by this GSComponent
     root = component.component
 
@@ -149,9 +149,7 @@ def instantiate_smart_component(self, layer, component, pen):
         )
 
     if len(masters) == 1:
-        # Treat this as a dumb component.
-        pen.addComponent(component.name, component.transform)
-        return
+        return None, None, None
 
     model = variation_model(root, masters, layer)
 
@@ -169,6 +167,23 @@ def instantiate_smart_component(self, layer, component, pen):
         name: normalizeValue(value, axes_tuples[name], extrapolate=True)
         for name, value in component.smartComponentValues.items()
     }
+
+    return model, normalized_location, masters
+
+
+def instantiate_smart_component(self, layer, component, pen):
+    """Instantiate a smart component by interpolating and drawing to a pointPen."""
+    # Find the GSGlyph that is being used as a component by this GSComponent
+    root = component.component
+
+    model, normalized_location, masters = get_smart_component_variation_model(
+        layer, component
+    )
+    if model is None:
+        # Treat this as a dumb component.
+        pen.addComponent(component.name, component.transform)
+        return
+
     # Decompose nested smart components before extracting coordinates
     decomposed_masters = [decompose_smart_components_in_layer(self, l) for l in masters]
     coordinates = [get_coordinates(l) for l in decomposed_masters]

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -12,7 +12,14 @@ from typing import TYPE_CHECKING
 
 from fontTools.misc.transform import Transform as Affine
 
-from glyphsLib.classes import GSAnchor, GSFont, GSGlyph, GSLayer, GSComponent
+from glyphsLib.classes import (
+    GSAnchor,
+    GSFont,
+    GSGlyph,
+    GSLayer,
+    GSComponent,
+    GSSmartComponentAxis,
+)
 from glyphsLib.glyphdata import get_glyph
 from glyphsLib.types import Point, Transform
 from glyphsLib.writer import dumps
@@ -50,7 +57,7 @@ class GlyphSetBuilder:
         return {g.name: g for g in self.font.glyphs}
 
     def add_glyph(self, name: str, build_fn: Callable[["GlyphBuilder"], None]) -> Self:
-        glyph = GlyphBuilder(name)
+        glyph = GlyphBuilder(name, self.font)
         build_fn(glyph)
         # this inserts the glyph in the font and sets the glyph.parent attribute to it;
         # GSLayer._is_bracket_layer()/_bracket_axis_rules() require this to check the
@@ -60,13 +67,14 @@ class GlyphSetBuilder:
 
 
 class GlyphBuilder:
-    def __init__(self, name: str):
+    def __init__(self, name: str, font: GSFont = None):
         info = get_glyph(name)
         self.glyph = glyph = GSGlyph()
         glyph.name = name
         glyph.unicode = info.unicode
         glyph.category = info.category
         glyph.subCategory = info.subCategory
+        glyph.parent = font
         self.num_masters = 0
         self.num_alternates = 0
         self.add_master_layer()
@@ -117,9 +125,30 @@ class GlyphBuilder:
         self.glyph.subCategory = subCategory
         return self
 
-    def add_component(self, name: str, pos: tuple[float, float]) -> Self:
+    def add_smartComponentAxis(
+        self, name: str, top_value: float, bottom_value: float
+    ) -> Self:
+        axis = GSSmartComponentAxis()
+        axis.name = name
+        axis.topValue = top_value
+        axis.bottomValue = bottom_value
+        self.glyph.smartComponentAxes.append(axis)
+        return self
+
+    def set_smartComponentPoleMapping(self, name: str, pole: int) -> Self:
+        self.current_layer.smartComponentPoleMapping[name] = pole
+        return self
+
+    def add_component(
+        self,
+        name: str,
+        pos: tuple[float, float],
+        smart_component_values: dict[str, float] = None,
+    ) -> Self:
         component = GSComponent(name, offset=pos)
         self.current_layer.components.append(component)
+        if smart_component_values:
+            component.smartComponentValues = smart_component_values
         return self
 
     def rotate_component(self, degrees: float) -> Self:
@@ -830,3 +859,69 @@ def test_propagate_anchors_after_aligining_alternates(test_file):
     assert alt_bottom.name == master_bottom.name == "bottom"
     assert tuple(alt_bottom.position) == (329, 0)
     assert tuple(master_bottom.position) == (301, 0)
+
+
+def test_smart_component_anchors():
+    glyphs = (
+        GlyphSetBuilder()
+        .add_glyph(
+            "base",
+            lambda glyph: (
+                glyph.add_smartComponentAxis("TEST", 100, -100)
+                .set_smartComponentPoleMapping("TEST", 1)
+                .add_anchor("top", (23, 103))
+                .add_anchor("bottom", (36, -51))
+                .add_backup_layer()
+                .set_smartComponentPoleMapping("TEST", 2)
+                .add_anchor("top", (33, 123))
+                .add_anchor("bottom", (36, -51))
+            ),
+        )
+        .add_glyph(
+            "smart1",
+            lambda glyph: (glyph.add_component("base", (0, 0), {"TEST": -100})),
+        )
+        .add_glyph(
+            "smart2",
+            lambda glyph: (glyph.add_component("base", (0, 0), {"TEST": 100})),
+        )
+        .add_glyph(
+            "smart3",
+            lambda glyph: (glyph.add_component("base", (0, 0), {"TEST": 0})),
+        )
+        .add_glyph(
+            "smart4",
+            lambda glyph: (glyph.add_component("base", (20, 10), {"TEST": 0})),
+        )
+        .build()
+    )
+    propagate_all_anchors_impl(glyphs)
+
+    assert_anchors(
+        glyphs["smart1"].layers[0].anchors,
+        [
+            ("top", (23, 103)),
+            ("bottom", (36, -51)),
+        ],
+    )
+    assert_anchors(
+        glyphs["smart2"].layers[0].anchors,
+        [
+            ("top", (33, 123)),
+            ("bottom", (36, -51)),
+        ],
+    )
+    assert_anchors(
+        glyphs["smart3"].layers[0].anchors,
+        [
+            ("top", (28, 113)),
+            ("bottom", (36, -51)),
+        ],
+    )
+    assert_anchors(
+        glyphs["smart4"].layers[0].anchors,
+        [
+            ("top", (48, 123)),
+            ("bottom", (56, -41)),
+        ],
+    )


### PR DESCRIPTION
When propagating smart component anchors, we need to interpolate the anchors, otherwise we end up with the wrong anchor positions.