### PR TITLE
[builder] Check vhea custom parameters in _is_vertical()

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -194,22 +194,21 @@ class UFOBuilder(LoggerMixin):
         # To match ufo2ft, require all three vhea params (ascender, descender, lineGap):
         # https://github.com/googlefonts/ufo2ft/blob/28acf8870487/Lib/ufo2ft/outlineCompiler.py#L154-L163
         # https://github.com/googlefonts/glyphsLib/issues/1132
+        # Each pair contains aliases for the same metric
+        vhea_metrics = (
+            {"vheaVertAscender", "vheaVertTypoAscender"},
+            {"vheaVertDescender", "vheaVertTypoDescender"},
+            {"vheaVertLineGap", "vheaVertTypoLineGap"},
+        )
+
         def has_all_vhea_params(custom_params):
             names = {p.name for p in custom_params}
-            # Each pair contains aliases for the same metric
-            vhea_metrics = (
-                {"vheaVertAscender", "vheaVertTypoAscender"},
-                {"vheaVertDescender", "vheaVertTypoDescender"},
-                {"vheaVertLineGap", "vheaVertTypoLineGap"},
-            )
             return all(names & metric for metric in vhea_metrics)
 
-        if has_all_vhea_params(self.font.customParameters):
+        if has_all_vhea_params(self.font.customParameters) or any(
+            has_all_vhea_params(master.customParameters) for master in self.font.masters
+        ):
             return True
-
-        for master in self.font.masters:
-            if has_all_vhea_params(master.customParameters):
-                return True
 
         # Check for glyph-level vertical attributes
         master_ids = {m.id for m in self.font.masters}

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -190,6 +190,28 @@ class UFOBuilder(LoggerMixin):
         self.glyphdata = glyph_data
 
     def _is_vertical(self):
+        # Check for vhea custom parameters at font or master level.
+        # To match ufo2ft, require all three vhea params (ascender, descender, lineGap):
+        # https://github.com/googlefonts/ufo2ft/blob/28acf8870487/Lib/ufo2ft/outlineCompiler.py#L154-L163
+        # https://github.com/googlefonts/glyphsLib/issues/1132
+        def has_all_vhea_params(custom_params):
+            names = {p.name for p in custom_params}
+            # Each pair contains aliases for the same metric
+            vhea_metrics = (
+                {"vheaVertAscender", "vheaVertTypoAscender"},
+                {"vheaVertDescender", "vheaVertTypoDescender"},
+                {"vheaVertLineGap", "vheaVertTypoLineGap"},
+            )
+            return all(names & metric for metric in vhea_metrics)
+
+        if has_all_vhea_params(self.font.customParameters):
+            return True
+
+        for master in self.font.masters:
+            if has_all_vhea_params(master.customParameters):
+                return True
+
+        # Check for glyph-level vertical attributes
         master_ids = {m.id for m in self.font.masters}
         for glyph in self.font.glyphs:
             for layer in glyph.layers:


### PR DESCRIPTION
Previously, _is_vertical() only returned True if at least one glyph had vertWidth or vertOrigin attributes. This meant that fonts with vhea custom parameters (vheaVertAscender, vheaVertDescender, vheaVertLineGap) but no explicit per-glyph vertical metrics would not populate glyph.height in the resulting UFO.

Since UFO's glyph.height defaults to 0, this led to vmtx tables with all zero advance heights.

Now _is_vertical() also returns True when all three vhea custom parameters are defined at the font or master level (matching ufo2ft's behavior). This ensures that to_ufo_glyph_height_and_vertical_origin() is called for each glyph, setting height to typoAscender - typoDescender as the default.

Fixes https://github.com/googlefonts/glyphsLib/issues/1132