### PR TITLE
Expand "{{{...}}}" tokens in instance and font names

### DIFF
--- a/Lib/glyphsLib/builder/common.py
+++ b/Lib/glyphsLib/builder/common.py
@@ -14,9 +14,25 @@
 
 
 import datetime
+import re
+
 from glyphsLib.types import parse_datetime
 
 UFO_FORMAT = "%Y/%m/%d %H:%M:%S"
+
+# Expand “text tokens”: https://handbook.glyphsapp.com/tokens/text/
+_TEXT_TOKEN_RE = re.compile(r"\{\{\{(.+?)\}\}\}")
+
+
+def expand_text_tokens(value, obj):
+    if not isinstance(value, str) or "{{{" not in value:
+        return value
+
+    def replace(match):
+        resolved = getattr(obj, match.group(1).strip(), None)
+        return str(resolved) if resolved is not None else match.group(0)
+
+    return _TEXT_TOKEN_RE.sub(replace, value)
 
 
 def to_ufo_time(datetime_obj):

--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -19,7 +19,7 @@ import logging
 
 from glyphsLib.util import bin_to_int_list, int_list_to_bin
 from .filters import parse_glyphs_filter
-from .common import to_ufo_color
+from .common import expand_text_tokens, to_ufo_color
 from .constants import (
     GLYPHS_PREFIX,
     UFO2FT_COLOR_PALETTES_KEY,
@@ -114,13 +114,13 @@ class GlyphsObjectProxy:
         if len(values) > 1:
             raise RuntimeError(f"More than one value for this customParameter: {key}")
         if values:
-            return values[0]
+            return expand_text_tokens(values[0], self._owner)
         return None
 
     def get_custom_values(self, key):
         """Return a set of values for the given customParameter name."""
         self._handled.add(key)
-        return self._lookup[key]
+        return [expand_text_tokens(value, self._owner) for value in self._lookup[key]]
 
     def set_custom_value(self, key, value):
         """Set one custom parameter with the given value.
@@ -157,7 +157,7 @@ class GlyphsObjectProxy:
 
     def get_property(self, key):
         if key and hasattr(self._owner, "properties"):
-            return self._owner.properties.get(key)
+            return expand_text_tokens(self._owner.properties.get(key), self._owner)
         return None
 
 

--- a/Lib/glyphsLib/builder/font.py
+++ b/Lib/glyphsLib/builder/font.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from .common import to_ufo_time, from_ufo_time
+from .common import expand_text_tokens, to_ufo_time, from_ufo_time
 from .constants import (
     DEFAULT_FEATURE_WRITERS,
     UFO2FT_FEATURE_WRITERS_KEY,
@@ -103,7 +103,7 @@ def fill_ufo_metadata(master, ufo):
     for info_key, glyphs_key, name_id in PROPERTIES_FIELDS:
         value = properties.get(glyphs_key)
         if value:
-            setattr(ufo.info, info_key, value.value)
+            setattr(ufo.info, info_key, expand_text_tokens(value.value, font))
             # If the property has localized values, add them to openTypeNameRecords
             if name_id is not None and value._localized_values:
                 for lang, val in value._localized_values.items():
@@ -115,7 +115,7 @@ def fill_ufo_metadata(master, ufo):
                         {
                             "nameID": name_id,
                             "languageID": lang_id,
-                            "string": val,
+                            "string": expand_text_tokens(val, font),
                             "platformID": 3,  # Windows
                             "encodingID": 1,  # Unicode BMP
                         }

--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -39,6 +39,7 @@ from .constants import (
     PROPERTIES_KEY,
     PROPERTIES_WHITELIST,
 )
+from .common import expand_text_tokens
 from .names import build_stylemap_names
 from .axes import (
     get_axis_definitions,
@@ -118,12 +119,13 @@ def _to_designspace_instance(self, instance, ignore_disabled_cp=False):
     # at least according to https://docu.glyphsapp.com/#fontName
 
     # Read either from properties or custom parameters or the font
-    ufo_instance.familyName = instance.familyName
-    ufo_instance.styleName = instance.name
-    ufo_instance.postScriptFontName = (
+    ufo_instance.familyName = expand_text_tokens(instance.familyName, instance)
+    ufo_instance.styleName = expand_text_tokens(instance.name, instance)
+    ufo_instance.postScriptFontName = expand_text_tokens(
         instance.properties.get("variablePostscriptFontName")
         or instance.properties.get("postscriptFontName")
-        or instance.customParameters["postscriptFontName"]
+        or instance.customParameters["postscriptFontName"],
+        instance,
     )
     ufo_instance.filename = _to_filename(self, instance, ufo_instance)
 
@@ -177,7 +179,7 @@ def _to_designspace_instance(self, instance, ignore_disabled_cp=False):
 
 def _to_custom_parameters(instance, ignore_disabled=False):
     return [
-        (item.name, item.value)
+        (item.name, expand_text_tokens(item.value, instance))
         for item in instance.customParameters
         if item.name not in CUSTOM_PARAMETERS_BLACKLIST
         and not (ignore_disabled and item.disabled)
@@ -209,7 +211,7 @@ def _to_filename(self, instance, ufo_instance):
 
 def _to_properties(instance):
     return [
-        (item.name, item.value)
+        (item.name, expand_text_tokens(item.value, instance))
         for item in instance.properties
         if item.name in PROPERTIES_WHITELIST
     ]

--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -40,6 +40,7 @@ from .constants import (
     PROPERTIES_WHITELIST,
 )
 from .common import expand_text_tokens
+from .font import PROPERTIES_FIELDS
 from .names import build_stylemap_names
 from .axes import (
     get_axis_definitions,
@@ -170,7 +171,7 @@ def _to_designspace_instance(self, instance, ignore_disabled_cp=False):
     parameters = _to_custom_parameters(instance, ignore_disabled_cp)
     if parameters:
         ufo_instance.lib[CUSTOM_PARAMETERS_KEY] = parameters
-    properties = _to_properties(instance)
+    properties = _to_properties(self, instance)
     if properties:
         ufo_instance.lib[PROPERTIES_KEY] = properties
 
@@ -209,12 +210,21 @@ def _to_filename(self, instance, ufo_instance):
     )
 
 
-def _to_properties(instance):
-    return [
-        (item.name, expand_text_tokens(item.value, instance))
-        for item in instance.properties
-        if item.name in PROPERTIES_WHITELIST
-    ]
+def _to_properties(self, instance):
+    properties = {}
+    if not self.minimize_glyphs_diffs:
+        # A font-level name string resolves its tokens against the instance
+        # being exported. Carry the properties that have tokens over to the
+        # instance so they override the value the master was built with.
+        for item in self.font.properties:
+            if item.key in PROPERTIES_WHITELIST and item.value != (
+                expanded := expand_text_tokens(item.value, instance)
+            ):
+                properties[item.key] = expanded
+    for item in instance.properties:
+        if item.name in PROPERTIES_WHITELIST:
+            properties[item.name] = expand_text_tokens(item.value, instance)
+    return list(properties.items())
 
 
 def _is_instance_included_in_family(self, instance):
@@ -469,3 +479,11 @@ def apply_instance_data_to_ufo(ufo, instance, designspace):
 
     glyphs_instance = InstanceDescriptorAsGSInstance(instance)
     to_ufo_custom_params(None, ufo, glyphs_instance)
+
+    # The name properties that have no custom parameter handler are only read
+    # by fill_ufo_metadata, which builds masters. Apply them here so instances
+    # get their own values.
+    for info_key, glyphs_key, _ in PROPERTIES_FIELDS:
+        value = glyphs_instance.properties.get(glyphs_key)
+        if value is not None:
+            setattr(ufo.info, info_key, value)

--- a/tests/builder/instances_test.py
+++ b/tests/builder/instances_test.py
@@ -404,3 +404,56 @@ def test_expand_variable_instance_naming_tokens(ufo_module):
 
     # Static sibling on the same file still expands.
     assert designspace.instances[0].postScriptFontName == "VFBase-Bold"
+
+
+def test_expand_font_level_tokens_in_instance_context(ufo_module):
+    from glyphsLib.builder.instances import apply_instance_data_to_ufo
+
+    font, instance = _token_test_font("Acme", "Bold")
+    instance.properties["familyNames"] = "Other"
+    font.copyright = "(c) {{{familyName}}}"
+    font.properties["trademarks"] = "TM {{{familyName}}}"
+    font.properties["descriptions"] = "Desc {{{familyName}}}"
+    font.properties["licenses"] = "Lic {{{familyName}}}"
+    font.properties["sampleTexts"] = "Sample {{{familyName}}}"
+    font.properties["versionString"] = "Version {{{familyName}}}"
+    font.properties["manufacturers"] = "Mfg {{{familyName}}}"
+    font.properties["designers"] = "Des {{{familyName}}}"
+
+    designspace = glyphsLib.to_designspace(font, ufo_module=ufo_module)
+    ds_instance = designspace.instances[0]
+    assert ds_instance.familyName == "Other"
+
+    ufo = ufo_module.Font()
+    master_info = designspace.sources[0].font.info
+    for attr in (
+        "copyright",
+        "trademark",
+        "openTypeNameDescription",
+        "openTypeNameLicense",
+        "openTypeNameSampleText",
+        "openTypeNameVersion",
+        "openTypeNameManufacturer",
+        "openTypeNameDesigner",
+        "familyName",
+        "styleName",
+    ):
+        value = getattr(master_info, attr, None)
+        if value is not None:
+            setattr(ufo.info, attr, value)
+
+    apply_instance_data_to_ufo(ufo, ds_instance, designspace)
+    if ds_instance.familyName is not None:
+        ufo.info.familyName = ds_instance.familyName
+    if ds_instance.styleName is not None:
+        ufo.info.styleName = ds_instance.styleName
+
+    assert ufo.info.familyName == "Other"
+    assert ufo.info.copyright == "(c) Other"
+    assert ufo.info.trademark == "TM Other"
+    assert ufo.info.openTypeNameDescription == "Desc Other"
+    assert ufo.info.openTypeNameLicense == "Lic Other"
+    assert ufo.info.openTypeNameSampleText == "Sample Other"
+    assert ufo.info.openTypeNameVersion == "Version Other"
+    assert ufo.info.openTypeNameManufacturer == "Mfg Other"
+    assert ufo.info.openTypeNameDesigner == "Des Other"

--- a/tests/builder/instances_test.py
+++ b/tests/builder/instances_test.py
@@ -254,3 +254,153 @@ def test_rename_glyphs(tmpdir):
     assert len(ufos[1]["b"][0]) == 4  # Square
     assert ufos[0]["a"].unicode == 0x0061
     assert ufos[0]["b"].unicode == 0x0062
+
+
+def test_expand_instance_naming_tokens(ufo_module):
+    from glyphsLib.builder.instances import expand_text_tokens
+    from glyphsLib.builder.constants import PROPERTIES_KEY
+
+    font = glyphsLib.GSFont()
+    font.familyName = "Test"
+    font.copyright = "Some rights"
+    master = glyphsLib.GSFontMaster()
+    master.id = "m01"
+    font.masters.append(master)
+    instance = glyphsLib.GSInstance()
+    instance.name = "Bold"
+    font.instances = [instance]
+
+    assert expand_text_tokens("{{{familyName}}}-{{{name}}}", instance) == "Test-Bold"
+    assert expand_text_tokens("{{{fullName}}}", instance) == "Test Bold"
+    assert (
+        expand_text_tokens("{{{familyName}}}-{{{unknownKey}}}", instance)
+        == "Test-{{{unknownKey}}}"
+    )
+    assert expand_text_tokens("PlainName", instance) == "PlainName"
+    assert expand_text_tokens(None, instance) is None
+    # A font-only name (copyright) does not resolve against the instance, but
+    # does resolve against the font.
+    assert expand_text_tokens("{{{copyright}}}", instance) == "{{{copyright}}}"
+    assert expand_text_tokens("{{{copyright}}}", font) == "Some rights"
+
+    # End to end: tokens are expanded in the PostScript name, in the other
+    # instance name properties, and in the font-level names.
+    instance.customParameters["postscriptFontName"] = "{{{familyName}}}-{{{name}}}"
+    instance.properties["preferredFamilyNames"] = "{{{familyName}}} Text"
+    font.copyright = "(c) {{{familyName}}}"
+
+    designspace = glyphsLib.to_designspace(font, ufo_module=ufo_module)
+    ds_instance = designspace.instances[0]
+    assert ds_instance.postScriptFontName == "Test-Bold"
+    assert dict(ds_instance.lib[PROPERTIES_KEY])["preferredFamilyNames"] == "Test Text"
+    assert designspace.sources[0].font.info.copyright == "(c) Test"
+
+
+def _token_test_font(family_name="Test", instance_name="Bold"):
+    """Minimal one-master, one-instance font with parent links set."""
+    font = glyphsLib.GSFont()
+    font.familyName = family_name
+    master = glyphsLib.GSFontMaster()
+    master.id = "m01"
+    font.masters.append(master)
+    instance = glyphsLib.GSInstance()
+    instance.name = instance_name
+    font.instances = [instance]
+    return font, instance
+
+
+def test_expand_font_level_name_properties(ufo_module):
+    font, _instance = _token_test_font("PropOnly", "Regular")
+    font.copyright = "(c) {{{familyName}}}"
+    font.properties["trademarks"] = "TM {{{familyName}}}"
+    font.properties["descriptions"] = "Desc {{{familyName}}}"
+    font.properties["licenses"] = "Lic {{{familyName}}}"
+    font.properties["sampleTexts"] = "Sample {{{familyName}}}"
+    font.properties["versionString"] = "Version {{{familyName}}}"
+    font.properties["manufacturers"] = "Mfg {{{familyName}}}"
+    font.properties["designers"] = "Des {{{familyName}}}"
+
+    designspace = glyphsLib.to_designspace(font, ufo_module=ufo_module)
+    info = designspace.sources[0].font.info
+
+    assert info.copyright == "(c) PropOnly"
+    assert info.trademark == "TM PropOnly"
+    assert info.openTypeNameDescription == "Desc PropOnly"
+    assert info.openTypeNameLicense == "Lic PropOnly"
+    assert info.openTypeNameSampleText == "Sample PropOnly"
+    assert info.openTypeNameVersion == "Version PropOnly"
+    assert info.openTypeNameManufacturer == "Mfg PropOnly"
+    assert info.openTypeNameDesigner == "Des PropOnly"
+
+
+def test_expand_font_and_instance_custom_parameter_names(ufo_module):
+    from glyphsLib.builder.constants import CUSTOM_PARAMETERS_KEY
+    from glyphsLib.builder.instances import apply_instance_data_to_ufo
+
+    font, instance = _token_test_font("CpOnly", "Bold")
+    font.copyright = "(c) {{{familyName}}}"
+    font.customParameters["versionString"] = "CPVer {{{familyName}}}"
+    font.customParameters["trademark"] = "CPFontTM {{{familyName}}}"
+    font.customParameters["description"] = "CPDesc {{{familyName}}}"
+    font.customParameters["license"] = "CPLic {{{familyName}}}"
+    font.customParameters["sampleText"] = "CPSample {{{familyName}}}"
+
+    instance.customParameters["postscriptFontName"] = "{{{familyName}}}-{{{name}}}"
+    instance.customParameters["preferredFamilyName"] = "CP {{{familyName}}}"
+    instance.customParameters["postscriptFullName"] = "CPFull {{{familyName}}}"
+    instance.customParameters["trademark"] = "CPTM {{{familyName}}}"
+
+    designspace = glyphsLib.to_designspace(font, ufo_module=ufo_module)
+    info = designspace.sources[0].font.info
+    assert info.copyright == "(c) CpOnly"
+    assert info.openTypeNameVersion == "CPVer CpOnly"
+    assert info.trademark == "CPFontTM CpOnly"
+    assert info.openTypeNameDescription == "CPDesc CpOnly"
+    assert info.openTypeNameLicense == "CPLic CpOnly"
+    assert info.openTypeNameSampleText == "CPSample CpOnly"
+
+    ds_instance = designspace.instances[0]
+    assert ds_instance.postScriptFontName == "CpOnly-Bold"
+    # Tokens must be expanded in Designspace custom parameters as well.
+    cps = dict(ds_instance.lib.get(CUSTOM_PARAMETERS_KEY) or [])
+    assert cps.get("preferredFamilyName") == "CP CpOnly"
+    assert cps.get("postscriptFullName") == "CPFull CpOnly"
+    assert cps.get("trademark") == "CPTM CpOnly"
+
+    ufo = ufo_module.Font()
+    apply_instance_data_to_ufo(ufo, ds_instance, designspace)
+    assert ufo.info.openTypeNamePreferredFamilyName == "CP CpOnly"
+    assert ufo.info.postscriptFullName == "CPFull CpOnly"
+    assert ufo.info.trademark == "CPTM CpOnly"
+
+
+def test_expand_variable_instance_naming_tokens(ufo_module):
+    from glyphsLib.classes import InstanceType
+
+    font = glyphsLib.GSFont()
+    font.familyName = "VFBase"
+    master = glyphsLib.GSFontMaster()
+    master.id = "m01"
+    font.masters.append(master)
+
+    variable = glyphsLib.GSInstance()
+    variable.name = "Regular"
+    variable.type = InstanceType.VARIABLE
+    variable.properties["postscriptFontName"] = "{{{familyName}}}VF"
+    variable.properties["preferredFamilyNames"] = "{{{familyName}}} Pref"
+
+    static = glyphsLib.GSInstance()
+    static.name = "Bold"
+    static.properties["postscriptFontName"] = "{{{familyName}}}-{{{name}}}"
+
+    font.instances = [variable, static]
+
+    designspace = glyphsLib.to_designspace(font, ufo_module=ufo_module)
+
+    assert len(designspace.variableFonts) == 1
+    info = designspace.variableFonts[0].lib["public.fontInfo"]
+    assert info.get("postscriptFontName") == "VFBaseVF"
+    assert info.get("openTypeNamePreferredFamilyName") == "VFBase Pref"
+
+    # Static sibling on the same file still expands.
+    assert designspace.instances[0].postScriptFontName == "VFBase-Bold"


### PR DESCRIPTION
Glyphs resolves {{{token}}} tokens in naming fields as key paths, so an instance PostScript name can be written as “{{{familyName}}}-{{{name}}}” instead of repeating the family and instance names.

Expand the tokens in the instance and font names by resolving the token as an attribute lookup on the instance or the font.

Glyphs does not have a fixed list of tokens, they are resolved as key paths using its Core API, so we use object properties as approximation: https://handbook.glyphsapp.com/tokens/text/