### PR TITLE
[propagate_anchors] support interpolating anchors for intermediate (brace) layers on composite glyphs

### DIFF
--- a/Lib/glyphsLib/builder/transformations/propagate_anchors.py
+++ b/Lib/glyphsLib/builder/transformations/propagate_anchors.py
@@ -20,6 +20,8 @@ from math import atan2, degrees, isinf
 from typing import TYPE_CHECKING
 
 from fontTools.misc.transform import Transform
+from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
+from fontTools.varLib.models import VariationModel, normalizeLocation
 
 from glyphsLib import glyphdata
 from glyphsLib.classes import GSAnchor
@@ -43,12 +45,15 @@ def propagate_all_anchors(
     category and subCategory of glyphs.
     """
     glyphs = {glyph.name: glyph for glyph in font.glyphs}
-    propagate_all_anchors_impl(glyphs, glyph_data=glyph_data)
+    propagate_all_anchors_impl(glyphs, font=font, glyph_data=glyph_data)
 
 
 # the actual implementation, easier to test and compare with the original Rust code
 def propagate_all_anchors_impl(
-    glyphs: dict[str, GSGlyph], *, glyph_data: glyphdata.GlyphData | None = None
+    glyphs: dict[str, GSGlyph],
+    *,
+    font: GSFont | None = None,
+    glyph_data: glyphdata.GlyphData | None = None,
 ) -> None:
     # the reference implementation does this recursively, but we opt to
     # implement it by pre-sorting the work to ensure we always process components
@@ -61,9 +66,20 @@ def propagate_all_anchors_impl(
     # to make this work, we write the anchors to a separate data structure, and
     # then only update the actual glyphs after we've done all the work.
     all_anchors: dict[str, dict[str, list[GSAnchor]]] = {}
+
+    # For brace layer interpolation
+    master_locations, axes_triples = _get_design_space_info(font)
+    layer_locations: dict[str, dict[str, float]] = {}
+    variation_model_cache: dict = {}
+
     for name in todo:
         glyph = glyphs[name]
         for layer in _interesting_layers(glyph):
+            # Record this layer's location before traversal so it's available
+            # for interpolation of component anchors at brace layer locations
+            loc = _get_layer_location(layer, master_locations)
+            if loc is not None:
+                layer_locations[layer.layerId] = loc
             anchors = anchors_traversing_components(
                 glyph,
                 layer,
@@ -71,6 +87,9 @@ def propagate_all_anchors_impl(
                 all_anchors,
                 num_base_glyphs,
                 glyph_data,
+                layer_locations=layer_locations,
+                axes_triples=axes_triples,
+                variation_model_cache=variation_model_cache,
             )
             maybe_log_new_anchors(anchors, glyph, layer)
             all_anchors.setdefault(name, {})[layer.layerId] = anchors
@@ -107,14 +126,10 @@ def _is_master_layer(layer: GSLayer) -> bool:
 
 
 def _interesting_layers(glyph):
-    # only master layers are currently supported for anchor propagation:
-    # https://github.com/googlefonts/glyphsLib/issues/1017
     return (
         l
         for l in glyph.layers
-        if _is_master_layer(l) or l._is_bracket_layer()
-        # or l._is_brace_layer
-        # etc.
+        if _is_master_layer(l) or l._is_bracket_layer() or l._is_brace_layer()
     )
 
 
@@ -146,6 +161,183 @@ def _get_subCategory(
     )
 
 
+def _get_design_space_info(
+    font: GSFont | None,
+) -> tuple[dict[str, dict[str, float]], dict[str, tuple[float, float, float]]]:
+    """Compute master locations and axis (min, default, max) triples from a font.
+
+    Returns a (master_locations, axes_triples) tuple where:
+    - master_locations maps master ID -> {axis_name: design_loc}
+    - axes_triples maps axis_name -> (minimum, default, maximum)
+
+    Returns empty dicts if font is None or has no masters.
+    """
+    if not font or not font.masters:
+        return {}, {}
+
+    from glyphsLib.builder.axes import get_axis_definitions, get_regular_master
+
+    axis_defs = get_axis_definitions(font)
+    default_master = get_regular_master(font)
+    master_locations = {}
+    for master in font.masters:
+        master_locations[master.id] = {
+            a.name: a.get_design_loc(master) for a in axis_defs
+        }
+    default_loc = master_locations[default_master.id]
+    axes_triples = {}
+    for axis_def in axis_defs:
+        vals = [loc[axis_def.name] for loc in master_locations.values()]
+        axes_triples[axis_def.name] = (min(vals), default_loc[axis_def.name], max(vals))
+    return master_locations, axes_triples
+
+
+def _get_layer_location(
+    layer: GSLayer,
+    master_locations: dict[str, dict[str, float]],
+) -> dict[str, float] | None:
+    """Return the design-space coordinates for a layer as a dict.
+
+    For master layers, this is the master's axis values.
+    For brace (intermediate) layers, this is the brace coordinates, filled
+    with the associated master's values for any missing trailing axes.
+    Returns None for other layer types (bracket, backup, etc.).
+    """
+    if not master_locations:
+        return None
+    if layer._is_master_layer:
+        return master_locations[layer.layerId]
+    if layer._is_brace_layer():
+        master_loc = master_locations.get(layer.associatedMasterId)
+        if master_loc is None:
+            return None
+        axis_names = list(master_loc.keys())
+        coords = layer._brace_coordinates()
+        # Fill missing trailing axes with the associated master's values
+        loc = {}
+        for i, name in enumerate(axis_names):
+            if i < len(coords):
+                loc[name] = coords[i]
+            else:
+                loc[name] = master_loc[name]
+        return loc
+    return None
+
+
+def _interpolate_component_anchors(
+    component_name: str,
+    target_location: dict[str, float],
+    all_anchors: dict[str, dict[str, list[GSAnchor]]],
+    layer_locations: dict[str, dict[str, float]],
+    axes_triples: dict[str, tuple[float, float, float]],
+    variation_model_cache: dict,
+) -> list[GSAnchor] | None:
+    """Interpolate a component's anchors at a location where it has no source.
+
+    Collects all available (location, anchors) pairs for the component, builds
+    a VariationModel from normalized locations, and interpolates each anchor
+    independently. Models are cached by source location set.
+
+    Returns None if the component has no entries in all_anchors or interpolation
+    fails entirely.
+    """
+    comp_layers = all_anchors.get(component_name)
+    if not comp_layers:
+        return None
+
+    # Collect (normalized_location, anchors) pairs from master and brace layers.
+    # Bracket layers are excluded: they define alternate glyph shapes whose
+    # anchors shouldn't be interpolation sources for the default shape.
+    # TODO (#1050): bracket+brace layers could be sources for alternate shapes.
+    per_location: list[tuple[dict[str, float], list[GSAnchor]]] = []
+    for layer_id, layer_anchors in comp_layers.items():
+        loc = layer_locations.get(layer_id)
+        if loc is None:
+            continue
+        norm_loc = normalizeLocation(loc, axes_triples)
+        per_location.append((norm_loc, layer_anchors))
+
+    if not per_location:
+        return None
+
+    norm_target = normalizeLocation(target_location, axes_triples)
+
+    # Get canonical anchor names from the default source location.
+    default_source_anchors = next(
+        (
+            anchors
+            for norm_loc, anchors in per_location
+            if all(v == 0.0 for v in norm_loc.values())
+        ),
+        None,
+    )
+    if default_source_anchors is None:
+        logger.warning(
+            "component '%s' has no default source for anchor interpolation; "
+            "falling back to first available source",
+            component_name,
+        )
+        default_source_anchors = per_location[0][1]
+    anchor_names = [a.name for a in default_source_anchors]
+    if not anchor_names:
+        return []
+
+    # Build per-anchor {normalized_location: position} maps
+    per_anchor: dict[str, list[tuple[dict[str, float], Point]]] = {}
+    for norm_loc, anchors in per_location:
+        for anchor in anchors:
+            if anchor.name in anchor_names:
+                per_anchor.setdefault(anchor.name, []).append(
+                    (norm_loc, anchor.position)
+                )
+
+    axis_order = list(axes_triples.keys())
+
+    # Interpolate each anchor independently from its own set of source locations
+    result = []
+    for name in anchor_names:
+        sources = per_anchor.get(name)
+        if not sources:
+            continue
+
+        source_locs = [loc for loc, _ in sources]
+        cache_key = frozenset(tuple(sorted(loc.items())) for loc in source_locs)
+        if cache_key not in variation_model_cache:
+            try:
+                variation_model_cache[cache_key] = VariationModel(
+                    source_locs, axisOrder=axis_order
+                )
+            except Exception as e:
+                logger.warning(
+                    "failed to build VariationModel for anchor '%s' on "
+                    "component '%s': %s",
+                    name,
+                    component_name,
+                    e,
+                )
+                continue
+
+        model = variation_model_cache[cache_key]
+        master_values = [GlyphCoordinates([(pos.x, pos.y)]) for _, pos in sources]
+
+        try:
+            interpolated = model.interpolateFromMasters(norm_target, master_values)
+        except Exception as e:
+            logger.warning(
+                "failed to interpolate anchor '%s' on component '%s': %s",
+                name,
+                component_name,
+                e,
+            )
+            continue
+
+        if interpolated:
+            x, y = interpolated[0]
+            result.append(GSAnchor(name=name, position=Point(x, y)))
+
+    return result if result else None
+
+
 def _interpolate_smart_component_anchors(
     layer: GSLayer,
     component: GSComponent,
@@ -154,7 +346,6 @@ def _interpolate_smart_component_anchors(
     anchors: list[GSAnchor],
 ) -> None:
     from ..smart_components import get_smart_component_variation_model
-    from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 
     model, location, masters = get_smart_component_variation_model(layer, component)
     if model is not None:
@@ -199,6 +390,51 @@ def _get_base_glyph_count(
     return base_glyph_counts.get((component_name, layer.associatedMasterId), 0)
 
 
+def _resolve_component_anchors(
+    component: GSComponent,
+    layer: GSLayer,
+    glyph: GSGlyph,
+    glyphs: dict[str, GSGlyph],
+    done_anchors: dict[str, dict[str, list[GSAnchor]]],
+    layer_locations: dict[str, dict[str, float]] | None,
+    axes_triples: dict[str, tuple[float, float, float]] | None,
+    variation_model_cache: dict | None,
+) -> list[GSAnchor] | None:
+    """Get anchors for a component, falling back to interpolation for brace layers."""
+    anchors = get_component_layer_anchors(component, layer, glyphs, done_anchors)
+    if anchors is not None:
+        return anchors
+
+    # Component doesn't have an explicit source at this location (e.g. the
+    # composite has a brace layer that its component doesn't). Try to
+    # interpolate anchors from the component's available sources.
+    if (
+        layer._is_brace_layer()
+        and layer_locations is not None
+        and axes_triples
+        and variation_model_cache is not None
+    ):
+        target_loc = layer_locations.get(layer.layerId)
+        if target_loc is None:
+            logger.warning(
+                "brace layer '%s' of glyph '%s' has no known "
+                "design-space location; skipping anchor interpolation",
+                layer.name,
+                glyph.name,
+            )
+        else:
+            anchors = _interpolate_component_anchors(
+                component.name,
+                target_loc,
+                done_anchors,
+                layer_locations,
+                axes_triples,
+                variation_model_cache,
+            )
+
+    return anchors
+
+
 def anchors_traversing_components(
     glyph: GSGlyph,
     layer: GSLayer,
@@ -206,6 +442,9 @@ def anchors_traversing_components(
     done_anchors: dict[str, dict[str, list[GSAnchor]]],
     base_glyph_counts: dict[(str, str), int],
     glyph_data: glyphdata.GlyphData | None = None,
+    layer_locations: dict[str, dict[str, float]] | None = None,
+    axes_triples: dict[str, tuple[float, float, float]] | None = None,
+    variation_model_cache: dict | None = None,
 ) -> list[GSAnchor]:
     """Return the anchors for this glyph, including anchors from components
 
@@ -237,7 +476,16 @@ def anchors_traversing_components(
     for component_idx, component in enumerate(layer.components):
         # because we process dependencies first we know that all components
         # referenced have already been propagated
-        anchors = get_component_layer_anchors(component, layer, glyphs, done_anchors)
+        anchors = _resolve_component_anchors(
+            component,
+            layer,
+            glyph,
+            glyphs,
+            done_anchors,
+            layer_locations,
+            axes_triples,
+            variation_model_cache,
+        )
         if anchors is None:
             logger.debug(
                 "could not get layer '%s' for component '%s' of glyph '%s'",
@@ -457,25 +705,20 @@ def get_component_layer_anchors(
     if glyph is None:
         return None  # invalid component reference, skip
 
-    # in Glyphs.app, the `componentLayer` property would synthesize a layer
-    # if it is missing. glyphsLib does not have that yet, so for now we
-    # only support the corresponding 'master' or alternate ('bracket') layers
-    # of a component's base glyph.
-
     layer_anchors = None
 
-    # whether the parent layer where the component is defined is a 'master' layer
-    # and/or a 'bracket' or alternate layer (masters can have bracket layers too but
-    # glyphsLib doesn't support that yet).
     parent_is_master = _is_master_layer(layer)
     parent_is_bracket = layer._is_bracket_layer()
+    parent_is_brace = layer._is_brace_layer()
     parent_axis_rules = (
         [] if not parent_is_bracket else list(layer._bracket_axis_rules())
     )
 
-    # we support propagating anchors from the component base glyph's 'master' layer
-    # (with same layerId), or from a 'bracket' alternate layer with matching axis
-    # rules and the same associated master; we try the latter first
+    # Try matching: master layer (by layerId), bracket layer (by axis rules +
+    # associated master), or brace layer (by coordinates).
+    # TODO (#1050, #1018): A layer can be both bracket and brace; matching
+    # should check both axis rules AND coordinates for such layers.
+    # Using GSLayer.layerKey() (#1018) would handle all combinations.
     for comp_layer in _interesting_layers(glyph):
         if (
             parent_is_bracket
@@ -485,11 +728,18 @@ def get_component_layer_anchors(
         ) or (parent_is_master and comp_layer.layerId == layer.layerId):
             layer_anchors = anchors[component.name][comp_layer.layerId]
             break
+        if (
+            parent_is_brace
+            and comp_layer._is_brace_layer()
+            and comp_layer._brace_coordinates() == layer._brace_coordinates()
+            and comp_layer.layerId in anchors.get(component.name, {})
+        ):
+            layer_anchors = anchors[component.name][comp_layer.layerId]
+            break
 
-    # else we fall back to the associated master layer; this is guaranteed to exist
-    # since all glyphs must at least define one layer per master; if this raised
-    # KeyError, the font is broken
-    if layer_anchors is None:
+    # For brace layers, return None when no match is found so the caller can
+    # try interpolation. For other layer types, fall back to the associated master.
+    if layer_anchors is None and not parent_is_brace:
         layer_anchors = anchors[component.name][layer.associatedMasterId]
 
     if layer_anchors is not None:

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -118,6 +118,27 @@ class GlyphBuilder:
         self.current_layer = layer
         return self
 
+    def add_brace_layer(self, coordinates, associated_master_idx=None):
+        if associated_master_idx is None:
+            # Find the most recent master layer
+            associated_master_id = None
+            for l in reversed(list(self.glyph.layers)):
+                if l._is_master_layer:
+                    associated_master_id = l.layerId
+                    break
+            assert associated_master_id is not None
+        else:
+            master_layer = self.glyph.layers[associated_master_idx]
+            associated_master_id = master_layer.layerId
+        layer = GSLayer()
+        layer.name = f"{{{', '.join(str(c) for c in coordinates)}}}"
+        layer.layerId = str(uuid.uuid4()).upper()
+        layer.associatedMasterId = associated_master_id
+        layer.attributes["coordinates"] = coordinates
+        self.glyph.layers.append(layer)
+        self.current_layer = layer
+        return self
+
     def set_category(self, category: str) -> Self:
         self.glyph.category = category
         return self
@@ -1042,4 +1063,258 @@ def test_bracket_ligature_anchor_numbering():
     assert_anchors(
         bracket_layers[0].anchors,
         [("top_1", (100, 700)), ("top_2", (500, 600))],
+    )
+
+
+def test_interpolate_brace_layer_component_anchors():
+    """When a composite has a brace layer but its component doesn't, interpolate
+    the component's anchor positions from its available master sources.
+
+    See: https://github.com/googlefonts/fontc/issues/1661
+    """
+    builder = GlyphSetBuilder()
+    # Set up font with two masters on the weight axis
+    master0 = GSFontMaster()
+    master0.id = "master-0"
+    master0.axes = [100]  # light
+    builder.font.masters.append(master0)
+    master1 = GSFontMaster()
+    master1.id = "master-1"
+    master1.axes = [200]  # bold
+    builder.font.masters.append(master1)
+
+    # 'ae': base glyph with anchors at both masters
+    builder.add_glyph(
+        "ae",
+        lambda glyph: (
+            glyph.add_anchor("top", (300, 600))
+            .add_anchor("bottom", (300, 0))
+            .add_master_layer()
+            .add_anchor("top", (380, 700))
+            .add_anchor("bottom", (380, 0))
+        ),
+    )
+
+    # 'acutecomb': mark glyph with anchors at both masters only (no brace layer)
+    builder.add_glyph(
+        "acutecomb",
+        lambda glyph: (
+            glyph.add_anchor("_top", (100, 500))
+            .add_anchor("top", (120, 700))
+            .add_master_layer()
+            .add_anchor("_top", (140, 520))
+            .add_anchor("top", (160, 740))
+        ),
+    )
+
+    # 'aeacute': composite with 2 masters + a brace layer at weight=150
+    builder.add_glyph(
+        "aeacute",
+        lambda glyph: (
+            glyph.add_component("ae", (0, 0))
+            .add_component("acutecomb", (200, 100))
+            .add_master_layer()
+            .add_component("ae", (0, 0))
+            .add_component("acutecomb", (240, 120))
+            # Add brace layer at weight=150 (midpoint)
+            .add_brace_layer([150], associated_master_idx=0)
+            .add_component("ae", (0, 0))
+            .add_component("acutecomb", (220, 110))
+        ),
+    )
+
+    propagate_all_anchors(builder.font)
+
+    aeacute = builder.font.glyphs["aeacute"]
+
+    # Master 0 (weight=100): acutecomb has explicit sources
+    # top from acutecomb.top (120, 700) + offset (200, 100) = (320, 800)
+    # bottom from ae: (300, 0)
+    assert_anchors(
+        aeacute.layers["master-0"].anchors,
+        [("top", (320, 800)), ("bottom", (300, 0))],
+    )
+
+    # Master 1 (weight=200): acutecomb has explicit sources
+    # top from acutecomb.top (160, 740) + offset (240, 120) = (400, 860)
+    # bottom from ae: (380, 0)
+    assert_anchors(
+        aeacute.layers["master-1"].anchors,
+        [("top", (400, 860)), ("bottom", (380, 0))],
+    )
+
+    # Brace layer (weight=150): both ae and acutecomb must be INTERPOLATED
+    # Interpolated ae anchors at weight=150 (midpoint of 100..200):
+    #   top: (300, 600) + 0.5 * ((380, 700) - (300, 600)) = (340, 650)
+    #   bottom: (300, 0) + 0.5 * ((380, 0) - (300, 0)) = (340, 0)
+    # Interpolated acutecomb anchors at weight=150:
+    #   _top: (100, 500) + 0.5 * ((140, 520) - (100, 500)) = (120, 510)
+    #   top:  (120, 700) + 0.5 * ((160, 740) - (120, 700)) = (140, 720)
+    # Component offsets at brace layer: acutecomb offset = (220, 110)
+    # Final top = interpolated acutecomb.top + offset = (140, 720) + (220, 110) = (360, 830)
+    # Final bottom = interpolated ae.bottom = (340, 0)
+    brace_layers = [l for l in aeacute.layers if l._is_brace_layer()]
+    assert len(brace_layers) == 1
+    assert_anchors(
+        brace_layers[0].anchors,
+        [("top", (360, 830)), ("bottom", (340, 0))],
+    )
+
+
+def test_brace_layer_matching():
+    """When the component has a matching brace layer (same coordinates +
+    associated master), use it directly without interpolation."""
+    builder = GlyphSetBuilder()
+    master0 = GSFontMaster()
+    master0.id = "master-0"
+    master0.axes = [100]
+    builder.font.masters.append(master0)
+    master1 = GSFontMaster()
+    master1.id = "master-1"
+    master1.axes = [200]
+    builder.font.masters.append(master1)
+
+    # 'base': has a brace layer at weight=150
+    builder.add_glyph(
+        "base",
+        lambda glyph: (
+            glyph.add_anchor("top", (100, 600))
+            .add_master_layer()
+            .add_anchor("top", (200, 700))
+            .add_brace_layer([150], associated_master_idx=0)
+            .add_anchor("top", (160, 660))  # explicit, not interpolated
+        ),
+    )
+
+    # 'composite': also has a brace layer at weight=150
+    builder.add_glyph(
+        "composite",
+        lambda glyph: (
+            glyph.add_component("base", (0, 0))
+            .add_master_layer()
+            .add_component("base", (0, 0))
+            .add_brace_layer([150], associated_master_idx=0)
+            .add_component("base", (10, 0))
+        ),
+    )
+
+    propagate_all_anchors(builder.font)
+
+    composite = builder.font.glyphs["composite"]
+    brace_layers = [l for l in composite.layers if l._is_brace_layer()]
+    assert len(brace_layers) == 1
+    # Should use the component's explicit brace layer anchor (160, 660) + offset (10, 0)
+    assert_anchors(brace_layers[0].anchors, [("top", (170, 660))])
+
+
+def test_brace_layer_interpolation_with_existing_brace_sources():
+    """Component has brace layers at different coordinates; interpolation uses
+    both masters and existing brace layers as sources."""
+    builder = GlyphSetBuilder()
+    master0 = GSFontMaster()
+    master0.id = "master-0"
+    master0.axes = [100]
+    builder.font.masters.append(master0)
+    master1 = GSFontMaster()
+    master1.id = "master-1"
+    master1.axes = [300]
+    builder.font.masters.append(master1)
+
+    # 'base': 2 masters + a brace layer at weight=200
+    builder.add_glyph(
+        "base",
+        lambda glyph: (
+            glyph.add_anchor("top", (100, 600))
+            .add_master_layer()
+            .add_anchor("top", (300, 800))
+            .add_brace_layer([200], associated_master_idx=0)
+            .add_anchor("top", (220, 720))  # off the linear path
+        ),
+    )
+
+    # 'composite': brace layer at weight=150 (not matched by component)
+    builder.add_glyph(
+        "composite",
+        lambda glyph: (
+            glyph.add_component("base", (0, 0))
+            .add_master_layer()
+            .add_component("base", (0, 0))
+            .add_brace_layer([150], associated_master_idx=0)
+            .add_component("base", (0, 0))
+        ),
+    )
+
+    propagate_all_anchors(builder.font)
+
+    composite = builder.font.glyphs["composite"]
+    brace_layers = [l for l in composite.layers if l._is_brace_layer()]
+    assert len(brace_layers) == 1
+
+    # The component has 3 sources: weight=100, 200, 300.
+    # Interpolating at weight=150 with a 3-source model should use the brace
+    # layer at 200 as well, giving a different result than simple 2-master lerp.
+    # With 2-master linear: top = (100, 600) + 0.25 * ((300, 800) - (100, 600)) = (150, 650)
+    # With 3-source model the result differs because (220, 720) at weight=200 is
+    # off the linear path between (100, 600) and (300, 800).
+    anchors = brace_layers[0].anchors
+    assert len(anchors) == 1
+    assert anchors[0].name == "top"
+    # Verify it's NOT the 2-master linear result
+    assert (round(anchors[0].position.x), round(anchors[0].position.y)) != (150, 650)
+
+
+def test_interpolate_brace_uses_default_source_anchor_names():
+    """Canonical anchor names should come from the default source location.
+
+    If an anchor is present in the default source but missing from another source,
+    it must still be interpolated (sparse interpolation), not dropped.
+    """
+    builder = GlyphSetBuilder()
+    master0 = GSFontMaster()
+    master0.id = "master-0"
+    master0.name = "Bold"
+    master0.axes = [200]
+    builder.font.masters.append(master0)
+    master1 = GSFontMaster()
+    master1.id = "master-1"
+    master1.name = "Regular"
+    master1.axes = [100]
+    builder.font.masters.append(master1)
+    # Make default source != first source layer
+    builder.font.customParameters["Variable Font Origin"] = "master-1"
+
+    # Component:
+    # - non-default source (master-0): top only
+    # - default source (master-1): top + bottom
+    builder.add_glyph(
+        "base",
+        lambda glyph: (
+            glyph.add_anchor("top", (200, 700))
+            .add_master_layer()
+            .add_anchor("top", (100, 600))
+            .add_anchor("bottom", (100, 0))
+        ),
+    )
+
+    # Composite has a brace layer at weight=150; component has no matching brace layer
+    builder.add_glyph(
+        "comp",
+        lambda glyph: (
+            glyph.add_component("base", (0, 0))
+            .add_master_layer()
+            .add_component("base", (0, 0))
+            .add_brace_layer([150], associated_master_idx=0)
+            .add_component("base", (0, 0))
+        ),
+    )
+
+    propagate_all_anchors(builder.font)
+
+    comp = builder.font.glyphs["comp"]
+    brace_layers = [l for l in comp.layers if l._is_brace_layer()]
+    assert len(brace_layers) == 1
+    # `bottom` must not be dropped just because it's missing in non-default source.
+    assert_anchors(
+        brace_layers[0].anchors,
+        [("top", (150, 650)), ("bottom", (100, 0))],
     )

--- a/tests/builder/transformations/propagate_anchors_test.py
+++ b/tests/builder/transformations/propagate_anchors_test.py
@@ -29,6 +29,7 @@ from glyphsLib.builder.transformations.align_alternate_layers import (
     align_alternate_layers,
 )
 from glyphsLib.builder.transformations.propagate_anchors import (
+    _get_design_space_info,
     compute_max_component_depths,
     get_xy_rotation,
     propagate_all_anchors,
@@ -1066,6 +1067,62 @@ def test_bracket_ligature_anchor_numbering():
     )
 
 
+def test_get_design_space_info_none():
+    """Returns empty dicts when font is None or has no masters."""
+    assert _get_design_space_info(None) == ({}, {})
+    assert _get_design_space_info(GSFont()) == ({}, {})
+
+
+def test_get_design_space_info_single_axis():
+    """Computes correct locations and triples for a single-axis font."""
+    font = GSFont()
+    font.format_version = 3
+    master0 = GSFontMaster()
+    master0.id = "light"
+    master0.axes = [100]
+    font.masters.append(master0)
+    master1 = GSFontMaster()
+    master1.id = "bold"
+    master1.axes = [200]
+    font.masters.append(master1)
+
+    master_locations, axes_triples = _get_design_space_info(font)
+
+    assert master_locations["light"]["Weight"] == 100
+    assert master_locations["bold"]["Weight"] == 200
+    # Default is first master (light), so triple is (min=100, default=100, max=200)
+    assert axes_triples["Weight"] == (100, 100, 200)
+
+
+def test_get_design_space_info_two_axes():
+    """Computes correct locations and triples for a two-axis font."""
+    font = GSFont()
+    font.format_version = 3
+    m0 = GSFontMaster()
+    m0.id = "light-narrow"
+    m0.axes = [100, 75]
+    font.masters.append(m0)
+    m1 = GSFontMaster()
+    m1.id = "bold-narrow"
+    m1.axes = [200, 75]
+    font.masters.append(m1)
+    m2 = GSFontMaster()
+    m2.id = "bold-wide"
+    m2.axes = [200, 100]
+    font.masters.append(m2)
+
+    master_locations, axes_triples = _get_design_space_info(font)
+
+    assert len(master_locations) == 3
+    assert master_locations["light-narrow"]["Weight"] == 100
+    assert master_locations["light-narrow"]["Width"] == 75
+    assert master_locations["bold-wide"]["Weight"] == 200
+    assert master_locations["bold-wide"]["Width"] == 100
+    # Default is first master
+    assert axes_triples["Weight"] == (100, 100, 200)
+    assert axes_triples["Width"] == (75, 75, 100)
+
+
 def test_interpolate_brace_layer_component_anchors():
     """When a composite has a brace layer but its component doesn't, interpolate
     the component's anchor positions from its available master sources.
@@ -1151,7 +1208,8 @@ def test_interpolate_brace_layer_component_anchors():
     #   _top: (100, 500) + 0.5 * ((140, 520) - (100, 500)) = (120, 510)
     #   top:  (120, 700) + 0.5 * ((160, 740) - (120, 700)) = (140, 720)
     # Component offsets at brace layer: acutecomb offset = (220, 110)
-    # Final top = interpolated acutecomb.top + offset = (140, 720) + (220, 110) = (360, 830)
+    # Final top = interpolated acutecomb.top + offset
+    #           = (140, 720) + (220, 110) = (360, 830)
     # Final bottom = interpolated ae.bottom = (340, 0)
     brace_layers = [l for l in aeacute.layers if l._is_brace_layer()]
     assert len(brace_layers) == 1
@@ -1253,7 +1311,8 @@ def test_brace_layer_interpolation_with_existing_brace_sources():
     # The component has 3 sources: weight=100, 200, 300.
     # Interpolating at weight=150 with a 3-source model should use the brace
     # layer at 200 as well, giving a different result than simple 2-master lerp.
-    # With 2-master linear: top = (100, 600) + 0.25 * ((300, 800) - (100, 600)) = (150, 650)
+    # With 2-master linear:
+    #   top = (100, 600) + 0.25 * ((300, 800) - (100, 600)) = (150, 650)
     # With 3-source model the result differs because (220, 720) at weight=200 is
     # off the linear path between (100, 600) and (300, 800).
     anchors = brace_layers[0].anchors


### PR DESCRIPTION
When a composite has a brace layer but any of its components don't, anchors should be interpolated from the components' available master sources.

Fixes https://github.com/googlefonts/glyphsLib/issues/1017

The intent is to match the behavior implemented in fontc PR [#1887](https://github.com/googlefonts/fontc/pull/1887)

also see https://github.com/googlefonts/fontc/issues/1661

I will push a failing test first and will follow up with the actual implementation in a second commit.