### PR TITLE
Convert variable feature code when building UFOs from Glyphs

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -34,6 +34,7 @@ from .constants import (
     INSERT_FEATURE_MARKER_COMMENT,
 )
 from .tokens import TokenExpander, PassThruExpander
+from .variable_features import VariableFeatureConverter
 
 if TYPE_CHECKING:
     from ufoLib2 import Font
@@ -192,6 +193,10 @@ def _to_ufo_features(  # noqa: C901
 
     full_text = "\n\n".join(filter(None, [class_str, prefix_str, fea_str])) + "\n"
     full_text = full_text if full_text.strip() else ""
+
+    # Convert Glyphs conditional features and variable GPOS to feaLib syntax.
+    if master is not None:
+        full_text = VariableFeatureConverter(font).convert(full_text)
 
     if not full_text or not expand_includes:
         return full_text

--- a/Lib/glyphsLib/builder/variable_features.py
+++ b/Lib/glyphsLib/builder/variable_features.py
@@ -1,0 +1,483 @@
+# Copyright 2026 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+import re
+from types import SimpleNamespace
+
+from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.misc.fixedTools import floatToFixedToStr
+from fontTools.misc.roundTools import otRound
+from fontTools.varLib.featureVars import overlayFeatureVariations
+from fontTools.varLib.models import piecewiseLinearMap
+
+from .axes import to_designspace_axes
+
+logger = logging.getLogger(__name__)
+
+_tag = r"[a-zA-Z0-9]{4}"
+_number = r"-?\d+(?:\.\d+)?"
+
+_axis_spec = rf"{_tag}\s*:\s*{_number}"
+# Comment | "string": matched first by the passes below and left unchanged.
+_skip = r"\#[^\n]*|\"[^\"\n]*\""
+# A value record, allowing a nested <...> (e.g. a device table).
+_value_record = r"<\s*((?:[^<>;]|<[^<>;]*>)*?)\s*>"
+
+_feaLib_vf_pos_re = re.compile(rf"{_tag}\s*=\s*{_number}\s*:{_number}")
+_token_re = re.compile(rf"\([\s\S]*?\)|{_number}")
+# condition ...; (as a whole word, not part of a glyph name like a.condition
+# or condition.alt)
+_condition_re = re.compile(r"(?<![\w.])condition(?![\w.])\s*([^;]*);")
+
+
+def _format_value(value):
+    # feaLib scalar values must be integers.
+    return str(otRound(float(value)))
+
+
+# Strip static-only code. No “#ifdef”/“#ifndef” may appear in the body, so an
+# unterminated block does not take over the following block’s “#endif”.
+_ifndef_re = re.compile(
+    r"""
+    [^\S\n]*\#ifndef\s+VARIABLE[^\n]*\n  # “#ifndef VARIABLE” line.
+    (?:(?!\#ifn?def)[\s\S])*?            # Body.
+    \#endif[^\n]*\n?                     # “#endif” line.
+    """,
+    re.VERBOSE,
+)
+_ifndef_start_re = re.compile(r"#ifndef\s+VARIABLE")
+
+
+def _strip_ifndef(fea):
+    fea = _ifndef_re.sub("", fea)
+    # An unterminated #ifndef VARIABLE runs to the end of the enclosing
+    # feature code, like in Glyphs.
+    while m := _ifndef_start_re.search(fea):
+        masked = _blank_comments_and_strings(fea)
+        end = len(fea)
+        depth = 0
+        for i in range(m.end(), len(fea)):
+            if masked[i] == "{":
+                depth += 1
+            elif masked[i] == "}":
+                if depth == 0:
+                    end = i
+                    break
+                depth -= 1
+        fea = fea[: m.start()] + fea[end:]
+    return fea
+
+
+# Comments and strings may contain braces that do not open or close a block.
+# Block scanning uses a copy with them blanked out.
+_comment_or_string_re = re.compile(_skip)
+
+
+def _blank_comments_and_strings(fea):
+    return _comment_or_string_re.sub(lambda m: " " * len(m.group()), fea)
+
+
+def _match_block(masked, start):
+    # index of the brace closing the block opened before `start`, or None
+    depth = 1
+    for i in range(start, len(masked)):
+        if masked[i] == "{":
+            depth += 1
+        elif masked[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def _box_within(a, b):
+    for axis in set(a) | set(b):
+        a_min, a_max = a.get(axis, (-math.inf, math.inf))
+        b_min, b_max = b.get(axis, (-math.inf, math.inf))
+        if a_min < b_min or a_max > b_max:
+            return False
+    return True
+
+
+# Any of the Glyphs-only syntaxes this module converts.
+_has_variable_re = re.compile(
+    rf"""
+      (?<![\w.])condition(?![\w.])  # “condition” statement
+    | \#ifn?def\s+VARIABLE          # “#ifdef” / “#ifndef VARIABLE” block
+    | \(\s*{_tag}\s*:               # “(axis:” variable GPOS location
+    """,
+    re.VERBOSE,
+)
+_axis_spec_re = re.compile(_axis_spec)
+_value_record_keyword_re = re.compile(r"\b(?:device|contourpoint|NULL)\b")
+_value_record_re = re.compile(rf"{_skip}|{_value_record}")
+_scalar_re = re.compile(
+    rf"""
+      {_skip}          # Left unchanged.
+    | {_value_record}  # Left unchanged so the numbers inside are not scalars.
+    | {_number}        # A variable scalar, e.g. “10 (wght:900) 20”.
+      (?:              # “(location)” value pairs after the default value.
+        \s*\(\s*{_axis_spec}(?:\s*,?\s*{_axis_spec})*\s*\)  # Commas optional.
+        \s*{_number}
+      )+
+    """,
+    re.VERBOSE,
+)
+# “MIN < axis < MAX”, either bound is optional
+_axis_range_re = re.compile(
+    rf"""
+    (?:({_number})\s*<\s*)?  # optional minimum
+    ({_tag})                 # axis tag
+    (?:\s*<\s*({_number}))?  # optional maximum
+    """,
+    re.VERBOSE,
+)
+_feature_start_re = re.compile(rf"feature\s+({_tag})(\s+useExtension)?\s*\{{")
+
+
+class VariableFeatureConverter:
+    def __init__(self, font):
+        # We don’t have access to axes definitions yet, so we get them here the
+        # same way they will be generated for the Designspace.
+        shim = SimpleNamespace(
+            font=font,
+            designspace=DesignSpaceDocument(),
+            minimize_glyphs_diffs=False,
+        )
+        to_designspace_axes(shim)
+        axes = shim.designspace.axes
+        self.axes = {axis.tag: axis for axis in axes}
+        self.default_coords = ",".join(f"{a.tag}={a.default}" for a in axes)
+        self.condition_sets = {}
+
+    def convert(self, fea):
+        if not _has_variable_re.search(fea):
+            return fea
+
+        fea = _strip_ifndef(fea)
+        fea = self._translate_gpos(fea)
+        fea = self._translate_gsub(fea)
+
+        # every condition must sit inside a feature block; a leftover means one
+        # appeared at top level (e.g. in a prefix) and was not converted
+        if _condition_re.search(_blank_comments_and_strings(fea)):
+            raise ValueError(
+                "condition statements outside feature blocks are not supported"
+            )
+
+        return fea
+
+    def _axis(self, tag):
+        if tag not in self.axes:
+            raise ValueError(
+                f"unknown axis '{tag}' in feature code, expected one of "
+                f"{sorted(self.axes)}"
+            )
+        return self.axes[tag]
+
+    def _map_coordinate(self, tag, value):
+        # Glyphs coordinates are design-space; feaLib wants user-space.
+        mapping = self._axis(tag).map  # [(userCoord, designCoord), ...]
+        if mapping:
+            mapping = {float(design): float(user) for user, design in mapping}
+            value = piecewiseLinearMap(value, mapping)
+        return floatToFixedToStr(value, 16)
+
+    # GPOS
+
+    def _translate_axis_spec(self, spec):
+        # Converts `(wdth:80)` to `wdth=80`.
+        spec = spec.strip("() ")
+        converted = []
+        for part in _axis_spec_re.findall(spec):
+            axis, val = part.split(":")
+            axis = axis.strip()
+            val = self._map_coordinate(axis, float(val))
+            converted.append(f"{axis}={val}")
+        return ",".join(converted)
+
+    def _translate_scalar(self, match):
+        # Converts `10 (wdth:80) 20` to `(wght=400:10 wdth=80:20)`.
+        tokens = _token_re.findall(match.group(0))
+        if not tokens:
+            return match.group(0)
+
+        default_val = tokens.pop(0)
+        entries = [f"{self.default_coords}:{_format_value(default_val)}"]
+
+        for i in range(0, len(tokens), 2):
+            if not tokens[i].startswith("("):
+                raise ValueError(f"invalid variable position value: {match.group(0)!r}")
+            axes = self._translate_axis_spec(tokens[i])
+            entries.append(f"{axes}:{_format_value(tokens[i + 1])}")
+
+        return f"({' '.join(entries)})"
+
+    def _variable_scalars(self, tokens, num_components, record, kind):
+        # The tokens are num_components values for the default master, then a
+        # (location) and num_components values for each other master, e.g.
+        # “10 0 5 0 (wght:900) 20 10 5 2”. Returns one scalar per component.
+        # A component with the same value in all masters stays a plain number.
+        if (
+            len(tokens) < 2 * num_components + 1
+            or (len(tokens) - num_components) % (num_components + 1) != 0
+        ):
+            raise ValueError(f"invalid variable {kind}: <{record}>")
+
+        def value(token):
+            if token.startswith("("):
+                raise ValueError(f"invalid variable {kind}: <{record}>")
+            return _format_value(token)
+
+        default_vals = [value(v) for v in tokens[:num_components]]
+        masters = []
+        for i in range(num_components, len(tokens), num_components + 1):
+            if not tokens[i].startswith("("):
+                raise ValueError(f"invalid variable {kind}: <{record}>")
+            axes = self._translate_axis_spec(tokens[i])
+            if not axes:
+                raise ValueError(
+                    f"invalid axis location {tokens[i]} in {kind}: <{record}>"
+                )
+            vals = [value(v) for v in tokens[i + 1 : i + 1 + num_components]]
+            masters.append((axes, vals))
+
+        scalars = []
+        for i in range(num_components):
+            if all(vals[i] == default_vals[i] for _, vals in masters):
+                scalars.append(default_vals[i])
+            else:
+                entries = [f"{self.default_coords}:{default_vals[i]}"]
+                for axes, vals in masters:
+                    entries.append(f"{axes}:{vals[i]}")
+                scalars.append(f"({' '.join(entries)})")
+        return scalars
+
+    def _translate_anchor(self, match, record):
+        # Converts `<anchor 100 200 (wght:900) 150 260>` to
+        # `<anchor (wght=400:100 wght=900:150) (wght=400:200 wght=900:260)>`.
+        if (
+            "(" not in record
+            or "NULL" in record
+            or "contourpoint" in record
+            or _feaLib_vf_pos_re.search(record)
+        ):
+            return match.group(0)
+        tokens = _token_re.findall(record.strip()[len("anchor") :])
+        scalars = self._variable_scalars(tokens, 2, record, "anchor")
+        return f"<anchor {' '.join(scalars)}>"
+
+    def _translate_value_record(self, match):
+        # Converts `<10 0 5 0 (wdth:80) 20 10 5 2 ...>` to
+        # `<(wdth=400:10 wdth=80:20) (wdth=400:0 wdth=80:10)
+        #   (wdth=400:5 wdth=80:5) (wdth=400:0 wdth=80:2)>`.
+        record = match.group(1)
+        if record.strip().startswith("anchor"):
+            return self._translate_anchor(match, record)
+        if (
+            "(" not in record
+            or _value_record_keyword_re.search(record)
+            or _feaLib_vf_pos_re.search(record)
+        ):
+            return match.group(0)
+
+        tokens = _token_re.findall(record.strip())
+        scalars = self._variable_scalars(tokens, 4, record, "value record")
+        return f"<{' '.join(scalars)}>"
+
+    def _translate_gpos(self, fea):
+        fea = _value_record_re.sub(
+            lambda m: (
+                m.group(0) if m.group(0)[0] in '#"' else self._translate_value_record(m)
+            ),
+            fea,
+        )
+        fea = _scalar_re.sub(
+            lambda m: (
+                m.group(0) if m.group(0)[0] in '#"<' else self._translate_scalar(m)
+            ),
+            fea,
+        )
+        return fea
+
+    # GSUB
+
+    def _parse_conditions(self, params):
+        # Returns ((tag, min, max), ...), or None for a bare `condition;`
+        if not params.strip():
+            return None
+
+        ranges = {}
+        for part in params.split(","):
+            match = _axis_range_re.fullmatch(part.strip())
+            if match is None or (match.group(1) is None and match.group(3) is None):
+                raise ValueError(f"invalid condition axis range: '{part.strip()}'")
+            c_min, tag, c_max = match.groups()
+            axis = self._axis(tag)
+            c_min = self._map_coordinate(tag, float(c_min)) if c_min else axis.minimum
+            c_max = self._map_coordinate(tag, float(c_max)) if c_max else axis.maximum
+            if tag in ranges:
+                raise ValueError(f"condition for axis '{tag}' already specified")
+            ranges[tag] = (c_min, c_max)
+
+        return tuple(
+            sorted(
+                (t, str(axis_min), str(axis_max))
+                for t, (axis_min, axis_max) in ranges.items()
+            )
+        )
+
+    def _condition_set(self, conditions):
+        if conditions in self.condition_sets:
+            return self.condition_sets[conditions], None
+        name = f"conditionset_{len(self.condition_sets) + 1}"
+        body = ";\n    ".join(" ".join(c) for c in conditions)
+        definition = f"conditionset {name} {{\n    {body};\n}} {name};\n"
+        self.condition_sets[conditions] = name
+        return name, definition
+
+    def _split_at_conditions(self, body, masked_body):
+        segments = []
+        last, conditions = 0, None
+        for m in _condition_re.finditer(masked_body):
+            segments.append((conditions, body[last : m.start()]))
+            conditions = self._parse_conditions(m.group(1))
+            last = m.end()
+        segments.append((conditions, body[last:]))
+        return segments
+
+    def _translate_feature(self, body, masked_body, tag, use_extension=""):
+        # Emit unconditional rules in the feature block, then a variation block
+        # per conditional region.
+        for m in _condition_re.finditer(masked_body):
+            depth = masked_body.count("{", 0, m.start()) - masked_body.count(
+                "}", 0, m.start()
+            )
+            if depth > 0:
+                raise ValueError(
+                    f"condition statements inside lookup blocks are not supported "
+                    f"in feature '{tag}': {m.group(0).strip()}"
+                )
+
+        segments = self._split_at_conditions(body, masked_body)
+        base = [segments[0][1]]
+        conditional = []
+        for conditions, text in segments[1:]:
+            if conditions is None:
+                # Rules after a bare `condition;` are unconditional again and
+                # go in the feature block.
+                base.append(text)
+            elif text.strip():
+                if all(
+                    float(axis_min) <= float(axis_max)
+                    for _, axis_min, axis_max in conditions
+                ):
+                    conditional.append((conditions, text))
+                else:
+                    # An inverted range. Glyphs allows these but feaLib rejects
+                    # them. They wouldn’t be applied any way, so dropping them
+                    # is equivalent.
+                    ranges = ", ".join(
+                        f"{axis_min} < {t} < {axis_max}"
+                        for t, axis_min, axis_max in conditions
+                    )
+                    logger.warning(
+                        "dropping rules in feature '%s': condition '%s' can "
+                        "never match",
+                        tag,
+                        ranges,
+                    )
+
+        # useExtension is only valid on the feature block, not variation blocks
+        parts = [
+            f"feature {tag}{use_extension} {{\n{''.join(base).strip()}\n}} {tag};\n"
+        ]
+
+        # non-overlapping regions, most specific first
+        overlaid = overlayFeatureVariations(
+            [
+                (
+                    [
+                        {
+                            t: (float(axis_min), float(axis_max))
+                            for t, axis_min, axis_max in conds
+                        }
+                    ],
+                    {i: text},
+                )
+                for i, (conds, text) in enumerate(conditional)
+            ]
+        )
+        # overlayFeatureVariations skips single-point overlaps. ٫eep a pinned
+        # region ahead of any broader one that contains it
+        ordered = []
+        for item in overlaid:
+            index = len(ordered)
+            for i, other in enumerate(ordered):
+                if _box_within(item[0], other[0]):
+                    index = i
+                    break
+            ordered.insert(index, item)
+
+        for box, _ in ordered:
+            conditions = tuple(
+                sorted(
+                    (t, str(axis_min), str(axis_max))
+                    for t, (axis_min, axis_max) in box.items()
+                )
+            )
+            name, definition = self._condition_set(conditions)
+            if definition is not None:
+                parts.append(f"\n{definition}")
+            # Rules of the containing region also apply inside this one. The
+            # overlay skips single-point intersections, so merge them here.
+            # Sorting by the segment index restores source order.
+            merged = {}
+            for other_box, other_values in ordered:
+                if other_box is box or _box_within(box, other_box):
+                    for d in other_values:
+                        merged.update(d)
+            rules = "\n".join(text.strip() for _, text in sorted(merged.items()))
+            parts.append(f"\nvariation {tag} {name} {{\n{rules}\n}} {tag};\n")
+
+        return "".join(parts)
+
+    def _translate_gsub(self, fea):
+        masked = _blank_comments_and_strings(fea)
+        out = []
+        pos = 0
+        while m := _feature_start_re.search(masked, pos):
+            tag = m.group(1)
+            if (close := _match_block(masked, m.end())) is None:
+                break
+            tail = re.match(rf"\s*{tag}\s*;", masked[close + 1 :])
+            end = close + 1 + (tail.end() if tail else 0)
+            masked_body = masked[m.end() : close]
+            if tail is None or not _condition_re.search(masked_body):
+                out.append(fea[pos:end])
+            else:
+                out.append(fea[pos : m.start()])
+                out.append(
+                    self._translate_feature(
+                        fea[m.end() : close],
+                        masked_body,
+                        tag,
+                        use_extension=" useExtension" if m.group(2) else "",
+                    )
+                )
+            pos = end
+        out.append(fea[pos:])
+        return "".join(out)

--- a/tests/builder/variable_features_test.py
+++ b/tests/builder/variable_features_test.py
@@ -1,0 +1,776 @@
+#
+# Copyright 2026 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+
+import pytest
+
+from glyphsLib import classes, to_ufos
+from glyphsLib.builder.variable_features import VariableFeatureConverter
+
+# tag -> (minimum, default, maximum), in design space
+AXES = {
+    "wght": (100, 400, 1000),
+    "wdth": (40, 100, 100),
+    "opsz": (8, 12, 28),
+    "MSHQ": (0, 10, 100),
+    "SPAC": (-100, 0, 100),
+    "KASH": (0, 0, 100),
+}
+
+
+def make_font(axes=("wght",), masters=None, axis_locations=None, axis_mappings=None):
+    if masters is None:
+        # a master at every axis default, then one at each axis extreme
+        defaults = tuple(AXES[tag][1] for tag in axes)
+        positions = [defaults]
+        for i, tag in enumerate(axes):
+            minimum, _, maximum = AXES[tag]
+            positions += [
+                defaults[:i] + (value,) + defaults[i + 1 :]
+                for value in (minimum, maximum)
+            ]
+        masters = list(dict.fromkeys(positions))
+    font = classes.GSFont()
+    font.axes = [classes.GSAxis(name=tag, tag=tag) for tag in axes]
+    for i, pos in enumerate(masters):
+        master = classes.GSFontMaster()
+        master.axes = list(pos)
+        if axis_locations:
+            master.customParameters["Axis Location"] = [
+                {"Axis": tag, "Location": loc}
+                for tag, loc in zip(axes, axis_locations[i])
+            ]
+        font.masters.append(master)
+    if axis_mappings:
+        font.customParameters["Axis Mappings"] = axis_mappings
+    return font
+
+
+@pytest.fixture
+def mapped_font():
+    # wght design 100..1000 mapped to user 400..900
+    return make_font(masters=((100,), (1000,)), axis_locations=((400,), (900,)))
+
+
+def convert(fea, axes=("wght",), font=None):
+    if font is None:
+        font = make_font(axes)
+    return VariableFeatureConverter(font).convert(fea)
+
+
+@pytest.mark.parametrize(
+    "fea, axes, expected",
+    [
+        (
+            "feature cpsp { pos @Uppercase 10 (wdth:80) 20; } cpsp;",
+            ("wdth",),
+            "feature cpsp { pos @Uppercase (wdth=100:10 wdth=80.0:20); } cpsp;",
+        ),
+        # "There can be multiple alternative values and axes"
+        (
+            "feature cpsp { pos @Uppercase 10 (wdth:80) 20 (wdth:40 opsz:28) 30; }"
+            " cpsp;",
+            ("wdth", "opsz"),
+            "feature cpsp { pos @Uppercase (wdth=100,opsz=12:10 wdth=80.0:20"
+            " wdth=40.0,opsz=28.0:30); } cpsp;",
+        ),
+        # The handbook’s tab-indented four-value example.
+        (
+            dedent("""\
+                feature test {
+                pos @Digit colon' <10 50 20 0
+                \t(wdth:80) 30 40 60 0
+                \t(wdth:40 opsz:28) 5 10 10 0> @Digit;
+                } test;"""),
+            ("wdth", "opsz"),
+            "feature test {\n"
+            "pos @Digit colon' <(wdth=100,opsz=12:10 wdth=80.0:30"
+            " wdth=40.0,opsz=28.0:5) (wdth=100,opsz=12:50 wdth=80.0:40"
+            " wdth=40.0,opsz=28.0:10) (wdth=100,opsz=12:20 wdth=80.0:60"
+            " wdth=40.0,opsz=28.0:10) 0> @Digit;\n"
+            "} test;",
+        ),
+        # A component equal across all masters stays a plain number.
+        (
+            "feature kern { pos a b <10 0 5 0 (wght:900) 20 10 5 2>; } kern;",
+            ("wght",),
+            "feature kern { pos a b <(wght=400:10 wght=900.0:20)"
+            " (wght=400:0 wght=900.0:10) 5 (wght=400:0 wght=900.0:2)>; } kern;",
+        ),
+        (
+            "feature cpsp { pos a 10 (wdth:80) 20.5; } cpsp;",
+            ("wdth",),
+            "feature cpsp { pos a (wdth=100:10 wdth=80.0:21); } cpsp;",
+        ),
+        # Undocumented, but accepted by Glyphs.
+        (
+            "feature kern { pos a b -10 (MSHQ:100, SPAC:50) -30; } kern;",
+            ("MSHQ", "SPAC"),
+            "feature kern { pos a b (MSHQ=10,SPAC=0:-10 MSHQ=100.0,SPAC=50.0:-30); }"
+            " kern;",
+        ),
+        # An unbounded side becomes the axis maximum.
+        (
+            "feature rlig {\ncondition 127 < wght;\nsub a by b;\n} rlig;",
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 127.0 1000.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # An unbounded side becomes the axis minimum.
+        (
+            "feature rlig { condition wght < 900; sub a by b; } rlig;",
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 100.0 900.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        (
+            "feature rlig { condition 600 < wght < 900; sub a by b; } rlig;",
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 600.0 900.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # Comma is AND: both ranges in one condition set.
+        (
+            dedent("""\
+                feature rlig {
+                condition 600 < wght < 900, 70 < wdth < 90;
+                sub a by b;
+                } rlig;"""),
+            ("wght", "wdth"),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wdth 70.0 90.0;
+                    wght 600.0 900.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # The tutorial’s OR: identical rules under two conditions
+        (
+            dedent("""\
+                feature rlig {
+                condition 127 < wght;
+                sub a by b;
+                condition 105 < wght < 127, wdth < 90;
+                sub a by b;
+                } rlig;"""),
+            ("wght", "wdth"),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wdth 40.0 90.0;
+                    wght 105.0 127.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+
+                conditionset conditionset_2 {
+                    wght 127.0 1000.0;
+                } conditionset_2;
+
+                variation rlig conditionset_2 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # useExtension is kept on the feature block, not the variation blocks.
+        (
+            dedent("""\
+                feature kern useExtension {
+                pos a b -10;
+                condition 600 < wght;
+                pos a b 10 (wght:80) 20;
+                } kern;"""),
+            ("wght",),
+            dedent("""\
+                feature kern useExtension {
+                pos a b -10;
+                } kern;
+
+                conditionset conditionset_1 {
+                    wght 600.0 1000.0;
+                } conditionset_1;
+
+                variation kern conditionset_1 {
+                pos a b (wght=400:10 wght=80.0:20);
+                } kern;
+                """),
+        ),
+        # The two conditions partially overlap.
+        (
+            dedent("""\
+                feature rlig {
+                condition KASH < 54;
+                sub a by b;
+                condition 53 < KASH;
+                sub c by d;
+                } rlig;"""),
+            ("KASH",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    KASH 53.0 54.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                sub c by d;
+                } rlig;
+
+                conditionset conditionset_2 {
+                    KASH 53.0 100.0;
+                } conditionset_2;
+
+                variation rlig conditionset_2 {
+                sub c by d;
+                } rlig;
+
+                conditionset conditionset_3 {
+                    KASH 0.0 53.0;
+                } conditionset_3;
+
+                variation rlig conditionset_3 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # Decimal bounds are kept as-is.
+        (
+            dedent("""\
+                feature rclt {
+                condition 10 < MSHQ < 10.001;
+                sub a by b;
+                condition 10.001 < MSHQ < 15;
+                sub c by d;
+                } rclt;
+                """),
+            ("MSHQ",),
+            dedent("""\
+                feature rclt {
+
+                } rclt;
+
+                conditionset conditionset_1 {
+                    MSHQ 10.001 15.0;
+                } conditionset_1;
+
+                variation rclt conditionset_1 {
+                sub c by d;
+                } rclt;
+
+                conditionset conditionset_2 {
+                    MSHQ 10.0 10.001;
+                } conditionset_2;
+
+                variation rclt conditionset_2 {
+                sub a by b;
+                } rclt;
+
+                """),
+        ),
+        # Mark anchors.
+        (
+            dedent("""\
+                feature dist {
+                markClass acutecomb <anchor 0 0> @TOP;
+                pos base a <anchor 250 700 (wght:1000) 300 760> mark @TOP;
+                } dist;"""),
+            ("wght",),
+            "feature dist {\n"
+            "markClass acutecomb <anchor 0 0> @TOP;\n"
+            "pos base a <anchor (wght=400:250 wght=1000.0:300)"
+            " (wght=400:700 wght=1000.0:760)> mark @TOP;\n"
+            "} dist;",
+        ),
+        # Cursive anchors,
+        (
+            dedent("""\
+                feature dist {
+                pos cursive a <anchor 100 200 (wght:1000) 150 260> <anchor NULL>;
+                } dist;"""),
+            ("wght",),
+            "feature dist {\n"
+            "pos cursive a <anchor (wght=400:100 wght=1000.0:150)"
+            " (wght=400:200 wght=1000.0:260)> <anchor NULL>;\n"
+            "} dist;",
+        ),
+        # A component equal across all masters stays a plain number.
+        (
+            dedent("""\
+                feature dist {
+                pos cursive a <anchor 100 700 (wght:1000) 150 700> <anchor NULL>;
+                } dist;"""),
+            ("wght",),
+            "feature dist {\n"
+            "pos cursive a <anchor (wght=400:100 wght=1000.0:150) 700>"
+            " <anchor NULL>;\n"
+            "} dist;",
+        ),
+        # Variable anchors: multi-axis location.
+        (
+            "feature dist {\n"
+            "pos cursive a <anchor 100 200 (wght:1000 wdth:80) 150 260>"
+            " <anchor NULL>;\n"
+            "} dist;",
+            ("wght", "wdth"),
+            "feature dist {\n"
+            "pos cursive a <anchor (wght=400,wdth=100:100"
+            " wght=1000.0,wdth=80.0:150) (wght=400,wdth=100:200"
+            " wght=1000.0,wdth=80.0:260)> <anchor NULL>;\n"
+            "} dist;",
+        ),
+        # sub c by d is unconditional again and stays in the feature block
+        (
+            dedent("""\
+                feature rlig {
+                condition 600 < wght;
+                sub a by b;
+                condition;
+                sub c by d;
+                } rlig;"""),
+            ("wght",),
+            dedent("""\
+                feature rlig {
+                sub c by d;
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 600.0 1000.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # Non-overlapping regions, most specific first.
+        (
+            dedent("""\
+                feature rlig {
+                condition 600 < wght;
+                sub a by b;
+                condition 800 < wght;
+                sub c by d;
+                } rlig;"""),
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 800.0 1000.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                sub c by d;
+                } rlig;
+
+                conditionset conditionset_2 {
+                    wght 600.0 800.0;
+                } conditionset_2;
+
+                variation rlig conditionset_2 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+        # The pinned region precedes its container and carries the union of
+        # both regions rules.
+        (
+            dedent("""\
+                feature rlig {
+                condition 600 < wght < 600;
+                sub a by b;
+                condition 400 < wght;
+                sub c by d;
+                } rlig;"""),
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 600.0 600.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                sub c by d;
+                } rlig;
+
+                conditionset conditionset_2 {
+                    wght 400.0 1000.0;
+                } conditionset_2;
+
+                variation rlig conditionset_2 {
+                sub c by d;
+                } rlig;
+                """),
+        ),
+        # Duplicate conditions merge into one variation block, keeping source
+        # order.
+        (
+            dedent("""\
+                feature rlig {
+                condition 600 < wght;
+                sub a' b by c;
+                condition 600 < wght;
+                sub a by d;
+                } rlig;"""),
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 600.0 1000.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a' b by c;
+                sub a by d;
+                } rlig;
+                """),
+        ),
+        # Identical conditions across features reuse the condition set.
+        (
+            dedent("""\
+                feature rlig { condition 600 < wght; sub a by b; } rlig;
+                feature liga { condition 600 < wght; sub c by d; } liga;"""),
+            ("wght",),
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 600.0 1000.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+
+                feature liga {
+
+                } liga;
+
+                variation liga conditionset_1 {
+                sub c by d;
+                } liga;
+                """),
+        ),
+        # The #ifndef block is stripped.
+        (
+            dedent("""\
+                feature rlig {
+                sub a by b;
+                #ifndef VARIABLE
+                sub c by d;
+                #endif
+                sub e by f;
+                } rlig;"""),
+            ("wght",),
+            "feature rlig {\nsub a by b;\nsub e by f;\n} rlig;",
+        ),
+        # The #ifdef markers are kept as comments.
+        (
+            "feature rlig {\n#ifdef VARIABLE\nsub a by b;\n#endif\n} rlig;",
+            ("wght",),
+            "feature rlig {\n#ifdef VARIABLE\nsub a by b;\n#endif\n} rlig;",
+        ),
+        # An unterminated #ifndef runs to the feature’s end.
+        (
+            "feature rlig {\nsub a by b;\n#ifndef VARIABLE\nsub c by d;\n} rlig;",
+            ("wght",),
+            "feature rlig {\nsub a by b;\n} rlig;",
+        ),
+        # Rules after #endif but before the next condition are still
+        # conditional.
+        (
+            dedent("""\
+                feature rlig {
+                sub x by y;
+                #ifdef VARIABLE
+                condition 600 < wght;
+                sub a by b;
+                #endif
+                sub p by q;
+                } rlig;"""),
+            ("wght",),
+            dedent("""\
+                feature rlig {
+                sub x by y;
+                #ifdef VARIABLE
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 600.0 1000.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                #endif
+                sub p by q;
+                } rlig;
+                """),
+        ),
+    ],
+)
+def test_convert(fea, axes, expected):
+    assert convert(fea, axes) == expected
+
+
+@pytest.mark.parametrize(
+    "fea, expected",
+    [
+        # GPOS locations are design-space and map to user-space.
+        (
+            "feature cpsp { pos a 10 (wght:1000) 20; } cpsp;",
+            "feature cpsp { pos a (wght=400:10 wght=900.0:20); } cpsp;",
+        ),
+        # Condition bounds too: design 600 -> user 677.77777
+        (
+            "feature rlig { condition 600 < wght; sub a by b; } rlig;",
+            dedent("""\
+                feature rlig {
+
+                } rlig;
+
+                conditionset conditionset_1 {
+                    wght 677.77777 900.0;
+                } conditionset_1;
+
+                variation rlig conditionset_1 {
+                sub a by b;
+                } rlig;
+                """),
+        ),
+    ],
+)
+def test_mapped(mapped_font, fea, expected):
+    # wght design 100..1000 mapped to user 400..900
+    assert convert(fea, font=mapped_font) == expected
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # A plain feaLib value record with device tables is not Glyphs syntax.
+        "feature kern { pos a b <10 0 5 0 <device 11 -2, 12 -1> "
+        "<device NULL> <device NULL> <device NULL>>; } kern;",
+        "feature rlig {\n# condition 600 < wght;\nsub a by b;\n} rlig;",
+        "feature calt {\nsub a.condition by b;\n} calt;",
+        "feature calt {\nsub condition.alt by b;\n} calt;",
+        "feature calt {\nsub @mycondition by b;\n} calt;",
+        'feature ss01 { featureNames { name "shift 10 (wght:80) 20"; };'
+        " sub a by b; } ss01;",
+        "feature dist {\npos cursive a <anchor 100 200> <anchor NULL>;\n} dist;",
+        "feature dist {\npos cursive a <anchor NULL> <anchor NULL>;\n} dist;",
+        dedent("""\
+            feature dist {
+            pos cursive a <anchor 100 200 contourpoint 5> <anchor NULL>;
+            } dist;"""),
+        # (wght=80) is not Glyphs syntax, it does not trigger conversion alone
+        "feature kern { pos a b <10 0 5 0 (wght=80) 20 10 5 2>; } kern;",
+        # Already feaLib variable syntax.
+        "feature test { pos a b (wght=400:10 wght=900:20); } test;",
+    ],
+)
+def test_untouched(src):
+    assert convert(src) == src
+
+
+def test_idempotent():
+    src = dedent("""\
+        feature cpsp { pos a 10 (wght:900) 20; } cpsp;
+        feature rlig { condition 600 < wght; sub a by b; } rlig;""")
+    once = convert(src)
+    assert convert(once) == once
+
+
+@pytest.mark.parametrize(
+    "fea, axes, match",
+    [
+        # Glyphs: "Condition for axis wght already specified"
+        (
+            "feature rlig { condition 100 < wght, wght < 700; sub a by b; } rlig;",
+            ("wght",),
+            "already specified",
+        ),
+        (
+            dedent("""\
+                feature rlig {
+                condition 600 < wght < 900 70 < wdth < 90;
+                sub a by b;
+                } rlig;"""),
+            ("wght", "wdth"),
+            "invalid condition axis range",
+        ),
+        (
+            dedent("""\
+                feature rlig {
+                lookup L {
+                condition 600 < wght;
+                sub a by b;
+                } L;
+                } rlig;"""),
+            ("wght",),
+            "lookup",
+        ),
+        (
+            "condition 600 < wght;\nsub a by b;",
+            ("wght",),
+            "outside feature blocks",
+        ),
+        (
+            "feature rlig { condition 600 < opsz; sub a by b; } rlig;",
+            ("wght",),
+            "unknown axis",
+        ),
+        (
+            "feature kern { pos a b <10 0 5 0 (wght:80) 30 40 60>; } kern;",
+            ("wght", "opsz"),
+            "value record",
+        ),
+        (
+            "feature kern { pos a b <10 0 5 0 (wght:80) 1 2 (opsz:28) 4>; } kern;",
+            ("wght", "opsz"),
+            "value record",
+        ),
+        (
+            dedent("""\
+                feature kern { pos a b <10 0 5 0 (wght=80) 20 10 5 2>; } kern;
+                feature cpsp { pos a 10 (wght:900) 20; } cpsp;"""),
+            ("wght",),
+            "value record",
+        ),
+        (
+            dedent("""\
+                feature dist {
+                pos cursive a <anchor 100 200 (wght:1000) 150> <anchor NULL>;
+                } dist;"""),
+            ("wght",),
+            "anchor",
+        ),
+    ],
+)
+def test_invalid_raises(fea, axes, match):
+    with pytest.raises(ValueError, match=match):
+        convert(fea, axes)
+
+
+def test_inverted_range_warns_and_drops_rules(caplog):
+    with caplog.at_level("WARNING"):
+        out = convert("feature rlig { condition 900 < wght < 600; sub a by b; } rlig;")
+    assert out == "feature rlig {\n\n} rlig;\n"
+    assert "can never match" in caplog.text
+
+
+def test_axis_info_identity():
+    converter = VariableFeatureConverter(make_font())
+    (axis,) = converter.axes.values()
+    assert (axis.minimum, axis.default, axis.maximum) == (100, 400, 1000)
+    assert not axis.map
+
+
+def test_axis_info_axis_location(mapped_font):
+    converter = VariableFeatureConverter(mapped_font)
+    axis = converter.axes["wght"]
+    assert (axis.minimum, axis.default, axis.maximum) == (400, 400, 900)
+    assert axis.map == [(400, 100), (900, 1000)]
+
+
+def test_axis_info_axis_mappings():
+    converter = VariableFeatureConverter(
+        make_font(
+            masters=((100,), (1000,)), axis_mappings={"wght": {400: 100, 900: 1000}}
+        )
+    )
+    axis = converter.axes["wght"]
+    assert (axis.minimum, axis.default, axis.maximum) == (400, 400, 900)
+    assert axis.map == [(400, 100), (900, 1000)]
+
+
+def test_to_ufos_converts_condition_with_axis_location(mapped_font, ufo_module):
+    mapped_font.features.append(
+        classes.GSFeature("rlig", "condition 600 < wght;\nsub a by b;")
+    )
+    ufo = to_ufos(mapped_font, ufo_module=ufo_module)[0]
+    text = ufo.features.text
+    # design-space 600 mapped through Axis Location to user-space 677.77777
+    assert "wght 677.77777 900.0" in text
+    assert "variation rlig conditionset_1" in text
+
+
+def test_to_ufos_plain_features_untouched(ufo_module):
+    font = make_font()
+    font.features.append(classes.GSFeature("liga", "sub a by b;"))
+    ufo = to_ufos(font, ufo_module=ufo_module)[0]
+    assert "sub a by b;" in ufo.features.text
+    assert "conditionset" not in ufo.features.text


### PR DESCRIPTION
Convert from Glyphs-specific conditional features and variable GPOS to the corresponding feaLib syntax:
https://handbook.glyphsapp.com/layout/conditional-feature-code/ https://handbook.glyphsapp.com/layout/variable-gpos/

Feature code already in feaLib syntax is kept unchanged.

The #ifndef VARIABLE blocks are dropped. We don’t have a way to tell if the font is going to be built as variable or static font, so we assume variable build.