### PR TITLE
Generate STAT table data matching Glyphs

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -326,8 +326,13 @@ def font_uses_axis_locations(font):
 
 
 def to_glyphs_axes(self):
+    from glyphsLib.builder.stat import is_stat_only_ital
+
+    # The STAT-only “ital” axis is not a real Glyphs axis.
+    axes = [a for a in self.designspace.axes if not is_stat_only_ital(a)]
+
     axes_parameter = []
-    for axis in self.designspace.axes:
+    for axis in axes:
         if axis.tag == "wght":
             name = axis.name or "Weight"
         elif axis.tag == "wdth":
@@ -341,10 +346,8 @@ def to_glyphs_axes(self):
     if axes_parameter and not _is_subset_of_default_axes(axes_parameter):
         self.font.axes = axes_parameter
 
-    if any(_has_meaningful_map(a, self.designspace) for a in self.designspace.axes):
-        mapping = {
-            axis.tag: {str(k): v for k, v in axis.map} for axis in self.designspace.axes
-        }
+    if any(_has_meaningful_map(a, self.designspace) for a in axes):
+        mapping = {axis.tag: {str(k): v for k, v in axis.map} for axis in axes}
         self.font.customParameters["Axis Mappings"] = mapping
 
 

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -365,6 +365,8 @@ class UFOBuilder(LoggerMixin):
         if self.bracket_layers:
             self.to_designspace_bracket_layers()  # .bracket_layers
 
+        self.to_designspace_stat()  # .axisLabels
+
         # append base style shared by all masters to designspace file name
         base_family = self.family_name or "Unnamed"
         base_style = find_base_style(self.font.masters)
@@ -419,6 +421,7 @@ class UFOBuilder(LoggerMixin):
     from .names import to_ufo_names
     from .paths import to_ufo_paths
     from .sources import to_designspace_sources
+    from .stat import to_designspace_stat
     from .glyph import (
         to_ufo_glyph,
         to_ufo_glyph_color,
@@ -611,6 +614,8 @@ class GlyphsBuilder(LoggerMixin):
         """Make sure that the user-provided designspace has loaded fonts and
         that names are the same as those from the UFOs.
         """
+        from .stat import is_stat_only_ital
+
         # TODO: (jany) really make a copy to avoid modifying the original object
         copy = designspace
         # Load only full UFO masters, sparse or "brace" layer sources are assumed
@@ -648,7 +653,7 @@ class GlyphsBuilder(LoggerMixin):
         # values) lost when converted to a Glyps.app file. To combat this we
         # add an explicit identity mapping.
         for axis in copy.axes:
-            if axis.map:
+            if axis.map or is_stat_only_ital(axis):
                 continue
             if axis.minimum == axis.maximum:
                 axis.map = [(axis.minimum, axis.minimum)]

--- a/Lib/glyphsLib/builder/stat.py
+++ b/Lib/glyphsLib/builder/stat.py
@@ -42,6 +42,14 @@ def _stat_disabled(instance):
     return export is not None and not export
 
 
+def _is_elidable(instance, axis):
+    return any(
+        param.value == axis.tag
+        for param in instance.customParameters
+        if param.name == "Elidable STAT Axis Value Name"
+    )
+
+
 def _stat_entry_tags(instance):
     return [
         param.value
@@ -137,7 +145,7 @@ def _manual_labels(designspace, instances, user_loc):
             if axis.tag in _stat_entry_tags(instance):
                 loc = user_loc(axis, instance)
                 if loc is not None and loc not in labels:
-                    labels[loc] = (instance.name, False)
+                    labels[loc] = (instance.name, _is_elidable(instance, axis))
         _set_axisLabels(axis, labels)
 
 
@@ -200,7 +208,7 @@ def _automatic_labels(
                 labels[loc] = (default, True)
                 continue
             name = _label_name(instance, default, plain_italic)
-            labels[loc] = (name, name == default)
+            labels[loc] = (name, name == default or _is_elidable(instance, axis))
         _set_axisLabels(axis, labels)
 
     # The regular weight links to a style-linked bold wherever it sits on the

--- a/Lib/glyphsLib/builder/stat.py
+++ b/Lib/glyphsLib/builder/stat.py
@@ -1,0 +1,228 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reproduce Glyphs’ automatic STAT table generation.
+
+Glyphs derives a STAT table from the exported instances: for every axis it
+generates one AxisValue per distinct instance coordinate, named after the
+instance style name, and it always appends a STAT-only “ital” axis.  This
+module reproduces that by populating the DesignSpace v5 ``axis.axisLabels``.
+"""
+
+import re
+
+from fontTools.designspaceLib import AxisLabelDescriptor, DiscreteAxisDescriptor
+
+from glyphsLib.classes import InstanceType
+from glyphsLib.builder.axes import get_axis_definitions, is_instance_active
+
+
+def _is_italic(instance):
+    # Glyphs uses the style name as well as the style-linking flag.
+    return bool(instance.isItalic) or "italic" in instance.name.lower()
+
+
+def _default_name(tag):
+    return "Normal" if tag == "wdth" else "Regular"
+
+
+def _stat_entry_tags(instance):
+    return [
+        param.value
+        for param in instance.customParameters
+        if param.name == "Style Name as STAT entry"
+    ]
+
+
+def _set_axisLabels(axis, labels):
+    if labels:
+        axis.axisLabels = [
+            AxisLabelDescriptor(name=name, userValue=value, elidable=elidable)
+            for value, (name, elidable) in sorted(labels.items())
+        ]
+
+
+def to_designspace_stat(self):
+    font = self.font
+    designspace = self.designspace
+
+    # Glyphs builds a STAT only for a variable font, which needs a Variable Font
+    # Setting instance. Do the same here.
+    if not any(i.type == InstanceType.VARIABLE for i in font.instances):
+        return
+
+    axis_defs = {ad.tag: ad for ad in get_axis_definitions(font)}
+    axis_tags = {axis.tag for axis in designspace.axes}
+    slope_tag = (
+        "ital" if "ital" in axis_tags else "slnt" if "slnt" in axis_tags else None
+    )
+
+    instances = [
+        instance
+        for instance in font.instances
+        if instance.type != InstanceType.VARIABLE and is_instance_active(instance)
+    ]
+
+    def user_loc(axis, instance):
+        axis_def = axis_defs.get(axis.tag)
+        return axis_def.get_user_loc(instance) if axis_def else None
+
+    default_instance = next(
+        (i for i in instances if _at_default(i, designspace.axes, user_loc)), None
+    )
+
+    italic = default_instance is not None and _is_italic(default_instance)
+    # Glyphs drops the italic part of the names only when the default instance is
+    # called nothing but “Italic”.
+    plain_italic = italic and default_instance.name.strip().lower() == "italic"
+
+    # “Style Name as STAT entry” on any instance switches the whole font to manual
+    # mode.
+    if any(_stat_entry_tags(instance) for instance in instances):
+        _manual_labels(designspace, instances, user_loc)
+    else:
+        _automatic_labels(
+            designspace, instances, user_loc, slope_tag, default_instance, plain_italic
+        )
+
+    designspace.elidedFallbackName = "Regular"
+
+    # Glyphs always appends a STAT-only “ital” axis unless the font already has
+    # an “ital” axis.
+    if "ital" not in axis_tags:
+        if italic:
+            label = AxisLabelDescriptor(name="Italic", userValue=1, elidable=False)
+        else:
+            label = AxisLabelDescriptor(
+                name="Roman", userValue=0, elidable=True, linkedUserValue=1
+            )
+        designspace.addAxis(
+            DiscreteAxisDescriptor(
+                tag="ital",
+                name="Italic",
+                values=[label.userValue],
+                default=label.userValue,
+                axisLabels=[label],
+            )
+        )
+
+
+def _manual_labels(designspace, instances, user_loc):
+    for axis in designspace.axes:
+        labels = {}
+        for instance in instances:
+            if axis.tag in _stat_entry_tags(instance):
+                loc = user_loc(axis, instance)
+                if loc is not None and loc not in labels:
+                    labels[loc] = (instance.name, False)
+        _set_axisLabels(axis, labels)
+
+
+def _at_default(instance, axes, user_loc, skip=None):
+    return all(
+        user_loc(axis, instance) in (None, axis.default)
+        for axis in axes
+        if axis is not skip
+    )
+
+
+def _representative_instance(instances, axis, designspace, user_loc):
+    # The instance at this value that is at the default on every other axis.
+    # Fall back to the first instance when none qualifies.
+    for instance in instances:
+        if _at_default(instance, designspace.axes, user_loc, skip=axis):
+            return instance
+    return instances[0]
+
+
+def _label_name(instance, default, plain_italic):
+    name = instance.name
+    if plain_italic:
+        name = re.sub(r"\s*italic\s*", " ", name, flags=re.IGNORECASE).strip()
+    return name or default
+
+
+def _automatic_labels(
+    designspace, instances, user_loc, slope_tag, default_instance, plain_italic=False
+):
+    # The default value of the first axis the instances vary on takes the
+    # default instance’s name, every other default value elides to the
+    # default name.
+    first = next(
+        (
+            axis
+            for axis in designspace.axes
+            if len({user_loc(axis, i) for i in instances} - {None}) > 1
+        ),
+        None,
+    )
+
+    for axis in designspace.axes:
+        default = _default_name(axis.tag)
+        by_value = {}  # user value -> instances sitting there
+        for instance in instances:
+            loc = user_loc(axis, instance)
+            if loc is not None:
+                by_value.setdefault(loc, []).append(instance)
+
+        labels = {}
+        for loc, instances_at_loc in by_value.items():
+            if loc != axis.default:
+                instance = _representative_instance(
+                    instances_at_loc, axis, designspace, user_loc
+                )
+            elif axis is first and default_instance is not None:
+                instance = default_instance
+            else:
+                labels[loc] = (default, True)
+                continue
+            name = _label_name(instance, default, plain_italic)
+            labels[loc] = (name, name == default)
+        _set_axisLabels(axis, labels)
+
+    # The regular weight links to a style-linked bold wherever it sits on the
+    # other axes.
+    wght = next((a for a in designspace.axes if a.tag == "wght"), None)
+    if wght is not None and _default_value_elides(wght):
+        bold = next((i for i in instances if i.isBold), None)
+        _set_linked_value(wght, user_loc(wght, bold) if bold else None)
+
+    # On a real “ital” axis the upright value links to the italic value.
+    if slope_tag == "ital":
+        ital = next(a for a in designspace.axes if a.tag == "ital")
+        _set_linked_value(
+            ital, max((l.userValue for l in ital.axisLabels), default=ital.default)
+        )
+
+
+def _default_value_elides(axis):
+    label = next(
+        (l for l in axis.axisLabels or [] if l.userValue == axis.default), None
+    )
+    return label is not None and label.elidable
+
+
+def _set_linked_value(axis, value):
+    if value is None or value == axis.default:
+        return
+    default_label = next(
+        (l for l in axis.axisLabels or [] if l.userValue == axis.default), None
+    )
+    if default_label is not None:
+        default_label.linkedUserValue = value
+
+
+def is_stat_only_ital(axis):
+    # The axis this module appends carries a single value, 0 or 1.
+    return axis.tag == "ital" and getattr(axis, "values", None) in ([0], [1])

--- a/Lib/glyphsLib/builder/stat.py
+++ b/Lib/glyphsLib/builder/stat.py
@@ -37,6 +37,11 @@ def _default_name(tag):
     return "Normal" if tag == "wdth" else "Regular"
 
 
+def _stat_disabled(instance):
+    export = instance.customParameters["Export STAT Table"]
+    return export is not None and not export
+
+
 def _stat_entry_tags(instance):
     return [
         param.value
@@ -59,7 +64,14 @@ def to_designspace_stat(self):
 
     # Glyphs builds a STAT only for a variable font, which needs a Variable Font
     # Setting instance. Do the same here.
-    if not any(i.type == InstanceType.VARIABLE for i in font.instances):
+    variable = [i for i in font.instances if i.type == InstanceType.VARIABLE]
+    if not variable:
+        return
+
+    # “Export STAT Table” = 0 turns the STAT off. Glyphs applies this per variable
+    # font, but varLib builds the STAT from the document as a whole, so we can only
+    # drop it when every variable-font instance turns it off.
+    if all(_stat_disabled(instance) for instance in variable):
         return
 
     axis_defs = {ad.tag: ad for ad in get_axis_definitions(font)}

--- a/tests/builder/axes_test.py
+++ b/tests/builder/axes_test.py
@@ -22,6 +22,7 @@ from fontTools import designspaceLib
 from glyphsLib import to_glyphs, to_designspace, to_ufos
 from glyphsLib.classes import GSFont, GSFontMaster, GSAxis, GSInstance
 from glyphsLib.builder.axes import _is_subset_of_default_axes, get_regular_master
+from glyphsLib.builder.stat import is_stat_only_ital
 
 """
 Goal: check how files with custom axes are roundtripped.
@@ -684,7 +685,8 @@ def test_variable_instance(ufo_module):
     varfont = doc.variableFonts[0]
     assert varfont.name == "Variable Foo Bar"
     assert varfont.filename == "Cairo-VariableFooBarVF"
-    assert len(varfont.axisSubsets) == len(doc.axes)
+    real_axes = [a for a in doc.axes if not is_stat_only_ital(a)]
+    assert len(varfont.axisSubsets) == len(real_axes)
     assert "public.fontInfo" in varfont.lib
 
     info = varfont.lib["public.fontInfo"]

--- a/tests/builder/stat_test.py
+++ b/tests/builder/stat_test.py
@@ -338,6 +338,57 @@ def test_export_stat_table_off_on_only_one_variable_font_keeps_stat():
     ]
 
 
+def test_elidable_stat_axis_value_name_param():
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Bold", [700])],
+        [
+            ("Regular", [400], {"weight": "Regular"}),
+            (
+                "Bold",
+                [700],
+                {
+                    "weight": "Bold",
+                    "customParameters": {"Elidable STAT Axis Value Name": "wght"},
+                },
+            ),
+        ],
+    )
+    doc = to_designspace(font)
+
+    # Bold at wght=700 is normally not elidable, the parameter marks it elidable.
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Bold", 700, True, None),
+    ]
+
+
+def test_elidable_default_still_links_to_the_style_linked_bold():
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Bold", [700])],
+        [
+            (
+                "Book",
+                [400],
+                {
+                    "weight": "Regular",
+                    "customParameters": {"Elidable STAT Axis Value Name": "wght"},
+                },
+            ),
+            ("Bold", [700], {"weight": "Bold", "isBold": True, "linkStyle": "Regular"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    # The default value is named “Book”, but the parameter elides it, so Glyphs
+    # still pairs it with the bold.
+    assert _labels(_axis(doc, "wght")) == [
+        ("Book", 400, True, 700),
+        ("Bold", 700, False, None),
+    ]
+
+
 def test_style_name_as_stat_entry_manual_mode():
     # The parameter on any instance disables automatic derivation.
     font = _make_font(

--- a/tests/builder/stat_test.py
+++ b/tests/builder/stat_test.py
@@ -299,6 +299,45 @@ def test_no_variable_font_instance_gets_no_stat():
     assert not any(a.tag == "ital" for a in doc.axes)
 
 
+def test_export_stat_table_off_disables_stat():
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Bold", [700])],
+        [
+            ("Regular", [400], {"weight": "Regular"}),
+            ("Bold", [700], {"weight": "Bold"}),
+        ],
+    )
+    font.instances[-1].customParameters["Export STAT Table"] = 0
+
+    doc = to_designspace(font)
+    assert not any(a.axisLabels for a in doc.axes)
+    assert not any(a.tag == "ital" for a in doc.axes)
+
+
+def test_export_stat_table_off_on_only_one_variable_font_keeps_stat():
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Bold", [700])],
+        [
+            ("Regular", [400], {"weight": "Regular"}),
+            ("Bold", [700], {"weight": "Bold"}),
+        ],
+    )
+    font.instances[-1].customParameters["Export STAT Table"] = 0
+    other = GSInstance()
+    other.name = "VF2"
+    other.type = InstanceType.VARIABLE
+    other.parent = font
+    font.instances.append(other)
+
+    doc = to_designspace(font)
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Bold", 700, False, None),
+    ]
+
+
 def test_style_name_as_stat_entry_manual_mode():
     # The parameter on any instance disables automatic derivation.
     font = _make_font(

--- a/tests/builder/stat_test.py
+++ b/tests/builder/stat_test.py
@@ -1,0 +1,495 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from glyphsLib import to_designspace, to_glyphs
+from glyphsLib.builder.stat import is_stat_only_ital
+from glyphsLib.classes import (
+    GSAxis,
+    GSFont,
+    GSFontMaster,
+    GSGlyph,
+    GSInstance,
+    GSLayer,
+    InstanceType,
+)
+
+
+def _make_font(axes, masters, instances, variable=True):
+    font = GSFont()
+    font.format_version = 3
+    font.familyName = "Test"
+    font.axes = [GSAxis(name=name, tag=tag) for tag, name in axes]
+
+    for name, coords in masters:
+        master = GSFontMaster()
+        master.name = name
+        master.axes = list(coords)
+        master.ascender, master.capHeight = 800, 700
+        master.xHeight, master.descender = 500, -200
+        font.masters.append(master)
+
+    glyph = GSGlyph()
+    glyph.name = ".notdef"
+    for master in font.masters:
+        layer = GSLayer()
+        layer.layerId = layer.associatedMasterId = master.id
+        layer.width = 500
+        glyph.layers.append(layer)
+    font.glyphs.append(glyph)
+
+    for name, coords, attrs in instances:
+        instance = GSInstance()
+        instance.name = name
+        instance.axes = list(coords)
+        for key, value in attrs.items():
+            if key == "customParameters":
+                for param, param_value in value.items():
+                    instance.customParameters[param] = param_value
+            else:
+                setattr(instance, key, value)
+        instance.parent = font
+        font.instances.append(instance)
+
+    if variable:
+        instance = GSInstance()
+        instance.name = "VF"
+        instance.type = InstanceType.VARIABLE
+        instance.parent = font
+        font.instances.append(instance)
+
+    return font
+
+
+def _labels(axis):
+    return [
+        (label.name, label.userValue, label.elidable, label.linkedUserValue)
+        for label in axis.axisLabels or []
+    ]
+
+
+def _axis(doc, tag):
+    return next(a for a in doc.axes if a.tag == tag)
+
+
+def test_style_linked_bold_links_the_default_weight():
+    def build(is_bold):
+        return _make_font(
+            [("wght", "Weight")],
+            [("Regular", [400]), ("Bold", [700])],
+            [
+                ("Regular", [400], {"weight": "Regular"}),
+                (
+                    "Bold",
+                    [700],
+                    (
+                        {"weight": "Bold", "isBold": is_bold, "linkStyle": "Regular"}
+                        if is_bold
+                        else {"weight": "Bold"}
+                    ),
+                ),
+            ],
+        )
+
+    assert _labels(_axis(to_designspace(build(True)), "wght")) == [
+        ("Regular", 400, True, 700),
+        ("Bold", 700, False, None),
+    ]
+    assert _labels(_axis(to_designspace(build(False)), "wght")) == [
+        ("Regular", 400, True, None),
+        ("Bold", 700, False, None),
+    ]
+
+
+def test_weight_width_labels():
+    font = _make_font(
+        [("wght", "Weight"), ("wdth", "Width")],
+        [("Regular", [400, 100]), ("Bold", [700, 100]), ("Condensed", [400, 75])],
+        [
+            ("Regular", [400, 100], {"weight": "Regular", "width": "Medium (normal)"}),
+            ("Bold", [700, 100], {"weight": "Bold", "width": "Medium (normal)"}),
+            ("Condensed", [400, 75], {"weight": "Regular", "width": "Condensed"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Bold", 700, False, None),
+    ]
+    assert _labels(_axis(doc, "wdth")) == [
+        ("Condensed", 75, False, None),
+        ("Normal", 100, True, None),
+    ]
+    # A STAT-only italic axis is always appended.
+    ital = _axis(doc, "ital")
+    assert is_stat_only_ital(ital)
+    assert ital.values == [0]
+    assert _labels(ital) == [("Roman", 0, True, 1)]
+
+
+def test_style_name_used_for_every_differing_axis():
+    # An instance differing from the default on more than one axis uses its whole
+    # style name for all of them, not just the first.
+    font = _make_font(
+        [("SPAC", "Spacing"), ("MSHQ", "Mashq")],
+        [("Regular", [0, 10]), ("Compact", [-100, 10]), ("High", [0, 20])],
+        [("Regular", [0, 10], {}), ("Compact High", [-100, 20], {})],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "SPAC")) == [
+        ("Compact High", -100, False, None),
+        ("Regular", 0, True, None),
+    ]
+    assert _labels(_axis(doc, "MSHQ")) == [
+        ("Regular", 10, True, None),
+        ("Compact High", 20, False, None),
+    ]
+
+
+def test_multi_word_style_name_is_not_split_across_axes():
+    font = _make_font(
+        [("wght", "Weight"), ("wdth", "Width")],
+        [("Regular", [400, 100]), ("Bold", [700, 100]), ("Condensed", [400, 75])],
+        [
+            ("Regular", [400, 100], {"weight": "Regular", "width": "Medium (normal)"}),
+            ("Bold Condensed", [700, 75], {"weight": "Bold", "width": "Condensed"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Bold Condensed", 700, False, None),
+    ]
+    assert _labels(_axis(doc, "wdth")) == [
+        ("Bold Condensed", 75, False, None),
+        ("Normal", 100, True, None),
+    ]
+
+
+def test_instance_driven_values_and_custom_axis():
+    # A weight instance at a non-master coordinate (Medium at wght=500) still
+    # gets a value, and a custom-axis instance name (Compact) attaches to it.
+    font = _make_font(
+        [("wght", "Weight"), ("SPAC", "Spacing")],
+        [("Regular", [400, 0]), ("Bold", [700, 0]), ("Compact", [400, -100])],
+        [
+            ("Regular", [400, 0], {"weight": "Regular"}),
+            ("Medium", [500, 0], {"weight": "Medium"}),
+            ("Bold", [700, 0], {"weight": "Bold"}),
+            ("Compact", [400, -100], {"weight": "Regular"}),
+            ("Bold Compact", [700, -100], {"weight": "Bold"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Medium", 500, False, None),
+        ("Bold", 700, False, None),
+    ]
+    assert _labels(_axis(doc, "SPAC")) == [
+        ("Compact", -100, False, None),
+        ("Regular", 0, True, None),
+    ]
+
+
+def test_non_regular_default_instance_labels_first_axis():
+    # A non-Regular default instance labels the first axis; the degenerate axis
+    # and the elided fallback stay "Regular".
+    font = _make_font(
+        [("SPAC", "Spacing"), ("MSHQ", "Mashq")],
+        [("Regular", [0, 10]), ("Compact", [-100, 10])],
+        [
+            ("Book", [0, 10], {}),
+            ("Compact", [-100, 10], {}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "SPAC")) == [
+        ("Compact", -100, False, None),
+        ("Book", 0, False, None),
+    ]
+    assert _labels(_axis(doc, "MSHQ")) == [("Regular", 10, True, None)]
+    assert doc.elidedFallbackName == "Regular"
+
+
+def test_default_instance_labels_first_varying_axis():
+    font = _make_font(
+        [("wght", "Weight"), ("wdth", "Width")],
+        [("Regular", [400, 100]), ("Bold", [700, 100]), ("Condensed", [400, 75])],
+        [
+            ("Book", [400, 100], {"weight": "Regular", "width": "Medium (normal)"}),
+            ("Condensed", [400, 75], {"weight": "Regular", "width": "Condensed"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [("Regular", 400, True, None)]
+    assert _labels(_axis(doc, "wdth")) == [
+        ("Condensed", 75, False, None),
+        ("Book", 100, False, None),
+    ]
+
+
+def test_elided_fallback_name_is_always_regular():
+    # Even when the default instance is a style-linked Bold.
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Black", [900])],
+        [
+            ("Bold", [400], {"isBold": True}),
+            ("Black", [900], {}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert doc.elidedFallbackName == "Regular"
+
+
+def test_style_name_is_used_as_is():
+    # Style names are used as-is, only the default coordinate is elided.
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Bold", [700])],
+        [
+            ("Regular", [400], {"weight": "Regular"}),
+            ("Zzz", [600], {"weight": "SemiBold"}),
+            ("Bold", [700], {"weight": "Bold"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Zzz", 600, False, None),
+        ("Bold", 700, False, None),
+    ]
+
+
+def test_no_variable_font_instance_gets_no_stat():
+    # Build STAT only for variable fonts.
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [400]), ("Bold", [700])],
+        [
+            ("Regular", [400], {"weight": "Regular"}),
+            ("Bold", [700], {"weight": "Bold"}),
+        ],
+        variable=False,
+    )
+    doc = to_designspace(font)
+
+    assert not any(a.axisLabels for a in doc.axes)
+    assert not any(a.tag == "ital" for a in doc.axes)
+
+
+def test_style_name_as_stat_entry_manual_mode():
+    # The parameter on any instance disables automatic derivation.
+    font = _make_font(
+        [("wght", "Weight"), ("wdth", "Width")],
+        [("Regular", [400, 100]), ("Bold", [700, 100]), ("Condensed", [400, 75])],
+        [
+            ("Regular", [400, 100], {"weight": "Regular", "width": "Medium (normal)"}),
+            (
+                "Bold",
+                [700, 100],
+                {
+                    "weight": "Bold",
+                    "width": "Medium (normal)",
+                    "customParameters": {"Style Name as STAT entry": "wght"},
+                },
+            ),
+            ("Condensed", [400, 75], {"weight": "Regular", "width": "Condensed"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [("Bold", 700, False, None)]
+    assert not _axis(doc, "wdth").axisLabels
+    # The STAT-only italic axis is still appended in manual mode.
+    assert _labels(_axis(doc, "ital")) == [("Roman", 0, True, 1)]
+
+
+def test_real_italic_axis_suppresses_stat_only_and_links_upright():
+    font = _make_font(
+        [("wght", "Weight"), ("ital", "Italic")],
+        [
+            ("Regular", [400, 0]),
+            ("Bold", [700, 0]),
+            ("Italic", [400, 1]),
+            ("Bold Italic", [700, 1]),
+        ],
+        [
+            ("Regular", [400, 0], {"weight": "Regular"}),
+            ("Bold", [700, 0], {"weight": "Bold"}),
+            ("Italic", [400, 1], {"weight": "Regular"}),
+            ("Bold Italic", [700, 1], {"weight": "Bold"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    # Exactly one italic axis, the real one.
+    itals = [a for a in doc.axes if a.tag == "ital"]
+    assert len(itals) == 1
+    assert not is_stat_only_ital(itals[0])
+    # The upright value links to the italic value.
+    assert _labels(itals[0]) == [("Regular", 0, True, 1), ("Italic", 1, False, None)]
+
+
+def test_italic_family_gets_the_italic_axis_value():
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Italic", [400]), ("Bold Italic", [700])],
+        [
+            ("Italic", [400], {"weight": "Regular", "isItalic": True}),
+            (
+                "Bold Italic",
+                [700],
+                {"weight": "Bold", "isItalic": True, "isBold": True},
+            ),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "ital")) == [("Italic", 1, False, None)]
+    assert doc.elidedFallbackName == "Regular"
+
+
+def test_italic_family_detected_from_style_name():
+    # No italic flag on either instance.
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Italic", [400]), ("Bold Italic", [700])],
+        [
+            ("Italic", [400], {"weight": "Regular"}),
+            ("Bold Italic", [700], {"weight": "Bold"}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "ital")) == [("Italic", 1, False, None)]
+
+
+def test_italic_family_labels_drop_the_italic_word():
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Italic", [400]), ("Bold Italic", [700]), ("Black Italic", [900])],
+        [
+            ("Italic", [400], {"weight": "Regular", "isItalic": True}),
+            (
+                "Bold Italic",
+                [700],
+                {"weight": "Bold", "isItalic": True, "isBold": True},
+            ),
+            ("Black Italic", [900], {"weight": "Black", "isItalic": True}),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, 700),
+        ("Bold", 700, False, None),
+        ("Black", 900, False, None),
+    ]
+
+
+def test_italic_family_labels_keep_a_named_default():
+    # The default instance is "Book Italic", not the bare "Italic".
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Book Italic", [400]), ("Bold Italic", [700])],
+        [
+            ("Book Italic", [400], {"weight": "Regular", "isItalic": True}),
+            (
+                "Bold Italic",
+                [700],
+                {"weight": "Bold", "isItalic": True, "isBold": True},
+            ),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Book Italic", 400, False, None),
+        ("Bold Italic", 700, False, None),
+    ]
+
+
+def test_style_linked_bold_links_from_another_axis_position():
+    # The bold sits off the default width.
+    font = _make_font(
+        [("wght", "Weight"), ("wdth", "Width")],
+        [("Regular", [400, 100]), ("Bold", [700, 100]), ("Condensed", [400, 75])],
+        [
+            ("Regular", [400, 100], {"weight": "Regular"}),
+            (
+                "Bold Condensed",
+                [700, 75],
+                {"weight": "Bold", "width": "Condensed", "isBold": True},
+            ),
+        ],
+    )
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, 700),
+        ("Bold Condensed", 700, False, None),
+    ]
+
+
+def test_axis_location_uses_user_space_values():
+    # Design coordinates 0..100 map to user 400..700 via “Axis Location”, the STAT
+    # values must be in user space to match fvar.
+    font = _make_font(
+        [("wght", "Weight")],
+        [("Regular", [0]), ("Bold", [100])],
+        [
+            ("Regular", [0], {"weight": "Regular"}),
+            ("Bold", [100], {"weight": "Bold"}),
+        ],
+    )
+    locations = {0: 400, 100: 700}
+    for owner in list(font.masters) + list(font.instances):
+        owner.customParameters["Axis Location"] = [
+            {"Axis": "Weight", "Location": locations[owner.axes[0]]}
+        ]
+
+    doc = to_designspace(font)
+
+    assert _labels(_axis(doc, "wght")) == [
+        ("Regular", 400, True, None),
+        ("Bold", 700, False, None),
+    ]
+
+
+@pytest.mark.parametrize("style, italic", [("Regular", False), ("Italic", True)])
+def test_stat_only_italic_does_not_roundtrip_to_glyphs(style, italic):
+    font = _make_font(
+        [("wght", "Weight")],
+        [(style, [400]), ("Bold " + style, [700])],
+        [
+            (style, [400], {"weight": "Regular", "isItalic": italic}),
+            ("Bold " + style, [700], {"weight": "Bold", "isItalic": italic}),
+        ],
+    )
+    doc = to_designspace(font)
+    assert _axis(doc, "ital").values == [1 if italic else 0]
+
+    roundtripped = to_glyphs(doc)
+    assert "ital" not in [a.axisTag for a in roundtripped.axes]


### PR DESCRIPTION
Glyphs auto-generates a STAT table from the font instances. Reproduce the default algorithm by populating the DesignSpace v5 axis labels:

- One AxisValue per distinct instance coordinate on each axis
- The default axis value is elided
- A STAT-only “ital” axis, as a discrete axis pinned at 0, or at 1 for an italic family.

Also support “Style Name as STAT entry”, “Export STAT Table”, and [“Elidable STAT Axis Value Name” custom parameters for manual control.