### PR TITLE
Support Glyphs 3 slant transforms

### DIFF
--- a/Lib/glyphsLib/builder/smart_components.py
+++ b/Lib/glyphsLib/builder/smart_components.py
@@ -202,12 +202,13 @@ def instantiate_smart_component(self, layer, component, pen):
 
     # Don't forget that the GSComponent might also be transformed, so
     # we need to apply that transformation to the new layer as well
-    if component.transform:
+    transform = component._transformMatrix()
+    if transform:
         # We must reverse path direction for flipped components
         # https://github.com/googlefonts/glyphsLib/issues/882
-        should_reverse = component.transform.determinant() < 0
+        should_reverse = transform.determinant() < 0
         for p in new_layer.paths:
-            p.applyTransform(component.transform)
+            p.applyTransform(transform)
             if should_reverse:
                 p.reverse()
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -25,6 +25,7 @@ from enum import IntEnum
 from io import StringIO
 
 # renamed to avoid shadowing glyphsLib.types.Transform imported further below
+from fontTools.misc.bezierTools import solveQuadratic
 from fontTools.misc.transform import Identity, Transform as Affine
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import (
@@ -291,6 +292,118 @@ def transformStructToScaleAndRotation(transform):
         _R += 360
 
     return _sX, _sY, _R
+
+
+# Anything smaller than this is float noise, not a meaningful transform value.
+_TRANSFORM_EPSILON = 1e-12
+
+
+def composeGlyphs3Transform(position, scale, rotation, slant):
+    """Combine the Glyphs 3 transform fields into an affine matrix.
+
+    Points are scaled first, then rotated, then slanted, then translated, which
+    is the order Glyphs.app uses. `rotation` and both components of `slant` are
+    in degrees.
+    """
+    if not rotation and not slant[0] and not slant[1]:
+        # Shortcut for the overwhelmingly common case, and not only for speed:
+        # it keeps the numbers exactly as the file spelled them, so a component
+        # placed at an integer offset does not turn its anchors into floats on
+        # the way to the UFO.
+        return Transform(scale[0], 0, 0, scale[1], position[0], position[1])
+    return Transform(
+        *Affine()
+        .translate(position[0], position[1])
+        .skew(math.radians(slant[0]), math.radians(slant[1]))
+        .rotate(math.radians(rotation))
+        .scale(scale[0], scale[1])
+    )
+
+
+def _linearPartClose(t1, t2, epsilon=1e-9):
+    magnitude = max(1.0, max(abs(v) for v in t2[:4]))
+    return all(abs(v1 - v2) <= epsilon * magnitude for v1, v2 in zip(t1[:4], t2[:4]))
+
+
+def _snapToZero(value, epsilon=1e-9):
+    return 0.0 if abs(value) < epsilon else value
+
+
+def decomposeGlyphs3Transform(transform):
+    """Split an affine matrix into Glyphs 3 transform fields.
+
+    The inverse of :func:`composeGlyphs3Transform`; returns
+    ``(position, scale, rotation, slant)``, or None for a matrix that cannot be
+    expressed that way (a singular one, essentially).
+
+    Only needed when writing a format 3 file, which has no raw matrix key for
+    components. Reading format 3 goes the other way, and format 2 stores the
+    matrix as-is.
+    """
+    # Read the matrix column-vector style, translation peeled off:
+    #     M = [[a, b], [d, e]]  with a=xx, b=yx, d=xy, e=yy
+    a, d, b, e = transform[0], transform[1], transform[2], transform[3]
+
+    # M is expressible as K @ R @ S -- with K = [[1, kx], [ky, 1]],
+    # kx = tan(slantX), ky = tan(slantY) -- exactly when the columns of
+    # K^-1 @ M are orthogonal, i.e. when (kx, ky) lies on the conic
+    #     de*kx^2 + ab*ky^2 - (ae+bd)*(kx+ky) + (ab+de) = 0.
+    # We need canonical points on that curve, not the whole curve.
+    linear = a * e + b * d
+    constant = a * b + d * e
+    candidates = [(kx, 0.0) for kx in solveQuadratic(d * e, -linear, constant)]
+    candidates += [(0.0, ky) for ky in solveQuadratic(a * b, -linear, constant)]
+    if abs(a) > _TRANSFORM_EPSILON and abs(e) > _TRANSFORM_EPSILON:
+        # The rotation-free solution. It is always on the conic when a and e are
+        # nonzero: substituting kx=b/e, ky=d/a leaves (ab+de) - (ab+de) = 0. It
+        # is what covers the shears the two branches above cannot reach -- a
+        # vertical shear steeper than atan(1/2) has no slantY=0 form at all.
+        candidates.append((b / e, d / a))
+
+    best = None
+    for kx, ky in candidates:
+        detK = 1.0 - kx * ky
+        if abs(detK) < 1e-9:
+            continue
+        # N = K^-1 @ M has orthogonal columns by construction, so it is
+        # R(rotation) @ S(scale) and can be read off directly
+        n00, n01 = (a - kx * d) / detK, (b - kx * e) / detK
+        n10, n11 = (d - ky * a) / detK, (e - ky * b) / detK
+        scaleX = math.hypot(n00, n10)
+        if scaleX < _TRANSFORM_EPSILON:
+            continue
+        angle = math.atan2(n10, n00)
+        scaleY = -math.sin(angle) * n01 + math.cos(angle) * n11
+        fields = (
+            Point(transform[4], transform[5]),
+            (scaleX, scaleY),
+            math.degrees(angle),
+            (math.degrees(math.atan(kx)), math.degrees(math.atan(ky))),
+        )
+        if not _linearPartClose(composeGlyphs3Transform(*fields), transform):
+            continue
+        # prefer no vertical slant (all the Glyphs UI can express), then the
+        # gentlest shear
+        rank = (0 if abs(ky) < _TRANSFORM_EPSILON else 1, kx * kx + ky * ky)
+        if best is None or rank < best[0]:
+            best = (rank, fields)
+
+    if best is None:
+        return None
+    position, (scaleX, scaleY), rotation, slant = best[1]
+    if abs(abs(rotation) - 180.0) < 1e-9 and scaleY < 0:
+        # A mirror reads (and diffs) better as scale=(-1,1) than as angle=180
+        # scale=(1,-1) -- same matrix, same one negative scale, but no angle
+        # key at all. Only mirrors: a real 180 degree rotation has a positive
+        # scaleY here, and folding that one would just make both scales
+        # negative for nothing.
+        rotation, scaleX, scaleY = 0.0, -scaleX, -scaleY
+    return (
+        position,
+        (scaleX, scaleY),
+        _snapToZero(rotation),
+        (_snapToZero(slant[0]), _snapToZero(slant[1])),
+    )
 
 
 class GSApplication:
@@ -2586,13 +2699,189 @@ class segment(list):
         return min(xvalues), min(yvalues), max(xvalues), max(yvalues)
 
 
-class GSComponent(GSBase):
+def _asPair(value, singleY=None):
+    """Normalize a scale/slant value to a pair.
+
+    A lone number means both components for scale, but only the x component for
+    slant -- a single slant value is an italic angle, not a diagonal one. The
+    numbers are passed through as they came, ints included: a component written
+    with whole-number values should not gain a decimal point on a round trip.
+    """
+    if isinstance(value, (int, float)):
+        return (value, value if singleY is None else singleY)
+    if len(value) == 2:
+        return (value[0], value[1])
+    raise ValueError(value)
+
+
+class _GSTransformable(GSBase):
+    """Base for objects carrying a Glyphs 3 style transform.
+
+    Glyphs 3 stores a component transform as separate `pos`, `scale`, `angle`
+    and `slant` values; Glyphs 2 stores a raw matrix. We keep whichever the
+    source used, and convert only in the direction that is lossless.
+
+    A field-born object -- parsed from format 3, or built through the
+    `position`/`scale`/`rotation`/`slant` properties -- keeps those fields
+    authoritative and caches their composed matrix, so the numbers a user
+    typed round-trip verbatim and a nonzero vertical slant survives (no
+    skewX-only decomposition could regenerate it).
+    A matrix-born object -- parsed from format 2, converted from UFO, or handed
+    a `transform` -- keeps the matrix, and decomposes only where it has to: on
+    the way out to format 3, which has no matrix key.
+
+    The public `transform` property is a tuple, matching Glyphs.app. Internal
+    code may use `_transformMatrix()` when it consumes the matrix immediately,
+    but must not expose that mutable backing object.
+    """
+
+    _parent = None
+
+    def _initTransform(self):
+        self._position = Point(0, 0)
+        self._scale = (1, 1)
+        self._rotation = 0.0
+        self._slant = (0, 0)
+        # None means the fields above are the source of truth
+        self._transform = None
+        # The default fields already describe this identity matrix. Field
+        # setters invalidate it; the first matrix consumer composes it again.
+        self._composedTransform = Transform(1, 0, 0, 1, 0, 0)
+
+    @property
+    def parent(self):
+        return self._parent
+
+    def _transformFields(self):
+        """The (position, scale, rotation, slant) view of this transform."""
+        if self._transform is None:
+            return self._position, self._scale, self._rotation, self._slant
+        decomposed = decomposeGlyphs3Transform(self._transform)
+        if decomposed is None:
+            # A singular matrix has no such decomposition -- a collapsed or
+            # empty shape. Fall back to the legacy approximation, which drops
+            # the shear and is what this did for every matrix before slant
+            # existed, or to plain column lengths where even that divides by
+            # zero (it scales the angle by sX/sY).
+            matrix = self._transform
+            if math.hypot(matrix[2], matrix[3]):
+                scaleX, scaleY, rotation = transformStructToScaleAndRotation(
+                    matrix.value
+                )
+            else:
+                scaleX, scaleY, rotation = math.hypot(matrix[0], matrix[1]), 0.0, 0.0
+            decomposed = (
+                Point(matrix[4], matrix[5]),
+                (scaleX, scaleY),
+                rotation,
+                (0.0, 0.0),
+            )
+        return decomposed
+
+    def _switchToFields(self):
+        """Make the fields the source of truth, decomposing a stored matrix."""
+        if self._transform is not None:
+            (
+                self._position,
+                self._scale,
+                self._rotation,
+                self._slant,
+            ) = self._transformFields()
+            self._transform = None
+
+    # .transform
+    def _invalidateTransformCache(self):
+        # Glyphs 3 parsing assigns pos, scale, angle and slant one at a time.
+        # Rebuilding the matrix here would compose several partial transforms,
+        # or require parser-specific lifecycle hooks to batch those updates.
+        # Leave it dirty instead: the first matrix consumer composes it once,
+        # and later consumers reuse that result.
+        self._composedTransform = None
+
+    def _transformMatrix(self):
+        """The raw matrix for internal consumers that will not mutate it."""
+        if self._transform is not None:
+            return self._transform
+        if self._composedTransform is None:
+            self._composedTransform = composeGlyphs3Transform(
+                self._position, self._scale, self._rotation, self._slant
+            )
+        return self._composedTransform
+
+    @property
+    def transform(self):
+        return tuple(self._transformMatrix())
+
+    @transform.setter
+    def transform(self, value):
+        # Store a value copy: Glyphs.app's getter returns a tuple, so assigning
+        # a complete transform never exposes mutable backing storage.
+        self._transform = Transform(*value)
+
+    # .position
+    @property
+    def position(self):
+        if self._transform is not None:
+            return Point(self._transform[4], self._transform[5])
+        # Match the matrix-born and Glyphs.app value semantics: mutating the
+        # returned Point does not mutate the component behind the property's
+        # back (and therefore cannot make the composed-matrix cache stale).
+        return Point(self._position[0], self._position[1])
+
+    @position.setter
+    def position(self, value):
+        # Translation is independent of the linear part, so this is exact on a
+        # matrix-born object too -- no reason to decompose for it.
+        if self._transform is not None:
+            self._transform[4] = value[0]
+            self._transform[5] = value[1]
+        else:
+            self._position = Point(value[0], value[1])
+            self._invalidateTransformCache()
+
+    # .scale
+    @property
+    def scale(self):
+        return self._transformFields()[1]
+
+    @scale.setter
+    def scale(self, value):
+        self._switchToFields()
+        self._scale = _asPair(value)
+        self._invalidateTransformCache()
+
+    # .rotation
+    @property
+    def rotation(self):
+        return self._transformFields()[2]
+
+    @rotation.setter
+    def rotation(self, value):
+        self._switchToFields()
+        self._rotation = float(value)
+        self._invalidateTransformCache()
+
+    # .slant
+    @property
+    def slant(self):
+        return self._transformFields()[3]
+
+    @slant.setter
+    def slant(self, value):
+        self._switchToFields()
+        self._slant = _asPair(value, singleY=0.0)
+        self._invalidateTransformCache()
+
+
+class GSComponent(_GSTransformable):
     def _serialize_to_plist(self, writer):
         # NOTE: The fields should come in alphabetical order.
         writer.writeObjectKeyValue(self, "alignment", "if_true")
         writer.writeObjectKeyValue(self, "anchor", "if_true")
         if writer.format_version > 2:
-            writer.writeObjectKeyValue(self, "rotation", keyName="angle", default=0)
+            position, scale, rotation, slant = self._transformFields()
+            if rotation != 0:
+                writer.writeKeyValue("angle", rotation)
             if self.attributes:
                 writer.writeObjectKeyValue(self, "attributes", keyName="attr")
         writer.writeObjectKeyValue(self, "locked", "if_true")
@@ -2601,22 +2890,23 @@ class GSComponent(GSBase):
         if self.smartComponentValues:
             writer.writeKeyValue("piece", self.smartComponentValues)
         if writer.format_version > 2:
-            writer.writeObjectKeyValue(
-                self, "position", keyName="pos", default=Point(0, 0)
-            )
+            if position != Point(0, 0):
+                writer.writeKeyValue("pos", position)
             writer.writeObjectKeyValue(self, "name", keyName="ref")
-            if self.scale != (1, 1):
-                writer.writeKeyValue("scale", Point(list(self.scale)))
+            if tuple(scale) != (1, 1):
+                writer.writeKeyValue("scale", Point(*scale))
+            if tuple(slant) != (0, 0):
+                writer.writeKeyValue("slant", Point(*slant))
         if writer.format_version == 2:
-            writer.writeObjectKeyValue(
-                self, "transform", self.transform != Transform(1, 0, 0, 1, 0, 0)
-            )
+            transform = self._transformMatrix()
+            if transform != Transform(1, 0, 0, 1, 0, 0):
+                writer.writeKeyValue("transform", transform)
 
     _defaultsForName = {"transform": Transform(1, 0, 0, 1, 0, 0)}
-    _parent = None
 
     # TODO: glyph arg is required
     def __init__(self, glyph="", offset=(0, 0), scale=(1, 1), transform=None):
+        self._initTransform()
         self.alignment = 0
         self.anchor = ""
         self.locked = False
@@ -2629,84 +2919,29 @@ class GSComponent(GSBase):
 
         self.smartComponentValues = {}
 
-        if transform is None:
-            if scale != (1, 1) or offset != (0, 0):
-                xx, yy = scale
-                dx, dy = offset
-                self.transform = Transform(xx, 0, 0, yy, dx, dy)
-            else:
-                self.transform = copy.deepcopy(self._defaultsForName["transform"])
-        else:
+        if transform is not None:
             self.transform = transform
+        else:
+            if tuple(scale) != (1, 1):
+                self.scale = scale
+            if tuple(offset) != (0, 0):
+                self.position = Point(offset[0], offset[1])
 
     def clone(self):
-        return GSComponent(self.name, transform=copy.deepcopy(self.transform))
+        component = GSComponent(self.name)
+        component._position = copy.deepcopy(self._position)
+        component._scale = self._scale
+        component._rotation = self._rotation
+        component._slant = self._slant
+        component._transform = copy.deepcopy(self._transform)
+        component._composedTransform = copy.deepcopy(self._composedTransform)
+        return component
 
     def __repr__(self):
+        position = self.position
         return '<GSComponent "{}" x={:.1f} y={:.1f}>'.format(
-            self.name, self.transform[4], self.transform[5]
+            self.name, position[0], position[1]
         )
-
-    @property
-    def parent(self):
-        return self._parent
-
-    # .position
-    @property
-    def position(self):
-        return Point(self.transform[4], self.transform[5])
-
-    @position.setter
-    def position(self, value):
-        self.transform[4] = value[0]
-        self.transform[5] = value[1]
-
-    # .scale
-    @property
-    def scale(self):
-        self._sX, self._sY, self._R = transformStructToScaleAndRotation(
-            self.transform.value
-        )
-        return self._sX, self._sY
-
-    @scale.setter
-    def scale(self, value):
-        self._sX, self._sY, self._R = transformStructToScaleAndRotation(
-            self.transform.value
-        )
-        if type(value) in [int, float]:
-            self._sX = value
-            self._sY = value
-        elif type(value) in [tuple, list] and len(value) == 2:
-            self._sX, self._sY = value
-        else:
-            raise ValueError
-        self.updateAffineTransform()
-
-    # .rotation
-    @property
-    def rotation(self):
-        self._sX, self._sY, self._R = transformStructToScaleAndRotation(
-            self.transform.value
-        )
-        return self._R
-
-    @rotation.setter
-    def rotation(self, value):
-        self._sX, self._sY, self._R = transformStructToScaleAndRotation(
-            self.transform.value
-        )
-        self._R = value
-        self.updateAffineTransform()
-
-    def updateAffineTransform(self):
-        affine = (
-            Affine()
-            .translate(self.transform[4], self.transform[5])
-            .rotate(math.radians(self._R))
-            .scale(self._sX, self._sY)
-        )
-        self.transform = Transform(*affine)
 
     @property
     def componentName(self):
@@ -2774,6 +3009,7 @@ GSComponent._add_parsers(
         {"plist_name": "pos", "object_name": "position", "converter": Point},
         {"plist_name": "ref", "object_name": "name"},
         {"plist_name": "locked", "converter": bool},
+        {"plist_name": "slant", "converter": Point},
     ]
 )
 
@@ -3510,37 +3746,41 @@ GSInstance._add_parsers(
 )
 
 
-class GSBackgroundImage(GSBase):
+class GSBackgroundImage(_GSTransformable):
     def _serialize_to_plist(self, writer):
         writer.writeObjectKeyValue(self, "_alpha", keyName="alpha", default=50)
         if writer.format_version > 2:
-            writer.writeObjectKeyValue(self, "rotation", keyName="angle", default=0)
+            position, scale, rotation, slant = self._transformFields()
+            if rotation != 0:
+                writer.writeKeyValue("angle", rotation)
             writer.writeObjectKeyValue(self, "crop", default=Rect())
         else:
             writer.writeObjectKeyValue(self, "crop")
         writer.writeObjectKeyValue(self, "imagePath")
         writer.writeObjectKeyValue(self, "locked", "if_true")
         if writer.format_version > 2:
-            if self.position != Point(0, 0):
-                writer.writeObjectKeyValue(self, "position", keyName="pos")
-            if self.scale != (1.0, 1.0):
-                writer.writeKeyValue("scale", Point(list(self.scale)))
+            if position != Point(0, 0):
+                writer.writeKeyValue("pos", position)
+            if tuple(scale) != (1.0, 1.0):
+                writer.writeKeyValue("scale", Point(*scale))
+            # Background images take a slant key just like components do:
+            # Glyphs 3.4.1 reads one, applies it to the image, and writes it
+            # back unchanged.
+            if tuple(slant) != (0, 0):
+                writer.writeKeyValue("slant", Point(*slant))
         else:
-            writer.writeObjectKeyValue(
-                self, "transform", default=Transform(1, 0, 0, 1, 0, 0)
-            )
+            transform = self._transformMatrix()
+            if transform != Transform(1, 0, 0, 1, 0, 0):
+                writer.writeKeyValue("transform", transform)
 
     _defaultsForName = {"alpha": 50, "transform": Transform(1, 0, 0, 1, 0, 0)}
 
     def __init__(self, path=None):
-        self._R = 0.0
-        self._sX = 1.0
-        self._sY = 1.0
+        self._initTransform()
         self.alpha = self._defaultsForName["alpha"]
         self.crop = Rect()
         self.imagePath = path
         self.locked = False
-        self.transform = copy.deepcopy(self._defaultsForName["transform"])
 
     def __repr__(self):
         return "<GSBackgroundImage '%s'>" % self.imagePath
@@ -3562,42 +3802,6 @@ class GSBackgroundImage(GSBase):
         # else:
         self.imagePath = value
 
-    # .position
-    @property
-    def position(self):
-        return Point(self.transform[4], self.transform[5])
-
-    @position.setter
-    def position(self, value):
-        self.transform[4] = value[0]
-        self.transform[5] = value[1]
-
-    # .scale
-    @property
-    def scale(self):
-        return self._sX, self._sY
-
-    @scale.setter
-    def scale(self, value):
-        if type(value) in [int, float]:
-            self._sX = value
-            self._sY = value
-        elif type(value) in [tuple, list] and len(value) == 2:
-            self._sX, self._sY = value
-        else:
-            raise ValueError
-        self.updateAffineTransform()
-
-    # .rotation
-    @property
-    def rotation(self):
-        return self._R
-
-    @rotation.setter
-    def rotation(self, value):
-        self._R = value
-        self.updateAffineTransform()
-
     # .alpha
     @property
     def alpha(self):
@@ -3609,15 +3813,6 @@ class GSBackgroundImage(GSBase):
             value = 50
         self._alpha = value
 
-    def updateAffineTransform(self):
-        affine = (
-            Affine()
-            .translate(self.transform[4], self.transform[5])
-            .rotate(math.radians(self._R))
-            .scale(self._sX, self._sY)
-        )
-        self.transform = Transform(*affine)
-
 
 GSBackgroundImage._add_parsers(
     [
@@ -3625,7 +3820,8 @@ GSBackgroundImage._add_parsers(
         {"plist_name": "crop", "converter": Rect},
         {"plist_name": "locked", "converter": bool},
         {"plist_name": "angle", "object_name": "rotation"},
-        {"plist_name": "pos", "object_name": "position"},
+        {"plist_name": "pos", "object_name": "position", "converter": Point},
+        {"plist_name": "slant", "converter": Point},
     ]
 )
 

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -54,7 +54,7 @@ from glyphsLib.classes import (
     CURVE,
     OFFCURVE,
 )
-from glyphsLib.types import Point, Transform, Rect
+from glyphsLib.types import Point, Rect
 
 TESTFILE_PATH = os.path.join(
     os.path.dirname(__file__), os.path.join("data", "GlyphsUnitTestSans.glyphs")
@@ -1379,7 +1379,7 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         self.assertEqual([0.0, 0.0, 489.0, 637.0], list(image.crop))
         # Default values
         self.assertEqual(50, image.alpha)
-        self.assertEqual([1, 0, 0, 1, 0, 0], image.transform.value)
+        self.assertEqual((1, 0, 0, 1, 0, 0), image.transform)
         self.assertEqual(False, image.locked)
 
         # Test documented behaviour of "alpha"
@@ -1493,8 +1493,8 @@ class GSComponentFromFileTest(GSObjectsTestCase):
         self.assertFloat(self.component.rotation)
 
     def test_transform(self):
-        self.assertIsInstance(self.component.transform, Transform)
-        self.assertEqual(len(self.component.transform.value), 6)
+        self.assertIs(type(self.component.transform), tuple)
+        self.assertEqual(len(self.component.transform), 6)
 
     def test_bounds(self):
         self.assertIsInstance(self.component.bounds, Rect)

--- a/tests/component_transform_test.py
+++ b/tests/component_transform_test.py
@@ -1,0 +1,591 @@
+"""Tests for the Glyphs 3 component transform fields, in particular `slant`.
+
+See https://github.com/googlefonts/glyphsLib/issues/1047. Provenance of the
+expected values, since they differ: SLANTED_COMPONENT is Georg Seifert's value
+from the issue thread. SLANTED_ROTATED_COMPONENT was derived from the fixture's
+fields and then read back out of Glyphs 3.4.1, which reproduces it exactly. The
+decomposition expectations in TestDecomposition.test_matches_glyphs_app and the
+background image matrix also come from Glyphs 3.4.1 directly.
+"""
+
+import math
+import random
+from unittest.mock import patch
+
+import pytest
+from fontTools.pens.recordingPen import RecordingPen
+
+import glyphsLib
+from glyphsLib import to_glyphs, to_ufos
+from glyphsLib.classes import (
+    GSBackgroundImage,
+    GSComponent,
+    GSFont,
+    GSFontMaster,
+    GSGlyph,
+    GSLayer,
+    composeGlyphs3Transform,
+    decomposeGlyphs3Transform,
+)
+from glyphsLib.types import Point, Transform
+from glyphsLib.writer import dumps
+
+# component "B" of glyph "bitcoin": pos=(5,21) scale=(1,0.94) slant=(-0.7,0)
+SLANTED_COMPONENT = (1, 0, -0.011484837902484654, 0.94, 5, 21)
+# component "A" of glyph "B" in GlyphsFileFormatv3.glyphs, which also has a
+# rotation and so pins the order of the skew and the rotation
+SLANTED_ROTATED_COMPONENT = (
+    0.8,
+    0.273616114660535,
+    -0.14106158456677195,
+    0.7517540966287268,
+    0.0,
+    0.0,
+)
+
+
+def component_transform(layer):
+    pen = RecordingPen()
+    layer.draw(pen)
+    (component,) = [args for operator, args in pen.value if operator == "addComponent"]
+    return tuple(component[1])
+
+
+def assert_close(actual, expected, tolerance=1e-12):
+    assert len(actual) == len(expected)
+    for got, want in zip(actual, expected):
+        assert abs(got - want) <= tolerance, (tuple(actual), tuple(expected))
+
+
+class TestParsing:
+    def test_slant_is_applied(self, datadir):
+        font = glyphsLib.GSFont(str(datadir.join("ComponentSlant.glyphs")))
+        layer = font.glyphs["bitcoin"].layers[0]
+        assert_close(component_transform(layer), SLANTED_COMPONENT)
+
+    def test_slant_with_rotation_is_applied(self, datadir):
+        font = glyphsLib.GSFont(str(datadir.join("GlyphsFileFormatv3.glyphs")))
+        layer = font.glyphs["B"].layers["m01"]
+        assert_close(component_transform(layer), SLANTED_ROTATED_COMPONENT)
+
+    def test_fields_are_kept_verbatim(self, datadir):
+        font = glyphsLib.GSFont(str(datadir.join("GlyphsFileFormatv3.glyphs")))
+        component = font.glyphs["B"].layers["m01"].components[0]
+        assert component.rotation == 20
+        assert component.scale == (0.8, 0.8)
+        assert component.slant == (10, 0)
+        assert component.position == Point(0, 0)
+
+    def test_field_order_does_not_matter(self):
+        """Fields used to be applied in the order the file listed them."""
+        forwards = GSComponent("A")
+        forwards.rotation = 20
+        forwards.scale = (0.8, 0.8)
+        forwards.slant = (10, 0)
+
+        backwards = GSComponent("A")
+        backwards.slant = (10, 0)
+        backwards.scale = (0.8, 0.8)
+        backwards.rotation = 20
+
+        assert_close(forwards.transform, backwards.transform)
+        assert_close(forwards.transform, SLANTED_ROTATED_COMPONENT)
+
+    def test_parser_defers_composition_until_matrix_is_read(self, datadir):
+        with patch(
+            "glyphsLib.classes.composeGlyphs3Transform",
+            wraps=composeGlyphs3Transform,
+        ) as compose:
+            font = glyphsLib.GSFont(str(datadir.join("ComponentSlant.glyphs")))
+            assert compose.call_count == 0
+
+            component = font.glyphs["bitcoin"].layers[0].components[0]
+            transform = component._transformMatrix()
+            assert compose.call_count == 1
+            assert component._transformMatrix() is transform
+            assert compose.call_count == 1
+
+        assert_close(transform, SLANTED_COMPONENT)
+
+
+class TestWriting:
+    @pytest.mark.parametrize(
+        "source, block",
+        [
+            (
+                "ComponentSlant.glyphs",
+                "{\npos = (5,21);\nref = B;\nscale = (1,0.94);\nslant = (-0.7,0);\n}",
+            ),
+            (
+                "GlyphsFileFormatv3.glyphs",
+                "{\nangle = 20;\nlocked = 1;\nref = A;\nscale = (0.8,0.8);\n"
+                "slant = (10,0);\n}",
+            ),
+        ],
+    )
+    def test_component_block_survives_round_trip(self, datadir, source, block):
+        """The fields come back verbatim, no decompose-recompose drift."""
+        path = str(datadir.join(source))
+        with open(path, encoding="utf-8") as file:
+            assert block in file.read()
+        assert block in dumps(glyphsLib.GSFont(path))
+
+    @pytest.mark.parametrize("slant", [(10, 0), (10, 8), (0, 8), (-0.7, 0)])
+    def test_slant_is_written(self, slant):
+        component = GSComponent("A")
+        component.slant = slant
+        font = _font_with_component(component)
+
+        assert f"slant = ({_number(slant[0])},{_number(slant[1])});" in dumps(font)
+
+    def test_default_slant_is_omitted(self):
+        component = GSComponent("A")
+        component.slant = (0, 0)
+        assert "slant" not in dumps(_font_with_component(component))
+
+    def test_format_2_writes_the_composed_matrix(self):
+        """Format 2 has no slant field, so the shear goes into the matrix."""
+        component = GSComponent("A")
+        component.slant = (10, 0)
+        font = _font_with_component(component, format_version=2)
+
+        assert 'transform = "{1, 0, 0.17633, 1, 0, 0}"' in dumps(font)
+
+    def test_format_2_composes_every_field_together(self):
+        """All four fields set, then written to the format with no fields."""
+        component = GSComponent("A")
+        component.position = Point(45, -12)
+        component.scale = (0.8, 0.8)
+        component.rotation = 20
+        component.slant = (10, 0)
+        font = _font_with_component(component, format_version=2)
+
+        assert 'transform = "{0.8, 0.27362, -0.14106, 0.75175, 45, -12}"' in dumps(font)
+        # and the same matrix a format 3 writer would keep in fields
+        assert_close(component.transform[:4], SLANTED_ROTATED_COMPONENT[:4])
+
+    def test_format_2_round_trips_a_field_built_component(self):
+        """Format 2 out, format 2 back in: same matrix, now matrix-born."""
+        component = GSComponent("A")
+        component.scale = (0.8, 0.8)
+        component.rotation = 20
+        component.slant = (10, 8)
+        expected = tuple(component.transform)
+
+        font = _font_with_component(component, format_version=2)
+        reloaded = glyphsLib.loads(dumps(font))
+        back = reloaded.glyphs["B"].layers[0].components[0]
+
+        # five decimals is what the format 2 matrix is written with
+        assert_close(back.transform, expected, 1e-5)
+        assert back._transform is not None
+
+
+class TestDecomposition:
+    """Only matrix-born components decompose, i.e. format 2 and UFO sources."""
+
+    @pytest.mark.parametrize(
+        "transform, expected",
+        [
+            ((1, 0, 0, 1, 0, 0), ((0, 0), (1, 1), 0, (0, 0))),
+            ((1, 0, 0, 1, 30, -12), ((30, -12), (1, 1), 0, (0, 0))),
+            ((2, 0, 0, 3, 0, 0), ((0, 0), (2, 3), 0, (0, 0))),
+            # a plain flip should not come out as a 180 degree rotation
+            ((-1, 0, 0, 1, 0, 0), ((0, 0), (-1, 1), 0, (0, 0))),
+            ((1, 0, 0, -1, 0, 0), ((0, 0), (1, -1), 0, (0, 0))),
+            # a real 180 degree rotation, however, should stay one
+            ((-1, 0, 0, -1, 0, 0), ((0, 0), (1, 1), 180, (0, 0))),
+            (SLANTED_COMPONENT, ((5, 21), (1, 0.94), 0, (-0.7, 0))),
+            (SLANTED_ROTATED_COMPONENT, ((0, 0), (0.8, 0.8), 20, (10, 0))),
+            # steeper than atan(1/2), so it has no slantY=0 solution at all
+            ((1, 1, 0, 1, 0, 0), ((0, 0), (1, 1), 0, (0, 45))),
+        ],
+    )
+    def test_known_matrices(self, transform, expected):
+        position, scale, rotation, slant = decomposeGlyphs3Transform(
+            Transform(*transform)
+        )
+        assert_close(position, expected[0], 1e-9)
+        assert_close(scale, expected[1], 1e-9)
+        assert abs(rotation - expected[2]) <= 1e-9
+        assert_close(slant, expected[3], 1e-9)
+
+    @pytest.mark.parametrize(
+        "matrix, scale, rotation, slant",
+        [
+            # Read off Glyphs 3.4.1: each matrix assigned to a component's
+            # transform, then its own scale/rotation/slant reported back.
+            ((-1, 0, 0, 1, 0, 0), (-1, 1), 0, (0, 0)),
+            ((1, 0, 0, -1, 0, 0), (1, -1), 0, (0, 0)),
+            ((-1, 0, 0, -1, 0, 0), (1, 1), 180, (0, 0)),
+            ((1, 0, 0.5, 1, 0, 0), (1, 1), 0, (26.565051177, 0)),
+            ((1, 1, 0, 1, 0, 0), (1, 1), 0, (0, 45)),
+            ((0.866025403784, 0.5, -0.5, 0.866025403784, 0, 0), (1, 1), 30, (0, 0)),
+        ],
+    )
+    def test_matches_glyphs_app(self, matrix, scale, rotation, slant):
+        _, gotScale, gotRotation, gotSlant = decomposeGlyphs3Transform(
+            Transform(*matrix)
+        )
+        assert_close(gotScale, scale, 1e-9)
+        assert abs(gotRotation - rotation) <= 1e-9
+        assert_close(gotSlant, slant, 1e-9)
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [
+            (1, 2, 2, 4, 0, 0),  # collinear columns
+            (1, 0, 0, 0, 0, 0),  # collapsed to a line
+            (0, 0, 0, 0, 5, 5),  # collapsed to a point
+        ],
+    )
+    def test_singular_matrix_is_rejected(self, matrix):
+        assert decomposeGlyphs3Transform(Transform(*matrix)) is None
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [(1, 2, 2, 4, 0, 0), (1, 0, 0, 0, 0, 0), (0, 0, 0, 0, 5, 5)],
+    )
+    def test_singular_matrix_still_reads_and_writes(self, matrix):
+        """Degenerate shapes exist in the wild; they must not crash the writer."""
+        component = GSComponent("A", transform=Transform(*matrix))
+
+        assert component.slant == (0.0, 0.0)
+        assert len(component.scale) == 2
+        assert isinstance(component.rotation, float)
+        assert component.position == Point(matrix[4], matrix[5])
+        dumps(_font_with_component(component))
+
+    def test_random_matrices_round_trip(self):
+        rng = random.Random(1047)
+        checked = 0
+        while checked < 500:
+            matrix = [rng.uniform(-3, 3) for _ in range(4)]
+            if abs(matrix[0] * matrix[3] - matrix[1] * matrix[2]) < 1e-3:
+                continue
+            checked += 1
+            transform = Transform(
+                *matrix, rng.uniform(-500, 500), rng.uniform(-500, 500)
+            )
+            fields = decomposeGlyphs3Transform(transform)
+            assert fields is not None, tuple(transform)
+            assert_close(composeGlyphs3Transform(*fields), transform, 1e-9)
+
+
+class TestModes:
+    def test_assigning_transform_switches_to_the_matrix(self):
+        component = GSComponent("A")
+        component.slant = (10, 0)
+        component.transform = Transform(2, 0, 0, 2, 5, 5)
+
+        assert component.slant == (0, 0)
+        assert component.scale == (2, 2)
+        assert component.position == Point(5, 5)
+
+    def test_public_transform_is_a_tuple_in_both_modes(self):
+        field_born = GSComponent("A")
+        field_born.slant = (10, 0)
+        matrix_born = GSComponent("A")
+        matrix_born.transform = Transform(2, 0, 0, 3, 5, 6)
+
+        assert type(field_born.transform) is tuple
+        assert type(matrix_born.transform) is tuple
+        with pytest.raises(TypeError):
+            field_born.transform[0] = -1.0
+        with pytest.raises(TypeError):
+            matrix_born.transform[0] = -1.0
+
+    def test_assigning_a_transform_copies_its_value(self):
+        matrix = Transform(2, 0, 0, 3, 5, 6)
+        component = GSComponent("A")
+        component.transform = matrix
+
+        matrix[0] = -1
+
+        assert component.transform == (2, 0, 0, 3, 5, 6)
+
+    def test_assigning_field_born_transform_does_not_share_storage(self):
+        source = GSComponent("A")
+        source.slant = (10, 0)
+        original = source.transform
+        target = GSComponent("B")
+
+        target.transform = source.transform
+        target.position = Point(5, 6)
+        target.transform = (2, *target.transform[1:])
+
+        assert target.transform == (2, *original[1:4], 5, 6)
+        assert source.transform == original
+
+    @pytest.mark.parametrize("method_name", ["draw", "drawPoints"])
+    @pytest.mark.parametrize("matrix_born", [False, True])
+    def test_drawing_does_not_expose_internal_matrix(self, method_name, matrix_born):
+        component = GSComponent("A")
+        if matrix_born:
+            component.transform = Transform(2, 0, 0, 3, 5, 6)
+        else:
+            component.slant = (10, 0)
+        original = component.transform
+        pen = RecordingPen()
+
+        getattr(component, method_name)(pen)
+
+        recorded = pen.value[0][1][1]
+        assert type(recorded) is tuple
+        with pytest.raises(TypeError):
+            recorded[0] = -1
+        assert component.transform == original
+
+    def test_assigning_a_field_decomposes_the_matrix(self):
+        component = GSComponent("A", transform=Transform(1, 1, 0, 1, 0, 0))
+        component.scale = (2, 2)
+
+        # the shear was recovered, not silently dropped
+        assert_close(component.slant, (0, 45), 1e-9)
+        assert_close(component.transform, (2, 2, 0, 2, 0, 0), 1e-9)
+
+    def test_position_does_not_disturb_a_matrix(self):
+        """Translation is independent of the linear part, so it stays exact."""
+        component = GSComponent("A", transform=Transform(0.1, 0.2, 0.3, 0.4, 0, 0))
+        component.position = Point(7, 9)
+
+        assert tuple(component.transform) == (0.1, 0.2, 0.3, 0.4, 7, 9)
+
+    def test_field_born_position_has_value_semantics(self):
+        component = GSComponent("A", offset=(5, 6))
+        position = component.position
+        position.x = 100
+
+        assert component.position == Point(5, 6)
+
+    def test_field_born_matrix_cache_tracks_field_setters(self):
+        component = GSComponent("A")
+        identity = component._transformMatrix()
+        assert component._transformMatrix() is identity
+
+        component.position = Point(5, 21)
+        positioned = component._transformMatrix()
+        assert positioned is component._transformMatrix()
+        assert positioned is not identity
+        assert tuple(positioned) == (1, 0, 0, 1, 5, 21)
+
+        component.scale = (1, 0.94)
+        component.slant = (-0.7, 0)
+        assert_close(component._transformMatrix(), SLANTED_COMPONENT)
+
+    def test_constructor_arguments_stay_in_field_mode(self):
+        component = GSComponent("A", offset=(5, 6), scale=(2, 3))
+
+        assert component.position == Point(5, 6)
+        assert component.scale == (2, 3)
+        assert component._transform is None
+
+    def test_whole_numbers_stay_whole(self):
+        """Floats here propagate all the way into UFO anchor coordinates."""
+        component = GSComponent("A")
+        component.position = Point(613, 0)
+
+        assert tuple(component.transform) == (1, 0, 0, 1, 613, 0)
+        assert all(isinstance(v, int) for v in component.transform)
+
+    def test_single_slant_value_is_horizontal(self):
+        component = GSComponent("A")
+        component.slant = 10
+        assert component.slant == (10, 0)
+
+    def test_clone_keeps_the_fields(self):
+        component = GSComponent("A")
+        component.slant = (10, 8)
+        component.rotation = 20
+        clone = component.clone()
+
+        assert clone.slant == (10, 8)
+        assert clone.rotation == 20
+        assert_close(clone.transform, component.transform)
+
+
+class TestUFORoundTrip:
+    def test_shear_reaches_the_ufo(self, datadir, ufo_module):
+        font = glyphsLib.GSFont(str(datadir.join("ComponentSlant.glyphs")))
+        source_component = font.glyphs["bitcoin"].layers[0].components[0]
+        internal_matrix = source_component._transformMatrix()
+        (ufo,) = to_ufos(font, ufo_module=ufo_module)
+        (component,) = ufo["bitcoin"].components
+
+        assert_close(component.transformation, SLANTED_COMPONENT)
+        assert component.transformation is not internal_matrix
+
+    def test_shear_comes_back_from_the_ufo(self, datadir, ufo_module):
+        font = glyphsLib.GSFont(str(datadir.join("ComponentSlant.glyphs")))
+        ufos = to_ufos(font, ufo_module=ufo_module)
+        component = to_glyphs(ufos).glyphs["bitcoin"].layers[0].components[0]
+
+        assert_close(component.position, (5, 21), 1e-9)
+        assert_close(component.scale, (1, 0.94), 1e-9)
+        assert_close(component.slant, (-0.7, 0), 1e-9)
+        assert abs(component.rotation) <= 1e-9
+
+    @pytest.mark.parametrize(
+        "transformation, expected",
+        [
+            # a plain flip, which Glyphs 2 sources are full of
+            ((-1, 0, 0, 1, 0, 0), "scale = (-1,1);"),
+            # a vertical shear too steep for a slantY=0 decomposition
+            ((1, 1, 0, 1, 0, 0), "slant = (0,45);"),
+        ],
+    )
+    def test_ufo_matrix_is_decomposed_on_write(
+        self, transformation, expected, ufo_module
+    ):
+        ufo = ufo_module.Font()
+        ufo.info.unitsPerEm = 1000
+        ufo.newGlyph("A")
+        ufo.newGlyph("B").getPen().addComponent("A", transformation)
+
+        font = to_glyphs([ufo])
+        font.format_version = 3
+        written = dumps(font)
+
+        assert expected in written
+        component = font.glyphs["B"].layers[0].components[0]
+        assert_close(component.transform, transformation, 1e-9)
+
+
+class TestBackgroundImage:
+    """Background images carry the same transform fields as components."""
+
+    def test_public_transform_is_a_tuple_in_both_modes(self):
+        field_born = GSBackgroundImage("A.jpg")
+        field_born.slant = (10, 0)
+        matrix_born = GSBackgroundImage("A.jpg")
+        matrix_born.transform = Transform(2, 0, 0, 3, 5, 6)
+
+        assert type(field_born.transform) is tuple
+        assert type(matrix_born.transform) is tuple
+        with pytest.raises(TypeError):
+            field_born.transform[0] = -1.0
+        with pytest.raises(TypeError):
+            matrix_born.transform[0] = -1.0
+
+    def test_v3_fields_survive_round_trip(self, datadir):
+        # the imagePath line in between comes back quoted, hence the two halves
+        head = "backgroundImage = {\nangle = 3;\ncrop = (41.425,42.805,503.416,507.56);"
+        tail = "pos = (61,90);\nscale = (0.529,0.8);\n}"
+        path = str(datadir.join("GlyphsFileFormatv3.glyphs"))
+        with open(path, encoding="utf-8") as file:
+            source = file.read()
+        assert head in source and tail in source
+
+        written = dumps(glyphsLib.GSFont(path))
+        assert head in written and tail in written
+
+    def test_format_2_round_trips_the_composed_matrix(self):
+        image = GSBackgroundImage("A.jpg")
+        image.position = Point(45, -12)
+        image.scale = (0.8, 0.8)
+        image.rotation = 20
+        image.slant = (10, 0)
+        expected = image.transform
+        font = _font_with_component(GSComponent("A"), format_version=2)
+        font.glyphs["B"].layers[0].backgroundImage = image
+
+        written = dumps(font)
+        assert 'transform = "{0.8, 0.27362, -0.14106, 0.75175, 45, -12}"' in written
+        back = glyphsLib.loads(written).glyphs["B"].layers[0].backgroundImage
+        assert_close(back.transform, expected, 1e-5)
+        assert back._transform is not None
+
+    def test_slant_is_written(self):
+        """Images take a slant key like components: Glyphs 3.4.1 reads, applies
+        and rewrites one (probed with a background image at slant=(20,0))."""
+        image = GSBackgroundImage("Checker.png")
+        image.rotation = 3
+        image.position = Point(100, 100)
+        image.scale = (2, 2)
+        image.slant = (20, 0)
+        font = _font_with_component(GSComponent("A"))
+        font.glyphs["B"].layers[0].backgroundImage = image
+
+        written = dumps(font)
+        assert "slant = (20,0);" in written
+        # The linear part Glyphs 3.4.1 reports for exactly these fields. Its
+        # translation reads back as 100.00000000000001 rather than 100 -- the
+        # app runs the offset through its matrix pipeline where we pass it
+        # straight through -- so that part is compared separately.
+        assert_close(
+            image.transform[:4],
+            (
+                2.0353565300177276,
+                0.10467191248588766,
+                0.622270938933654,
+                1.9972590695091477,
+            ),
+            1e-16,
+        )
+        assert tuple(image.transform)[4:] == (100, 100)
+
+    def test_assigning_transform_updates_the_fields(self):
+        """These used to keep reporting scale=(1,1), rotation=0 forever."""
+        image = GSBackgroundImage("A.jpg")
+        image.transform = Transform(2, 0, 0, 3, 10, 20)
+
+        assert image.scale == (2, 3)
+        assert image.rotation == 0
+        assert image.position == Point(10, 20)
+
+    def test_format_2_matrix_reaches_format_3_fields(self, datadir):
+        """The linear part of a format 2 matrix used to be lost on the way."""
+        font = glyphsLib.GSFont(str(datadir.join("GlyphsUnitTestSans.glyphs")))
+        image = font.glyphs["A"].layers[0].backgroundImage
+        image.transform = Transform(0.5, 0, 0, 0.5, 3, 4)
+        font.format_version = 3
+
+        written = dumps(font)
+        assert "scale = (0.5,0.5);" in written
+        assert "pos = (3,4);" in written
+
+    def test_composition_matches_components(self):
+        image = GSBackgroundImage("A.jpg")
+        image.scale = (0.8, 0.8)
+        image.rotation = 20
+        image.slant = (10, 0)
+
+        assert_close(image.transform, SLANTED_ROTATED_COMPONENT)
+
+
+def _number(value):
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _font_with_component(component, format_version=3):
+    font = GSFont()
+    font.format_version = format_version
+    font.upm = 1000
+    master = GSFontMaster()
+    master.id = "m01"
+    font.masters.append(master)
+    for name in ("A", "B"):
+        glyph = GSGlyph()
+        glyph.name = name
+        layer = GSLayer()
+        layer.layerId = master.id
+        layer.associatedMasterId = master.id
+        glyph.layers.append(layer)
+        font.glyphs.append(glyph)
+    font.glyphs["B"].layers[0].components.append(component)
+    return font
+
+
+def test_composition_order_matches_glyphs_app():
+    """The order is translate * skew * rotate * scale, verified against the app."""
+    assert_close(
+        composeGlyphs3Transform((5, 21), (1, 0.94), 0, (-0.7, 0)), SLANTED_COMPONENT
+    )
+    assert_close(
+        composeGlyphs3Transform((0, 0), (0.8, 0.8), 20, (10, 0)),
+        SLANTED_ROTATED_COMPONENT,
+    )
+    # The first case's non-uniform scale pins the skew/scale order: applying
+    # the skew before the scale would omit the 0.94 factor.
+    wrong_skew_scale_order = math.tan(math.radians(-0.7))
+    assert abs(SLANTED_COMPONENT[2] - wrong_skew_scale_order) > 1e-6

--- a/tests/data/ComponentSlant.glyphs
+++ b/tests/data/ComponentSlant.glyphs
@@ -1,0 +1,177 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+date = "2024-11-13 17:01:56 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+pos = 10;
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = B;
+lastChange = "2024-11-13 17:03:00 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,0,ls),
+(340,0,o),
+(440,87,o),
+(440,203,cs),
+(440,274,o),
+(403,330,o),
+(343,358,c),
+(425,380,o),
+(482,452,o),
+(482,535,cs),
+(482,635,o),
+(402,700,o),
+(288,700,cs),
+(185,700,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,338,l),
+(234,338,ls),
+(325,338,o),
+(384,284,o),
+(384,204,cs),
+(384,116,o),
+(311,52,o),
+(208,52,cs),
+(126,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,648,l),
+(286,648,ls),
+(374,648,o),
+(428,601,o),
+(428,531,cs),
+(428,449,o),
+(358,390,o),
+(263,390,cs),
+(185,390,l)
+);
+}
+);
+width = 508;
+}
+);
+unicode = 66;
+},
+{
+glyphname = bitcoin;
+lastChange = "2024-11-13 17:03:44 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,650,l),
+(324,800,l),
+(276,800,l),
+(249,650,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,650,l),
+(439,800,l),
+(391,800,l),
+(364,650,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,-110,l),
+(191,50,l),
+(143,50,l),
+(115,-110,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,-110,l),
+(307,50,l),
+(259,50,l),
+(230,-110,l)
+);
+},
+{
+pos = (5,21);
+ref = B;
+scale = (1,0.94);
+slant = (-0.7,0);
+}
+);
+width = 508;
+}
+);
+unicode = 8383;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/data/GlyphsFileFormatv3.diff
+++ b/tests/data/GlyphsFileFormatv3.diff
@@ -666,7 +666,7 @@
   locked = 1;
   ref = A;
   scale = (0.8,0.8);
-- slant = (10,0);
+  slant = (10,0);
   }
   );
   width = 367;

--- a/tests/pen_test.py
+++ b/tests/pen_test.py
@@ -2,7 +2,6 @@ import fontTools.pens.recordingPen
 from fontTools.pens.pointPen import PointToSegmentPen
 
 import glyphsLib.classes as classes
-from glyphsLib.types import Transform
 
 
 def test_pen_roundtrip(datadir, ufo_module):
@@ -77,10 +76,10 @@ def test_pen_recording(datadir):
         ("moveTo", ((462, 387),)),
         ("curveTo", ((458, 358), (514, 295), (450, 301))),
         ("endPath", ()),
-        ("addComponent", ("dieresis", Transform(1, 0, 0, 1, 108, -126))),
+        ("addComponent", ("dieresis", (1, 0, 0, 1, 108, -126))),
         (
             "addComponent",
-            ("adieresis", Transform(0.84572, 0.30782, -0.27362, 0.75175, 517, 308)),
+            ("adieresis", (0.84572, 0.30782, -0.27362, 0.75175, 517, 308)),
         ),
     ]
 
@@ -130,10 +129,10 @@ def test_pointpen_recording(datadir):
         ("addPoint", ((514, 295), None, False, None), {"userData": {}}),
         ("addPoint", ((450, 301), "curve", False, None), {"userData": {}}),
         ("endPath", (), {}),
-        ("addComponent", ("dieresis", Transform(1, 0, 0, 1, 108, -126)), {}),
+        ("addComponent", ("dieresis", (1, 0, 0, 1, 108, -126)), {}),
         (
             "addComponent",
-            ("adieresis", Transform(0.84572, 0.30782, -0.27362, 0.75175, 517, 308)),
+            ("adieresis", (0.84572, 0.30782, -0.27362, 0.75175, 517, 308)),
             {},
         ),
     ]

--- a/tests/smart_components_test.py
+++ b/tests/smart_components_test.py
@@ -188,7 +188,7 @@ def test_smart_component_regular(values, expected_rect, smart_font):
 def test_smart_component_regular_flipped_x(values, expected_rect, smart_font):
     # same as test_smart_component_regular but with transform that flips x
     component = smart_font.glyphs["a"].layers[0].components[0]
-    component.transform[0] = -1.0
+    component.transform = (-1.0, 0, 0, 1, 0, 0)
     for key, value in values.items():
         component.smartComponentValues[key] = value
 


### PR DESCRIPTION
Fixes #1047

Glyphs 3 does not store component transforms as a single affine matrix. It stores `pos`, `scale`, `angle` and `slant` as separate attributes. glyphsLib previously collapsed the attributes it understood into an internal six-value `Transform`, then attempted to reconstruct the split attributes when writing Glyphs 3 again.

That conversion is not lossless. Affine decomposition is non-unique, so the original scale, rotation and slant values cannot in general be recovered from the matrix.

In addition, glyphsLib did not parse `slant` at all. A slanted component was therefore emitted unsheared when building UFOs, and merely opening and saving a Glyphs 3 source through glyphsLib deleted its `slant` attribute.

This PR keeps the split attributes authoritative for objects originating in Glyphs 3 and composes their affine matrix lazily only when a matrix consumer needs it. Their original values, including nonzero vertical slant, therefore round-trip verbatim. Objects originating from Glyphs 2, UFOs or explicit `.transform` assignment instead treat the matrix form as authoritative. Decomposition into split attributes occurs only when such an object must be written as Glyphs 3, where those attributes are unavoidable.

For matrix-authoritative objects, writing the linear matrix as `M = K × R × S`, where `K` contains the two shear factors, means that removing a candidate `K` must leave a matrix whose columns are orthogonal: rotation followed by independent X/Y scaling. That condition gives a conic equation in the two shear factors.

The implementation generates horizontal-only, vertical-only and closed-form rotation-free candidates. The rotation-free candidate attributes both off-diagonal terms to slant and therefore needs no rotation. Every candidate is recomposed and checked against the original matrix to reject numerical false solutions. The implementation prefers any valid candidate with `slantY = 0`, matching what the Glyphs UI can express; otherwise it selects the valid candidate requiring the least total shear.

Singular matrices have no unique decomposition. We preserve their translation and fall back to the existing legacy scale/rotation approximation with zero slant, allowing collapsed components to remain readable and writable without crashing.

The public `transform` getter now returns a built-in six-tuple instead of glyphsLib’s mutable `Transform`, exactly matching Glyphs.app’s Python scripting API. Builders and pens consequently receive immutable values rather than internal cache storage.

Compatibility note: code that mutates the returned object in place or uses `Transform`-specific attributes must instead assign a complete transform. Normal sequence access and whole-property assignment remain supported.

`GSBackgroundImage` now uses the same transform model. This also fixes two image-related bugs: stale `scale` and `rotation` values after assigning an image transform, and a format 2 image’s linear transform disappearing when written as format 3.

I have never seen a slanted background image in the wild, so I checked this directly: Glyphs 3.4.1 reads, applies and round-trips background-image slant.

Finally, I benchmarked this on both synthetic and real sources and observed no end-to-end performance regression in the tests I ran. On a deliberately component-only 2,000-component source, parse plus `to_ufos` was about 28% faster than main for ordinary components and 20% faster for slanted components, largely because fields are recorded cheaply and matrices composed lazily.

A `to_ufos`-only torture test using 10,000 cloned dirty components makes that deferred cache fill visible in the builder timer, but moves work from parsing rather than adding it end to end. On BigShoulders, with 9,252 components across six masters, tuple-returning boundaries showed no measurable `to_ufos` regression: 1.204 seconds versus 1.223 seconds using raw cached matrices, with the apparent improvement attributable to measurement noise.

I am also working on the equivalent fontc change, which I plan to push in the coming days while working intermittently from holiday.