### PR TITLE
Fix GSPath.reverse for open paths

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2394,6 +2394,11 @@ class GSPath(GSBase):
                 segment.nodes[-1].type = "curve"
                 nextSegment.nodes[0].type = "curve"
         self.setSegments(segments)
+        if not self.closed and segments:
+            # setSegments skips segment[0].nodes[0] (correct for closed paths
+            # where boundary nodes are shared), but open paths have a unique
+            # start node that must be reinserted explicitly.
+            self._nodes.insert(0, segments[0].nodes[0])
 
     # TODO
     def addNodesAtExtremes(self):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1734,6 +1734,28 @@ class GSPathFromFileTest(GSObjectsTestCase):
         self.assertEqual(bounds.size.width, 289)
         self.assertEqual(bounds.size.height, 490)
 
+    def test_reverse_open_path_preserves_all_nodes(self):
+        # Reversing an open path drops the last node of the original path
+        # because setSegments() skips segment[0]'s first node (correct for
+        # closed paths where boundary nodes are shared, but wrong for open
+        # paths where the start node is unique).
+        p = GSPath()
+        p.closed = False
+        p.nodes = [
+            GSNode((0, 0), "line"),
+            GSNode((100, 0), "line"),
+            GSNode((200, 0), "line"),
+        ]
+        positions_before = [(n.position.x, n.position.y) for n in p.nodes]
+
+        p.reverse()
+
+        # Should still have 3 nodes (not 2)
+        self.assertEqual(len(p.nodes), 3)
+        # Nodes should appear in reversed order
+        positions_after = [(n.position.x, n.position.y) for n in p.nodes]
+        self.assertEqual(positions_after, list(reversed(positions_before)))
+
 
 class GSNodeFromFileTest(GSObjectsTestCase):
     def setUp(self):


### PR DESCRIPTION
As written this would drop the final node, which in a closed path would be a duplicate but which is meaningful in an open path.

This limits the fix to just the 'reverse' call, but it looks like setSegments has this bug in general.

cc @anthrotype, this would match https://github.com/googlefonts/fontc/pull/1956