### PR TITLE
Fix smart components not decomposed at default location

### DIFF
--- a/Lib/glyphsLib/builder/components.py
+++ b/Lib/glyphsLib/builder/components.py
@@ -74,7 +74,7 @@ def to_ufo_components(self, ufo_glyph, layer):
         # if so) or changing the representation format (in which case we leave it
         # as a component and save the smart component values).
         # See https://github.com/googlefonts/glyphsLib/pull/822
-        if component.smartComponentValues and component.component.smartComponentAxes:
+        if component.component and component.component.smartComponentAxes:
             instantiate_smart_component(self, layer, component, pen)
         else:
             pen.addComponent(component_name, component.transform)

--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -103,7 +103,7 @@ def decompose_smart_components_in_layer(self, layer):
     from glyphsLib.pens import LayerPointPen
 
     has_smart_components = any(
-        comp.smartComponentValues and comp.component.smartComponentAxes
+        comp.component and comp.component.smartComponentAxes
         for comp in layer.components
     )
     if not has_smart_components:
@@ -120,7 +120,7 @@ def decompose_smart_components_in_layer(self, layer):
         if isinstance(shape, GSPath):
             new_layer.paths.append(shape.clone())
         elif isinstance(shape, GSComponent):
-            if shape.smartComponentValues and shape.component.smartComponentAxes:
+            if shape.component and shape.component.smartComponentAxes:
                 # Recursively decompose this smart component
                 instantiate_smart_component(self, new_layer, shape, pen)
             else:

--- a/Lib/glyphsLib/builder/transformations/propagate_anchors.py
+++ b/Lib/glyphsLib/builder/transformations/propagate_anchors.py
@@ -230,7 +230,7 @@ def anchors_traversing_components(
             )
             continue
 
-        if component.smartComponentValues and component.component.smartComponentAxes:
+        if component.component and component.component.smartComponentAxes:
             # If this is a smart component, we need to interpolate the anchors
             _interpolate_smart_component_anchors(
                 layer, component, glyphs, done_anchors, anchors


### PR DESCRIPTION
When a smart component is placed at its default location, Glyphs.app doesn't store the 'piece' attribute, so smartComponentValues is empty. The check `comp.smartComponentValues and comp.component.smartComponentAxes` short-circuits on the empty dict and skips decomposition.

Fix by checking `comp.component.smartComponentAxes` as the primary indicator that a component is smart, with a null guard for when the referenced glyph doesn't exist.

Fixes https://github.com/googlefonts/glyphsLib/issues/1134