### PR TITLE
Fix encoding problem with reading .glyphspackage .glyph file

### DIFF
--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -123,7 +123,7 @@ def load_glyphspackage(package_dir):
 
     data["glyphs"] = []
     for glyphfile in (package / "glyphs").glob("*.glyph"):
-        with open(glyphfile, "r") as fh:
+        with open(glyphfile, "r", encoding="utf-8") as fh:
             glyph = openstep_plist.load(fh, use_numbers=True)
         data["glyphs"].append(glyph)
     # Sort according to glyphorder

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -668,7 +668,7 @@ def test_designspace_generation_multiaxis_bracket(datadir, ufo_module):
 def test_designspace_generation_instances_disabled_custom_params(
     datadir, ufo_module, minimal
 ):
-    with open(str(datadir.join("GlyphsUnitTestSans.glyphs"))) as f:
+    with open(str(datadir.join("GlyphsUnitTestSans.glyphs")), encoding="utf-8") as f:
         font = glyphsLib.load(f)
 
     designspace = to_designspace(font, ufo_module=ufo_module, minimal=minimal)

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -742,7 +742,7 @@ position = "{248, 480}";
 annotations = (
 {
 position = "{427, 535}";
-text = "This is a text annotation";
+text = "This is a text annotation 일";
 type = Text;
 },
 {

--- a/tests/data/GlyphsUnitTestSans3.glyphs
+++ b/tests/data/GlyphsUnitTestSans3.glyphs
@@ -711,7 +711,7 @@ pos = (248,480);
 annotations = (
 {
 pos = (427,535);
-text = "This is a text annotation";
+text = "This is a text annotation 일";
 type = Text;
 },
 {

--- a/tests/data/GlyphsUnitTestSans3.glyphspackage/glyphs/a.glyph
+++ b/tests/data/GlyphsUnitTestSans3.glyphspackage/glyphs/a.glyph
@@ -143,7 +143,7 @@ pos = (248,480);
 annotations = (
 {
 pos = (427,535);
-text = "This is a text annotation";
+text = "This is a text annotation 일";
 type = Text;
 },
 {

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -62,7 +62,7 @@ def test_parser_main(capsys):
     and for the round-trip of GlyphsUnitTestSans.glyphs.
     """
     filename = os.path.join(DATA, "GlyphsUnitTestSans.glyphs")
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         expected = f.read()
 
     glyphsLib.parser.main([filename])
@@ -75,7 +75,7 @@ def test_parser_main_v3(capsys):
     and for the round-trip of GlyphsUnitTestSans.glyphs.
     """
     filename = os.path.join(DATA, "GlyphsUnitTestSans3.glyphs")
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         expected = f.read()
 
     glyphsLib.parser.main([filename])


### PR DESCRIPTION
Additionally adjusts some test code.

This fixes a similar bug as https://github.com/fontra/fontra-glyphs/issues/140. Occasional glyphsLib errors were mentioned there by @Eigi, so I went for a hunt and found one.