### PR TITLE
Fix COLR color intermediate layers for color palette glyphs

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -337,8 +337,10 @@ class UFOBuilder(LoggerMixin):
             elif (
                 self.minimal
                 and layer.layerId not in master_layer_ids
-                and not layer._is_brace_layer()
+                and (not layer._is_brace_layer() or layer._is_color_palette_layer())
             ):
+                # Only plain intermediate layers are built here, color
+                # palette layers are handled by to_ufo_color_layers.
                 continue
             else:
                 ufo_layer = self.to_ufo_layer(glyph, layer)  # .layers

--- a/Lib/glyphsLib/builder/color_layers.py
+++ b/Lib/glyphsLib/builder/color_layers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import math
 
 from fontTools.misc.transform import Identity, Transform
@@ -21,22 +22,72 @@ from .common import to_ufo_color
 from .constants import UFO2FT_COLOR_LAYERS_KEY, UFO2FT_COLOR_PALETTES_KEY
 
 
+def _to_ufo_brace_layer(builder, master, layer):
+    ufo_font = builder._sources[master.id].font
+    layer_name = layer._brace_layer_name()
+    if layer_name in ufo_font.layers:
+        return ufo_font.layers[layer_name]
+    return ufo_font.newLayer(layer_name)
+
+
 def _to_ufo_color_palette_layers(builder, master, layerMapping):
     for (glyph, masterLayer), layers in builder._color_palette_layers:
         if master.id != masterLayer.associatedMasterId:
             continue
 
+        # Group the intermediate color palette layers by location and then by
+        # palette index, so that each color layer glyph gets the intermediate
+        # with the same palette index. Several color layers can share a palette
+        # index, so we keep a list per index and consume it in document order.
+        brace_color_layers = {}
+        for l in glyph.layers:
+            if (
+                l.associatedMasterId == master.id
+                and l._is_color_palette_layer()
+                and l._is_brace_layer()
+            ):
+                by_color = brace_color_layers.setdefault(l._brace_layer_name(), {})
+                by_color.setdefault(l._color_palette_index(), []).append(l)
+
+        seen = collections.Counter()
         colorLayers = []
         for i, (layer, colorId) in enumerate(layers):
             if layer.layerId == master.id:
                 # This is master layer, we can re-use its UFO glyph.
                 layerGlyphName = glyph.name
+                is_color_layer_glyph = False
             else:
                 # Not the master layer, create a new UFO glyph for it.
                 layerGlyphName = f"{glyph.name}.color{i}"
+                is_color_layer_glyph = True
                 ufo_layer = builder.to_ufo_layer(glyph, masterLayer)
                 ufo_glyph = ufo_layer.newGlyph(layerGlyphName)
                 builder.to_ufo_glyph(ufo_glyph, layer, glyph, is_color_layer_glyph=True)
+
+            # Emit the same color layer glyph at each intermediate location.
+            n = seen[colorId]
+            seen[colorId] += 1
+            for by_color in brace_color_layers.values():
+                brace_layers = by_color.get(colorId, ())
+                if n >= len(brace_layers):
+                    continue
+                brace_layer = brace_layers[n]
+                ufo_brace_layer = _to_ufo_brace_layer(builder, master, brace_layer)
+                if layerGlyphName in ufo_brace_layer:
+                    builder.logger.warning(
+                        "%s: Glyph %s, layer %s: Duplicate color layer glyph",
+                        builder.font.familyName,
+                        layerGlyphName,
+                        ufo_brace_layer.name,
+                    )
+                    continue
+                ufo_brace_glyph = ufo_brace_layer.newGlyph(layerGlyphName)
+                builder.to_ufo_glyph(
+                    ufo_brace_glyph,
+                    brace_layer,
+                    glyph,
+                    is_color_layer_glyph=is_color_layer_glyph,
+                )
             colorLayers.append((layerGlyphName, colorId))
         layerMapping[glyph.name] = colorLayers
 

--- a/Lib/glyphsLib/builder/color_layers.py
+++ b/Lib/glyphsLib/builder/color_layers.py
@@ -89,6 +89,21 @@ def _to_ufo_color_palette_layers(builder, master, layerMapping):
                     is_color_layer_glyph=is_color_layer_glyph,
                 )
             colorLayers.append((layerGlyphName, colorId))
+
+        # Intermediate color palette layers whose palette index is not used by
+        # any color layer can’t be mapped to a color layer glyph. Create their
+        # UFO layers anyway, since a sparse source is generated for each of them.
+        for by_color in brace_color_layers.values():
+            for colorId, brace_layers in by_color.items():
+                for brace_layer in brace_layers[seen[colorId] :]:
+                    builder.logger.warning(
+                        "%s: Glyph %s, layer %s: Intermediate color layer has no "
+                        "matching color layer and will be skipped",
+                        builder.font.familyName,
+                        glyph.name,
+                        brace_layer._brace_layer_name(),
+                    )
+                    _to_ufo_brace_layer(builder, master, brace_layer)
         layerMapping[glyph.name] = colorLayers
 
 

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -307,7 +307,11 @@ def to_ufo_glyph_color(self, ufo_glyph, layer, glyph, do_color_layers=True):
         elif glyph.export:
             layers = []
             for layerId, colorId in layerMapping:
-                layers.append((glyph.layers[layerId], colorId))
+                color_layer = glyph.layers[layerId]
+                # Intermediate color layers are built separately.
+                if color_layer._is_brace_layer():
+                    continue
+                layers.append((color_layer, colorId))
             self._color_palette_layers.append(((glyph, layer), layers))
 
     if self.minimal:

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -26,6 +26,7 @@ import defcon
 import ufoLib2
 from textwrap import dedent
 from glyphsLib.classes import (
+    GSAxis,
     GSComponent,
     GSFeature,
     GSFont,
@@ -1417,6 +1418,200 @@ def test_glyph_color_palette_layers_explode_v3(ufo_module):
 
     assert len(ufo["a.color2"].components) == 1
     assert len(ufo["a.color2"]) == 0
+
+
+def test_glyph_color_palette_layers_with_intermediate_layers(ufo_module):
+    font = generate_minimal_font(format_version=3)
+    font.axes = [GSAxis(name="Weight", tag="wght")]
+    font.masters[0].axes = [0]
+
+    def quad(offset):
+        path = GSPath()
+        path.nodes = [
+            GSNode(position=(offset + i, offset + i), nodetype="line") for i in range(4)
+        ]
+        return path
+
+    master_id = font.masters[0].id
+    glypha = add_glyph(font, "a")
+    glypha.layers[0].paths.append(quad(0))
+
+    def add_layer(colorPalette=None, coordinates=None, offset=0):
+        layer = GSLayer()
+        layer.associatedMasterId = master_id
+        layer.width = 0
+        if colorPalette is not None:
+            layer.attributes["colorPalette"] = colorPalette
+        if coordinates is not None:
+            layer.attributes["coordinates"] = coordinates
+        layer.paths.append(quad(offset))
+        glypha.layers.append(layer)
+
+    # Two master color layers
+    add_layer(colorPalette=0, offset=1)
+    add_layer(colorPalette=1, offset=2)
+    # A plain intermediate layer at {50}
+    add_layer(coordinates=[50], offset=5)
+    # The intermediate counterparts of the two color layers.
+    add_layer(colorPalette=0, coordinates=[50], offset=6)
+    add_layer(colorPalette=1, coordinates=[50], offset=7)
+
+    ds = to_designspace(font, ufo_module=ufo_module, minimal=True)
+    ufo = ds.sources[0].font
+
+    # Only the two master color layers end up in the COLR table.
+    assert ufo.lib["com.github.googlei18n.ufo2ft.colorLayers"] == {
+        "a": [("a.color0", 0), ("a.color1", 1)]
+    }
+
+    # The color layer glyphs exist both in the default layer and in the {50}
+    # intermediate layer, so that they interpolate along the axis.
+    assert {"a", "a.color0", "a.color1"} <= set(ufo.layers.defaultLayer.keys())
+    intermediate_layer = ufo.layers["{50}"]
+    assert {"a", "a.color0", "a.color1"} <= set(intermediate_layer.keys())
+
+    # A sparse source was generated for the intermediate location.
+    assert [s.layerName for s in ds.sources] == [None, "{50}"]
+
+
+def test_glyph_color_palette_master_layer_with_intermediate_layer(ufo_module):
+    font = generate_minimal_font(format_version=3)
+    font.axes = [GSAxis(name="Weight", tag="wght")]
+    font.masters[0].axes = [0]
+
+    def quad(offset):
+        path = GSPath()
+        path.nodes = [
+            GSNode(position=(offset + i, offset + i), nodetype="line") for i in range(4)
+        ]
+        return path
+
+    master_id = font.masters[0].id
+    glypha = add_glyph(font, "a")
+    master_layer = glypha.layers[0]
+    master_layer.attributes["colorPalette"] = 0
+    master_layer.paths.append(quad(0))
+
+    color1 = GSLayer()
+    color1.associatedMasterId = master_id
+    color1.attributes["colorPalette"] = 1
+    color1.paths.append(quad(10))
+    glypha.layers.append(color1)
+
+    intermediate0 = GSLayer()
+    intermediate0.associatedMasterId = master_id
+    intermediate0.attributes["colorPalette"] = 0
+    intermediate0.attributes["coordinates"] = [50]
+    intermediate0.paths.append(quad(20))
+    intermediate0.paths.append(quad(30))
+    glypha.layers.append(intermediate0)
+
+    intermediate1 = GSLayer()
+    intermediate1.associatedMasterId = master_id
+    intermediate1.attributes["colorPalette"] = 1
+    intermediate1.attributes["coordinates"] = [50]
+    intermediate1.paths.append(quad(40))
+    glypha.layers.append(intermediate1)
+
+    ds = to_designspace(font, ufo_module=ufo_module, minimal=True)
+    ufo = ds.sources[0].font
+
+    assert ufo.lib["com.github.googlei18n.ufo2ft.colorLayers"] == {
+        "a": [("a", 0), ("a.color1", 1)]
+    }
+
+    intermediate_layer = ufo.layers["{50}"]
+    assert {"a", "a.color1"} <= set(intermediate_layer.keys())
+    assert len(intermediate_layer["a"]) == 2
+    assert len(intermediate_layer["a.color1"]) == 1
+
+
+def test_glyph_color_palette_partial_intermediate_layers(ufo_module):
+    font = generate_minimal_font(format_version=3)
+    font.axes = [GSAxis(name="Weight", tag="wght")]
+    font.masters[0].axes = [0]
+
+    def quad(offset):
+        path = GSPath()
+        path.nodes = [
+            GSNode(position=(offset + i, offset + i), nodetype="line") for i in range(4)
+        ]
+        return path
+
+    master_id = font.masters[0].id
+    glypha = add_glyph(font, "a")
+
+    def add_layer(color_palette, coordinates=None, offset=0):
+        layer = GSLayer()
+        layer.associatedMasterId = master_id
+        layer.attributes["colorPalette"] = color_palette
+        if coordinates is not None:
+            layer.attributes["coordinates"] = coordinates
+        layer.paths.append(quad(offset))
+        glypha.layers.append(layer)
+        return layer
+
+    add_layer(color_palette=0, offset=10)
+    add_layer(color_palette=1, offset=20)
+    intermediate1 = add_layer(color_palette=1, coordinates=[50], offset=30)
+    intermediate1.paths.append(quad(40))
+
+    ds = to_designspace(font, ufo_module=ufo_module, minimal=True)
+    ufo = ds.sources[0].font
+
+    assert ufo.lib["com.github.googlei18n.ufo2ft.colorLayers"] == {
+        "a": [("a.color0", 0), ("a.color1", 1)]
+    }
+
+    intermediate_layer = ufo.layers["{50}"]
+    assert "a.color1" in intermediate_layer
+    assert "a.color0" not in intermediate_layer
+    assert len(intermediate_layer["a.color1"]) == 2
+
+
+def test_glyph_color_palette_unordered_intermediate_layers(ufo_module):
+    font = generate_minimal_font(format_version=3)
+    font.axes = [GSAxis(name="Weight", tag="wght")]
+    font.masters[0].axes = [0]
+
+    def quad(offset):
+        path = GSPath()
+        path.nodes = [
+            GSNode(position=(offset + i, offset + i), nodetype="line") for i in range(4)
+        ]
+        return path
+
+    master_id = font.masters[0].id
+    glypha = add_glyph(font, "a")
+
+    def add_layer(color_palette, coordinates=None, offset=0):
+        layer = GSLayer()
+        layer.associatedMasterId = master_id
+        layer.attributes["colorPalette"] = color_palette
+        if coordinates is not None:
+            layer.attributes["coordinates"] = coordinates
+        layer.paths.append(quad(offset))
+        glypha.layers.append(layer)
+        return layer
+
+    add_layer(color_palette=0, offset=10)
+    add_layer(color_palette=1, offset=20)
+    # The intermediates come in the opposite order of the color layers.
+    add_layer(color_palette=1, coordinates=[50], offset=30).paths.append(quad(40))
+    add_layer(color_palette=0, coordinates=[50], offset=50)
+
+    ds = to_designspace(font, ufo_module=ufo_module, minimal=True)
+    ufo = ds.sources[0].font
+
+    assert ufo.lib["com.github.googlei18n.ufo2ft.colorLayers"] == {
+        "a": [("a.color0", 0), ("a.color1", 1)]
+    }
+
+    # Each color layer glyph gets the intermediate of its own palette, not the
+    # one that happens to come at the same position in the layer list.
+    intermediate_layer = ufo.layers["{50}"]
+    assert len(intermediate_layer["a.color0"]) == 1
+    assert len(intermediate_layer["a.color1"]) == 2
 
 
 def test_glyph_color_layers_no_unicode_mapping(ufo_module):


### PR DESCRIPTION
A glyph can has color palette layers that also has intermediate layers i.e. layers with both `colorPalette` and `coordinates` attributes. However, the builder worked as if a layer can be either of them and not both.

As a result the intermediate color layers were emitted as extra static COLR layers on the default master instead of participating in the variation of the color layer glyphs.

Now the color layer structure is defined only by the master (non-intermediate) color palette layers, and each intermediate color palette layer is emitted as the matching `.colorN` glyph in its corresponding sparse UFO.