### PR TITLE
Expand Glyphs multiple languages syntax when building UFOs

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -34,6 +34,7 @@ from .constants import (
     INSERT_FEATURE_MARKER_COMMENT,
 )
 from .tokens import TokenExpander, PassThruExpander
+from .multi_language import expand_multi_language_statements
 from .variable_features import VariableFeatureConverter
 
 if TYPE_CHECKING:
@@ -193,6 +194,10 @@ def _to_ufo_features(  # noqa: C901
 
     full_text = "\n\n".join(filter(None, [class_str, prefix_str, fea_str])) + "\n"
     full_text = full_text if full_text.strip() else ""
+
+    # Expand Glyphs' multiple languages syntax (`language AZE CRT;`) into the
+    # one-tag-per-statement form the FEA spec allows.
+    full_text = expand_multi_language_statements(full_text)
 
     # Convert Glyphs conditional features and variable GPOS to feaLib syntax.
     if master is not None:

--- a/Lib/glyphsLib/builder/multi_language.py
+++ b/Lib/glyphsLib/builder/multi_language.py
@@ -37,12 +37,21 @@ logger = logging.getLogger(__name__)
 # Keywords the FEA spec allows after the tag of a `language` statement.
 _LANGUAGE_KEYWORDS = frozenset(("exclude_dflt", "include_dflt", "required"))
 
+# Comment | "string": blanked out before anything below is matched, so that a
+# brace, a semicolon or a keyword inside one is never taken for code.
+_skip_re = re.compile(r"#[^\n]*|\"[^\"\n]*\"")
+
 _language_re = re.compile(r"^([ \t]*)language[ \t]+([^;]+);[ \t]*$")
 # A `language` or `script` statement closes the block opened by the previous one.
 _delimiter_re = re.compile(r"^[ \t]*(?:language|script)[ \t]+[^;]+;[ \t]*$")
-_lookup_open_re = re.compile(r"^([ \t]*)lookup[ \t]+([A-Za-z_][A-Za-z0-9_.]*)[ \t]*\{")
-_class_def_re = re.compile(r"^[ \t]*@[A-Za-z0-9_.]+[ \t]*=")
-_tag_re = re.compile(r"^[A-Za-z0-9_]{1,4}$")
+# `lookup NAME [useExtension] {`, with the brace allowed on a following line.
+# A reference (`lookup NAME;`) matches neither branch and stays a plain rule.
+_lookup_def_re = re.compile(
+    r"^([ \t]*)lookup[ \t]+([A-Za-z_][A-Za-z0-9_.]*)[ \t]*"
+    r"(?:useExtension[ \t]*)?(?:\{|$)"
+)
+# Definitions that name something: emitted once, dropped when replayed.
+_definition_re = re.compile(r"^[ \t]*(?:@[A-Za-z0-9_.]+[ \t]*=|markClass[ \t(\[])")
 
 
 def expand_multi_language_statements(fea):
@@ -51,7 +60,8 @@ def expand_multi_language_statements(fea):
     The block is emitted once for the first tag and then repeated for every
     remaining one. Named lookups cannot simply be duplicated -- that would
     redefine them -- so the repeats reference the lookup defined under the
-    first tag, and glyph class definitions are likewise emitted only once::
+    first tag, and glyph class and ``markClass`` definitions are likewise
+    emitted only once::
 
         language AZE;
         lookup idotaccent {
@@ -66,21 +76,26 @@ def expand_multi_language_statements(fea):
     for feaLib to report.
     """
     lines = fea.splitlines()
+    code = [_skip_re.sub(lambda m: " " * len(m.group(0)), line) for line in lines]
     out = []
     changed = False
     i = 0
     while i < len(lines):
-        line = lines[i]
-        match = _language_re.match(line)
+        match = _language_re.match(code[i])
         tags, keywords = _split_tokens(match.group(2)) if match else (None, None)
         if not tags or len(tags) < 2:
-            out.append(line)
+            out.append(lines[i])
             i += 1
             continue
         indent = match.group(1)
-        body, i = _collect_body(lines, i + 1)
-        items = _parse_body(body)
-        out.append(_statement(indent, tags[0], keywords))
+        # Keep anything the original statement carried after the semicolon
+        # (a trailing comment); the blanking above preserves column numbers.
+        trailing = lines[i][code[i].index(";") + 1 :].strip()
+        start = i + 1
+        i = _body_end(code, start)
+        body, body_code = lines[start:i], code[start:i]
+        items = _parse_body(body, body_code)
+        out.append(_statement(indent, tags[0], keywords, trailing))
         out.extend(body)
         for tag in tags[1:]:
             out.append(_statement(indent, tag, keywords))
@@ -96,8 +111,9 @@ def expand_multi_language_statements(fea):
     return expanded
 
 
-def _statement(indent, tag, keywords):
-    return "{}language {};".format(indent, " ".join([tag] + keywords))
+def _statement(indent, tag, keywords, trailing=""):
+    statement = "{}language {};".format(indent, " ".join([tag] + keywords))
+    return f"{statement} {trailing}" if trailing else statement
 
 
 def _split_tokens(tokens):
@@ -111,7 +127,7 @@ def _split_tokens(tokens):
     for token in tokens.split():
         if token in _LANGUAGE_KEYWORDS:
             keywords.append(token)
-        elif keywords or not _tag_re.match(token):
+        elif keywords or not re.fullmatch(r"[A-Za-z0-9_]{1,4}", token):
             # A tag after a keyword, or a token that is not a tag at all.
             return None, None
         else:
@@ -119,53 +135,55 @@ def _split_tokens(tokens):
     return tags, keywords
 
 
-def _collect_body(lines, start):
-    """Collect the lines governed by a ``language`` statement.
+def _body_end(code, start):
+    """Return the index of the first line no longer governed by the statement.
 
-    That is everything up to the next ``language``/``script`` statement or the
-    end of the enclosing block, whichever comes first. Returns the lines and
-    the index of the first line not taken.
+    The body runs up to the next ``language``/``script`` statement or the end
+    of the enclosing block, whichever comes first.
     """
-    body = []
     depth = 0
     i = start
-    while i < len(lines):
-        line = lines[i]
-        if depth == 0 and _delimiter_re.match(line):
+    while i < len(code):
+        if depth == 0 and _delimiter_re.match(code[i]):
             break
-        new_depth = depth + line.count("{") - line.count("}")
+        new_depth = depth + code[i].count("{") - code[i].count("}")
         if new_depth < 0:
             # The line closes the block we are nested in (`} locl;`).
             break
-        body.append(line)
         depth = new_depth
         i += 1
-    return body, i
+    return i
 
 
-def _parse_body(body):
+def _parse_body(body, code):
     """Split the body into ``(kind, name, lines)`` items.
 
-    ``kind`` is ``lookup`` for a named lookup block, ``class`` for a glyph
-    class definition and ``line`` for anything else.
+    ``kind`` is ``lookup`` for a named lookup block, ``definition`` for a
+    glyph class or ``markClass`` definition and ``line`` for anything else.
     """
     items = []
     i = 0
     while i < len(body):
-        line = body[i]
-        match = _lookup_open_re.match(line)
+        match = _lookup_def_re.match(code[i])
         if match:
-            depth = line.count("{") - line.count("}")
-            block = [line]
-            i += 1
-            while i < len(body) and depth > 0:
-                block.append(body[i])
-                depth += body[i].count("{") - body[i].count("}")
+            start, depth, opened = i, 0, False
+            while i < len(body):
+                depth += code[i].count("{") - code[i].count("}")
+                opened = opened or depth > 0
                 i += 1
-            items.append(("lookup", match.groups(), block))
+                if opened and depth <= 0:
+                    break
+            items.append(("lookup", match.groups(), body[start:i]))
             continue
-        kind = "class" if _class_def_re.match(line) else "line"
-        items.append((kind, None, [line]))
+        if _definition_re.match(code[i]):
+            start = i
+            # A definition runs to its terminating semicolon.
+            while i < len(body) and ";" not in code[i]:
+                i += 1
+            i = min(i + 1, len(body))
+            items.append(("definition", None, body[start:i]))
+            continue
+        items.append(("line", None, [body[i]]))
         i += 1
     return items
 
@@ -173,14 +191,14 @@ def _parse_body(body):
 def _replay(items):
     """Render the body again for a repeated tag.
 
-    Lookups become references, class definitions are dropped, the rest is
-    repeated as is.
+    Lookups become references, definitions are dropped, the rest is repeated
+    as is.
     """
     out = []
     for kind, name, block in items:
         if kind == "lookup":
             indent, lookup_name = name
             out.append(f"{indent}lookup {lookup_name};")
-        elif kind != "class":
+        elif kind != "definition":
             out.extend(block)
     return out

--- a/Lib/glyphsLib/builder/multi_language.py
+++ b/Lib/glyphsLib/builder/multi_language.py
@@ -1,0 +1,186 @@
+#
+# Copyright 2026 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Expand Glyphs' multiple languages syntax into plain FEA.
+
+Glyphs lets a single ``language`` statement carry several tags and applies
+everything that follows to each of them::
+
+    language AZE CRT KAZ TAT TRK;
+    lookup idotaccent {
+        sub i by idotaccent;
+    } idotaccent;
+
+The FEA spec allows exactly one tag per statement, so feaLib rejects this with
+``Expected ';'`` at the second tag. See
+https://handbook.glyphsapp.com/layout/multiple-languages-syntax/ and
+https://github.com/googlefonts/glyphsLib/issues/1109.
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Keywords the FEA spec allows after the tag of a `language` statement.
+_LANGUAGE_KEYWORDS = frozenset(("exclude_dflt", "include_dflt", "required"))
+
+_language_re = re.compile(r"^([ \t]*)language[ \t]+([^;]+);[ \t]*$")
+# A `language` or `script` statement closes the block opened by the previous one.
+_delimiter_re = re.compile(r"^[ \t]*(?:language|script)[ \t]+[^;]+;[ \t]*$")
+_lookup_open_re = re.compile(r"^([ \t]*)lookup[ \t]+([A-Za-z_][A-Za-z0-9_.]*)[ \t]*\{")
+_class_def_re = re.compile(r"^[ \t]*@[A-Za-z0-9_.]+[ \t]*=")
+_tag_re = re.compile(r"^[A-Za-z0-9_]{1,4}$")
+
+
+def expand_multi_language_statements(fea):
+    """Rewrite multi-tag ``language`` statements as one statement per tag.
+
+    The block is emitted once for the first tag and then repeated for every
+    remaining one. Named lookups cannot simply be duplicated -- that would
+    redefine them -- so the repeats reference the lookup defined under the
+    first tag, and glyph class definitions are likewise emitted only once::
+
+        language AZE;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
+        language CRT;
+        lookup idotaccent;
+
+    Everything else (bare rules, ``lookupflag``, ...) is repeated verbatim,
+    which is what the shorthand means. A statement that is already
+    spec-compliant, or that cannot be parsed with confidence, is left alone
+    for feaLib to report.
+    """
+    lines = fea.splitlines()
+    out = []
+    changed = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        match = _language_re.match(line)
+        tags, keywords = _split_tokens(match.group(2)) if match else (None, None)
+        if not tags or len(tags) < 2:
+            out.append(line)
+            i += 1
+            continue
+        indent = match.group(1)
+        body, i = _collect_body(lines, i + 1)
+        items = _parse_body(body)
+        out.append(_statement(indent, tags[0], keywords))
+        out.extend(body)
+        for tag in tags[1:]:
+            out.append(_statement(indent, tag, keywords))
+            out.extend(_replay(items))
+        logger.debug("Expanded 'language %s;'", " ".join(tags))
+        changed = True
+
+    if not changed:
+        return fea
+    expanded = "\n".join(out)
+    if fea.endswith("\n"):
+        expanded += "\n"
+    return expanded
+
+
+def _statement(indent, tag, keywords):
+    return "{}language {};".format(indent, " ".join([tag] + keywords))
+
+
+def _split_tokens(tokens):
+    """Split a statement's contents into tags and trailing keywords.
+
+    Returns ``(None, None)`` for anything unexpected, so that the caller
+    leaves the statement alone rather than guessing at it.
+    """
+    tags = []
+    keywords = []
+    for token in tokens.split():
+        if token in _LANGUAGE_KEYWORDS:
+            keywords.append(token)
+        elif keywords or not _tag_re.match(token):
+            # A tag after a keyword, or a token that is not a tag at all.
+            return None, None
+        else:
+            tags.append(token)
+    return tags, keywords
+
+
+def _collect_body(lines, start):
+    """Collect the lines governed by a ``language`` statement.
+
+    That is everything up to the next ``language``/``script`` statement or the
+    end of the enclosing block, whichever comes first. Returns the lines and
+    the index of the first line not taken.
+    """
+    body = []
+    depth = 0
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        if depth == 0 and _delimiter_re.match(line):
+            break
+        new_depth = depth + line.count("{") - line.count("}")
+        if new_depth < 0:
+            # The line closes the block we are nested in (`} locl;`).
+            break
+        body.append(line)
+        depth = new_depth
+        i += 1
+    return body, i
+
+
+def _parse_body(body):
+    """Split the body into ``(kind, name, lines)`` items.
+
+    ``kind`` is ``lookup`` for a named lookup block, ``class`` for a glyph
+    class definition and ``line`` for anything else.
+    """
+    items = []
+    i = 0
+    while i < len(body):
+        line = body[i]
+        match = _lookup_open_re.match(line)
+        if match:
+            depth = line.count("{") - line.count("}")
+            block = [line]
+            i += 1
+            while i < len(body) and depth > 0:
+                block.append(body[i])
+                depth += body[i].count("{") - body[i].count("}")
+                i += 1
+            items.append(("lookup", match.groups(), block))
+            continue
+        kind = "class" if _class_def_re.match(line) else "line"
+        items.append((kind, None, [line]))
+        i += 1
+    return items
+
+
+def _replay(items):
+    """Render the body again for a repeated tag.
+
+    Lookups become references, class definitions are dropped, the rest is
+    repeated as is.
+    """
+    out = []
+    for kind, name, block in items:
+        if kind == "lookup":
+            indent, lookup_name = name
+            out.append(f"{indent}lookup {lookup_name};")
+        elif kind != "class":
+            out.extend(block)
+    return out

--- a/Lib/glyphsLib/builder/multi_language.py
+++ b/Lib/glyphsLib/builder/multi_language.py
@@ -32,14 +32,12 @@ https://github.com/googlefonts/glyphsLib/issues/1109.
 import logging
 import re
 
+from .variable_features import _blank_comments_and_strings
+
 logger = logging.getLogger(__name__)
 
 # Keywords the FEA spec allows after the tag of a `language` statement.
 _LANGUAGE_KEYWORDS = frozenset(("exclude_dflt", "include_dflt", "required"))
-
-# Comment | "string": blanked out before anything below is matched, so that a
-# brace, a semicolon or a keyword inside one is never taken for code.
-_skip_re = re.compile(r"#[^\n]*|\"[^\"\n]*\"")
 
 _language_re = re.compile(r"^([ \t]*)language[ \t]+([^;]+);[ \t]*$")
 # A `language` or `script` statement closes the block opened by the previous one.
@@ -52,6 +50,14 @@ _lookup_def_re = re.compile(
 )
 # Definitions that name something: emitted once, dropped when replayed.
 _definition_re = re.compile(r"^[ \t]*(?:@[A-Za-z0-9_.]+[ \t]*=|markClass[ \t(\[])")
+# An OpenType language system tag, which unlike a feature tag may be shorter
+# than four characters (`ROM`, `AZE`).
+_tag_re = re.compile(r"[A-Za-z0-9_]{1,4}")
+
+
+def _depth_delta(line):
+    """How much the line changes the brace nesting depth."""
+    return line.count("{") - line.count("}")
 
 
 def expand_multi_language_statements(fea):
@@ -76,7 +82,10 @@ def expand_multi_language_statements(fea):
     for feaLib to report.
     """
     lines = fea.splitlines()
-    code = [_skip_re.sub(lambda m: " " * len(m.group(0)), line) for line in lines]
+    # Scan a copy with comments and string literals blanked out, so that a
+    # brace, a semicolon or a keyword inside one is never taken for code. The
+    # blanking preserves column numbers, so the original lines stay usable.
+    code = _blank_comments_and_strings(fea).splitlines()
     out = []
     changed = False
     i = 0
@@ -112,7 +121,7 @@ def expand_multi_language_statements(fea):
 
 
 def _statement(indent, tag, keywords, trailing=""):
-    statement = "{}language {};".format(indent, " ".join([tag] + keywords))
+    statement = f'{indent}language {" ".join([tag] + keywords)};'
     return f"{statement} {trailing}" if trailing else statement
 
 
@@ -127,7 +136,7 @@ def _split_tokens(tokens):
     for token in tokens.split():
         if token in _LANGUAGE_KEYWORDS:
             keywords.append(token)
-        elif keywords or not re.fullmatch(r"[A-Za-z0-9_]{1,4}", token):
+        elif keywords or not _tag_re.fullmatch(token):
             # A tag after a keyword, or a token that is not a tag at all.
             return None, None
         else:
@@ -146,7 +155,7 @@ def _body_end(code, start):
     while i < len(code):
         if depth == 0 and _delimiter_re.match(code[i]):
             break
-        new_depth = depth + code[i].count("{") - code[i].count("}")
+        new_depth = depth + _depth_delta(code[i])
         if new_depth < 0:
             # The line closes the block we are nested in (`} locl;`).
             break
@@ -168,7 +177,7 @@ def _parse_body(body, code):
         if match:
             start, depth, opened = i, 0, False
             while i < len(body):
-                depth += code[i].count("{") - code[i].count("}")
+                depth += _depth_delta(code[i])
                 opened = opened or depth > 0
                 i += 1
                 if opened and depth <= 0:

--- a/tests/builder/multi_language_test.py
+++ b/tests/builder/multi_language_test.py
@@ -18,7 +18,7 @@ from textwrap import dedent
 
 from fontTools.feaLib.parser import Parser
 
-from glyphsLib import classes, to_ufos
+from glyphsLib import classes, to_glyphs, to_ufos
 from glyphsLib.builder.multi_language import expand_multi_language_statements
 
 GLYPH_NAMES = ["i", "idotaccent", "Scedilla", "Scommaaccent", "Lcommaaccent"]
@@ -111,7 +111,7 @@ def test_unparseable_statement_is_untouched():
     assert expand_multi_language_statements(original) == original
 
 
-def test_to_ufos_expands_feature_code(ufo_module):
+def make_font():
     font = classes.GSFont()
     font.masters.append(classes.GSFontMaster())
     for name in ("i", "idotaccent"):
@@ -134,8 +134,11 @@ def test_to_ufos_expands_feature_code(ufo_module):
         } idotaccent;
     """)
     font.features.append(feature)
+    return font
 
-    (ufo,) = to_ufos(font, ufo_module=ufo_module)
+
+def test_to_ufos_expands_feature_code(ufo_module):
+    (ufo,) = to_ufos(make_font(), ufo_module=ufo_module)
 
     lines = [line.strip() for line in ufo.features.text.splitlines()]
     assert "language AZE TRK;" not in lines
@@ -143,3 +146,19 @@ def test_to_ufos_expands_feature_code(ufo_module):
     assert "language TRK;" in lines
     assert lines.count("lookup idotaccent;") == 1
     Parser(io.StringIO(ufo.features.text), glyphNames=GLYPH_NAMES).parse()
+
+
+def test_expansion_does_not_round_trip(ufo_module):
+    """The expansion is one-way: the shorthand is not restored.
+
+    Going back to Glyphs yields the expanded form rather than the original
+    statement. UFO -> Glyphs -> UFO is unaffected, because the original
+    feature text is recovered from ORIGINAL_FEATURE_CODE_KEY.
+    """
+    (ufo,) = to_ufos(make_font(), ufo_module=ufo_module)
+
+    (feature,) = to_glyphs([ufo]).features
+    lines = [line.strip() for line in feature.code.splitlines()]
+    assert "language AZE TRK;" not in lines
+    assert "language AZE;" in lines
+    assert "language TRK;" in lines

--- a/tests/builder/multi_language_test.py
+++ b/tests/builder/multi_language_test.py
@@ -23,128 +23,99 @@ from glyphsLib.builder.multi_language import expand_multi_language_statements
 
 GLYPH_NAMES = ["i", "idotaccent", "Scedilla", "Scommaaccent", "Lcommaaccent"]
 
+LANGUAGE_SYSTEMS = "languagesystem DFLT dflt;\nlanguagesystem latn dflt;\n" + "".join(
+    f"languagesystem latn {tag};\n"
+    for tag in ("AZE", "CRT", "KAZ", "TAT", "TRK", "ROM", "MOL")
+)
 
-def parse(fea, glyph_names=GLYPH_NAMES):
+
+def parse(fea):
     """Parse the feature text, raising on anything feaLib does not accept."""
-    header = "languagesystem DFLT dflt;\nlanguagesystem latn dflt;\n"
-    header += "".join(
-        f"languagesystem latn {tag};\n"
-        for tag in ("AZE", "CRT", "KAZ", "TAT", "TRK", "ROM", "MOL")
-    )
-    return Parser(io.StringIO(header + fea), glyphNames=glyph_names).parse()
+    feature_file = io.StringIO(LANGUAGE_SYSTEMS + fea)
+    return Parser(feature_file, glyphNames=GLYPH_NAMES).parse()
 
 
-def expand(fea):
-    return expand_multi_language_statements(dedent(fea))
-
-
-def stripped(fea):
-    return [line.strip() for line in fea.splitlines()]
-
-
-def test_named_lookup_is_defined_once_and_referenced():
-    fea = expand("""\
-        feature locl {
-        script latn;
-
-        language AZE CRT KAZ TAT TRK;
-        lookup idotaccent {
-            sub i by idotaccent;
-        } idotaccent;
-
-        } locl;
-        """)
-
-    lines = stripped(fea)
-    # Defined under the first tag only ...
-    assert lines.count("lookup idotaccent {") == 1
-    # ... and referenced under each of the remaining four.
-    assert lines.count("lookup idotaccent;") == 4
-    for tag in ("AZE", "CRT", "KAZ", "TAT", "TRK"):
-        assert f"language {tag};" in lines
+def check(source, expected):
+    """Expand the source, assert the whole output, then parse it."""
+    fea = expand_multi_language_statements(dedent(source))
+    assert fea == dedent(expected)
     parse(fea)
 
 
 def test_bare_rules_are_repeated():
-    fea = expand("""\
+    check(
+        """\
         feature locl {
         script latn;
         language ROM MOL;
         sub Scedilla by Scommaaccent;
         } locl;
-        """)
-
-    lines = stripped(fea)
-    assert lines.count("sub Scedilla by Scommaaccent;") == 2
-    assert lines.count("language ROM;") == 1
-    assert lines.count("language MOL;") == 1
-    parse(fea)
-
-
-def test_glyph_class_is_not_redefined():
-    fea = expand("""\
+        """,
+        """\
         feature locl {
-        language ROM MOL;
-        @Cedillas = [Scedilla];
-        sub @Cedillas by Scommaaccent;
+        script latn;
+        language ROM;
+        sub Scedilla by Scommaaccent;
+        language MOL;
+        sub Scedilla by Scommaaccent;
         } locl;
-        """)
-
-    lines = stripped(fea)
-    assert lines.count("@Cedillas = [Scedilla];") == 1
-    assert lines.count("sub @Cedillas by Scommaaccent;") == 2
-    parse(fea)
+        """,
+    )
 
 
-def test_multi_line_glyph_class_is_dropped_whole():
-    fea = expand("""\
+def test_named_lookup_is_defined_once_and_referenced():
+    check(
+        """\
         feature locl {
-        language ROM MOL;
-        @Ced = [Scedilla
-                Lcommaaccent];
-        sub @Ced by Scommaaccent;
+        script latn;
+        language AZE CRT KAZ;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
         } locl;
-        """)
-
-    lines = stripped(fea)
-    assert lines.count("Lcommaaccent];") == 1
-    assert lines.count("sub @Ced by Scommaaccent;") == 2
-    parse(fea)
-
-
-def test_mark_class_is_not_redefined():
-    fea = expand("""\
-        feature test {
-        language ROM MOL;
-        markClass [Scedilla] <anchor 0 0> @MC;
-        pos base i <anchor 0 0> mark @MC;
-        } test;
-        """)
-
-    lines = stripped(fea)
-    assert lines.count("markClass [Scedilla] <anchor 0 0> @MC;") == 1
-    assert lines.count("pos base i <anchor 0 0> mark @MC;") == 2
-    parse(fea)
+        """,
+        """\
+        feature locl {
+        script latn;
+        language AZE;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
+        language CRT;
+        lookup idotaccent;
+        language KAZ;
+        lookup idotaccent;
+        } locl;
+        """,
+    )
 
 
 def test_lookup_with_use_extension_is_referenced():
-    fea = expand("""\
+    check(
+        """\
         feature locl {
         language AZE CRT;
         lookup idot useExtension {
             sub i by idotaccent;
         } idot;
         } locl;
-        """)
-
-    lines = stripped(fea)
-    assert lines.count("lookup idot useExtension {") == 1
-    assert lines.count("lookup idot;") == 1
-    parse(fea)
+        """,
+        """\
+        feature locl {
+        language AZE;
+        lookup idot useExtension {
+            sub i by idotaccent;
+        } idot;
+        language CRT;
+        lookup idot;
+        } locl;
+        """,
+    )
 
 
 def test_lookup_with_brace_on_the_next_line_is_referenced():
-    fea = expand("""\
+    check(
+        """\
         feature locl {
         language AZE CRT;
         lookup idot
@@ -152,83 +123,195 @@ def test_lookup_with_brace_on_the_next_line_is_referenced():
             sub i by idotaccent;
         } idot;
         } locl;
-        """)
+        """,
+        """\
+        feature locl {
+        language AZE;
+        lookup idot
+        {
+            sub i by idotaccent;
+        } idot;
+        language CRT;
+        lookup idot;
+        } locl;
+        """,
+    )
 
-    lines = stripped(fea)
-    assert lines.count("lookup idot") == 1
-    assert lines.count("lookup idot;") == 1
-    parse(fea)
+
+def test_glyph_class_is_not_redefined():
+    check(
+        """\
+        feature locl {
+        language ROM MOL;
+        @Cedillas = [Scedilla];
+        sub @Cedillas by Scommaaccent;
+        } locl;
+        """,
+        """\
+        feature locl {
+        language ROM;
+        @Cedillas = [Scedilla];
+        sub @Cedillas by Scommaaccent;
+        language MOL;
+        sub @Cedillas by Scommaaccent;
+        } locl;
+        """,
+    )
 
 
-def test_brace_in_a_comment_does_not_truncate_the_body():
-    """A closing brace in a comment must not end the block early.
+def test_multi_line_glyph_class_is_dropped_whole():
+    check(
+        """\
+        feature locl {
+        language ROM MOL;
+        @Ced = [Scedilla
+                Lcommaaccent];
+        sub @Ced by Scommaaccent;
+        } locl;
+        """,
+        """\
+        feature locl {
+        language ROM;
+        @Ced = [Scedilla
+                Lcommaaccent];
+        sub @Ced by Scommaaccent;
+        language MOL;
+        sub @Ced by Scommaaccent;
+        } locl;
+        """,
+    )
 
-    That would bind the rules to the last tag only, and parse cleanly while
-    doing so.
-    """
-    fea = expand("""\
+
+def test_mark_class_is_not_redefined():
+    check(
+        """\
+        feature test {
+        language ROM MOL;
+        markClass [Scedilla] <anchor 0 0> @MC;
+        pos base i <anchor 0 0> mark @MC;
+        } test;
+        """,
+        """\
+        feature test {
+        language ROM;
+        markClass [Scedilla] <anchor 0 0> @MC;
+        pos base i <anchor 0 0> mark @MC;
+        language MOL;
+        pos base i <anchor 0 0> mark @MC;
+        } test;
+        """,
+    )
+
+
+def test_closing_brace_in_a_comment_does_not_truncate_the_body():
+    """It would otherwise bind the rules to the last tag only, and parse
+    cleanly while doing so."""
+    check(
+        """\
         feature locl {
         language AZE CRT;
         # see the } sign
         sub i by idotaccent;
         } locl;
-        """)
+        """,
+        """\
+        feature locl {
+        language AZE;
+        # see the } sign
+        sub i by idotaccent;
+        language CRT;
+        # see the } sign
+        sub i by idotaccent;
+        } locl;
+        """,
+    )
 
-    assert stripped(fea).count("sub i by idotaccent;") == 2
-    parse(fea)
 
-
-def test_brace_in_a_comment_does_not_swallow_the_closing_brace():
-    fea = expand("""\
+def test_opening_brace_in_a_comment_does_not_swallow_the_closing_brace():
+    check(
+        """\
         feature locl {
         language AZE CRT;
         # an opening { sign
         sub i by idotaccent;
         } locl;
-        """)
-
-    assert fea.rstrip().endswith("} locl;")
-    parse(fea)
+        """,
+        """\
+        feature locl {
+        language AZE;
+        # an opening { sign
+        sub i by idotaccent;
+        language CRT;
+        # an opening { sign
+        sub i by idotaccent;
+        } locl;
+        """,
+    )
 
 
 def test_trailing_comment_on_a_delimiter_ends_the_body():
-    fea = expand("""\
+    check(
+        """\
         feature locl {
         language AZE CRT;
         sub i by idotaccent;
         language TRK; # Turkish
         sub Scedilla by Scommaaccent;
         } locl;
-        """)
-
-    lines = stripped(fea)
-    # TRK keeps its own single rule and is not replayed under the shorthand.
-    assert lines.count("sub Scedilla by Scommaaccent;") == 1
-    assert lines.count("sub i by idotaccent;") == 2
-    assert lines.index("language TRK; # Turkish") > lines.index("language CRT;")
-    parse(fea)
+        """,
+        """\
+        feature locl {
+        language AZE;
+        sub i by idotaccent;
+        language CRT;
+        sub i by idotaccent;
+        language TRK; # Turkish
+        sub Scedilla by Scommaaccent;
+        } locl;
+        """,
+    )
 
 
 def test_trailing_comment_on_the_statement_is_kept():
-    fea = expand("""\
+    check(
+        """\
+        feature locl {
+        script latn;
         language AZE CRT; # Turkic
         sub i by idotaccent;
-        """)
-
-    lines = stripped(fea)
-    assert "language AZE; # Turkic" in lines
-    assert "language CRT;" in lines
+        } locl;
+        """,
+        """\
+        feature locl {
+        script latn;
+        language AZE; # Turkic
+        sub i by idotaccent;
+        language CRT;
+        sub i by idotaccent;
+        } locl;
+        """,
+    )
 
 
 def test_keywords_are_kept_on_every_tag():
-    fea = expand("""\
+    check(
+        """\
+        feature locl {
+        script latn;
         language ROM MOL exclude_dflt;
         sub Scedilla by Scommaaccent;
-        """)
-
-    lines = stripped(fea)
-    assert "language ROM exclude_dflt;" in lines
-    assert "language MOL exclude_dflt;" in lines
+        } locl;
+        """,
+        """\
+        feature locl {
+        script latn;
+        language ROM exclude_dflt;
+        sub Scedilla by Scommaaccent;
+        language MOL exclude_dflt;
+        sub Scedilla by Scommaaccent;
+        } locl;
+        """,
+    )
 
 
 def test_single_tag_is_untouched():
@@ -255,7 +338,7 @@ def make_font():
 
     prefix = classes.GSFeaturePrefix()
     prefix.name = "Languagesystems"
-    prefix.code = "languagesystem latn AZE;\nlanguagesystem latn TRK;\n"
+    prefix.code = "languagesystem latn AZE;\nlanguagesystem latn TRK;"
     font.featurePrefixes.append(prefix)
 
     feature = classes.GSFeature("locl")
@@ -264,8 +347,7 @@ def make_font():
         language AZE TRK;
         lookup idotaccent {
             sub i by idotaccent;
-        } idotaccent;
-        """)
+        } idotaccent;""")
     font.features.append(feature)
     return font
 
@@ -273,11 +355,21 @@ def make_font():
 def test_to_ufos_expands_feature_code(ufo_module):
     (ufo,) = to_ufos(make_font(), ufo_module=ufo_module)
 
-    lines = stripped(ufo.features.text)
-    assert "language AZE TRK;" not in lines
-    assert "language AZE;" in lines
-    assert "language TRK;" in lines
-    assert lines.count("lookup idotaccent;") == 1
+    assert ufo.features.text == dedent("""\
+        # Prefix: Languagesystems
+        languagesystem latn AZE;
+        languagesystem latn TRK;
+
+        feature locl {
+        script latn;
+        language AZE;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
+        language TRK;
+        lookup idotaccent;
+        } locl;
+        """)
     Parser(io.StringIO(ufo.features.text), glyphNames=GLYPH_NAMES).parse()
 
 
@@ -291,7 +383,11 @@ def test_expansion_does_not_round_trip(ufo_module):
     (ufo,) = to_ufos(make_font(), ufo_module=ufo_module)
 
     (feature,) = to_glyphs([ufo]).features
-    lines = stripped(feature.code)
-    assert "language AZE TRK;" not in lines
-    assert "language AZE;" in lines
-    assert "language TRK;" in lines
+    assert feature.code == dedent("""\
+        script latn;
+        language AZE;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
+        language TRK;
+        lookup idotaccent;""")

--- a/tests/builder/multi_language_test.py
+++ b/tests/builder/multi_language_test.py
@@ -34,8 +34,16 @@ def parse(fea, glyph_names=GLYPH_NAMES):
     return Parser(io.StringIO(header + fea), glyphNames=glyph_names).parse()
 
 
+def expand(fea):
+    return expand_multi_language_statements(dedent(fea))
+
+
+def stripped(fea):
+    return [line.strip() for line in fea.splitlines()]
+
+
 def test_named_lookup_is_defined_once_and_referenced():
-    fea = expand_multi_language_statements(dedent("""\
+    fea = expand("""\
         feature locl {
         script latn;
 
@@ -45,9 +53,9 @@ def test_named_lookup_is_defined_once_and_referenced():
         } idotaccent;
 
         } locl;
-    """))
+        """)
 
-    lines = [line.strip() for line in fea.splitlines()]
+    lines = stripped(fea)
     # Defined under the first tag only ...
     assert lines.count("lookup idotaccent {") == 1
     # ... and referenced under each of the remaining four.
@@ -58,15 +66,15 @@ def test_named_lookup_is_defined_once_and_referenced():
 
 
 def test_bare_rules_are_repeated():
-    fea = expand_multi_language_statements(dedent("""\
+    fea = expand("""\
         feature locl {
         script latn;
         language ROM MOL;
         sub Scedilla by Scommaaccent;
         } locl;
-    """))
+        """)
 
-    lines = [line.strip() for line in fea.splitlines()]
+    lines = stripped(fea)
     assert lines.count("sub Scedilla by Scommaaccent;") == 2
     assert lines.count("language ROM;") == 1
     assert lines.count("language MOL;") == 1
@@ -74,26 +82,151 @@ def test_bare_rules_are_repeated():
 
 
 def test_glyph_class_is_not_redefined():
-    fea = expand_multi_language_statements(dedent("""\
+    fea = expand("""\
         feature locl {
         language ROM MOL;
         @Cedillas = [Scedilla];
         sub @Cedillas by Scommaaccent;
         } locl;
-    """))
+        """)
 
-    lines = [line.strip() for line in fea.splitlines()]
+    lines = stripped(fea)
     assert lines.count("@Cedillas = [Scedilla];") == 1
     assert lines.count("sub @Cedillas by Scommaaccent;") == 2
     parse(fea)
 
 
-def test_keywords_are_kept_on_every_tag():
-    fea = expand_multi_language_statements(
-        "language ROM MOL exclude_dflt;\nsub Scedilla by Scommaaccent;\n"
-    )
+def test_multi_line_glyph_class_is_dropped_whole():
+    fea = expand("""\
+        feature locl {
+        language ROM MOL;
+        @Ced = [Scedilla
+                Lcommaaccent];
+        sub @Ced by Scommaaccent;
+        } locl;
+        """)
 
-    lines = [line.strip() for line in fea.splitlines()]
+    lines = stripped(fea)
+    assert lines.count("Lcommaaccent];") == 1
+    assert lines.count("sub @Ced by Scommaaccent;") == 2
+    parse(fea)
+
+
+def test_mark_class_is_not_redefined():
+    fea = expand("""\
+        feature test {
+        language ROM MOL;
+        markClass [Scedilla] <anchor 0 0> @MC;
+        pos base i <anchor 0 0> mark @MC;
+        } test;
+        """)
+
+    lines = stripped(fea)
+    assert lines.count("markClass [Scedilla] <anchor 0 0> @MC;") == 1
+    assert lines.count("pos base i <anchor 0 0> mark @MC;") == 2
+    parse(fea)
+
+
+def test_lookup_with_use_extension_is_referenced():
+    fea = expand("""\
+        feature locl {
+        language AZE CRT;
+        lookup idot useExtension {
+            sub i by idotaccent;
+        } idot;
+        } locl;
+        """)
+
+    lines = stripped(fea)
+    assert lines.count("lookup idot useExtension {") == 1
+    assert lines.count("lookup idot;") == 1
+    parse(fea)
+
+
+def test_lookup_with_brace_on_the_next_line_is_referenced():
+    fea = expand("""\
+        feature locl {
+        language AZE CRT;
+        lookup idot
+        {
+            sub i by idotaccent;
+        } idot;
+        } locl;
+        """)
+
+    lines = stripped(fea)
+    assert lines.count("lookup idot") == 1
+    assert lines.count("lookup idot;") == 1
+    parse(fea)
+
+
+def test_brace_in_a_comment_does_not_truncate_the_body():
+    """A closing brace in a comment must not end the block early.
+
+    That would bind the rules to the last tag only, and parse cleanly while
+    doing so.
+    """
+    fea = expand("""\
+        feature locl {
+        language AZE CRT;
+        # see the } sign
+        sub i by idotaccent;
+        } locl;
+        """)
+
+    assert stripped(fea).count("sub i by idotaccent;") == 2
+    parse(fea)
+
+
+def test_brace_in_a_comment_does_not_swallow_the_closing_brace():
+    fea = expand("""\
+        feature locl {
+        language AZE CRT;
+        # an opening { sign
+        sub i by idotaccent;
+        } locl;
+        """)
+
+    assert fea.rstrip().endswith("} locl;")
+    parse(fea)
+
+
+def test_trailing_comment_on_a_delimiter_ends_the_body():
+    fea = expand("""\
+        feature locl {
+        language AZE CRT;
+        sub i by idotaccent;
+        language TRK; # Turkish
+        sub Scedilla by Scommaaccent;
+        } locl;
+        """)
+
+    lines = stripped(fea)
+    # TRK keeps its own single rule and is not replayed under the shorthand.
+    assert lines.count("sub Scedilla by Scommaaccent;") == 1
+    assert lines.count("sub i by idotaccent;") == 2
+    assert lines.index("language TRK; # Turkish") > lines.index("language CRT;")
+    parse(fea)
+
+
+def test_trailing_comment_on_the_statement_is_kept():
+    fea = expand("""\
+        language AZE CRT; # Turkic
+        sub i by idotaccent;
+        """)
+
+    lines = stripped(fea)
+    assert "language AZE; # Turkic" in lines
+    assert "language CRT;" in lines
+
+
+def test_keywords_are_kept_on_every_tag():
+    fea = expand("""\
+        language ROM MOL exclude_dflt;
+        sub Scedilla by Scommaaccent;
+        """)
+
+    lines = stripped(fea)
     assert "language ROM exclude_dflt;" in lines
     assert "language MOL exclude_dflt;" in lines
 
@@ -132,7 +265,7 @@ def make_font():
         lookup idotaccent {
             sub i by idotaccent;
         } idotaccent;
-    """)
+        """)
     font.features.append(feature)
     return font
 
@@ -140,7 +273,7 @@ def make_font():
 def test_to_ufos_expands_feature_code(ufo_module):
     (ufo,) = to_ufos(make_font(), ufo_module=ufo_module)
 
-    lines = [line.strip() for line in ufo.features.text.splitlines()]
+    lines = stripped(ufo.features.text)
     assert "language AZE TRK;" not in lines
     assert "language AZE;" in lines
     assert "language TRK;" in lines
@@ -158,7 +291,7 @@ def test_expansion_does_not_round_trip(ufo_module):
     (ufo,) = to_ufos(make_font(), ufo_module=ufo_module)
 
     (feature,) = to_glyphs([ufo]).features
-    lines = [line.strip() for line in feature.code.splitlines()]
+    lines = stripped(feature.code)
     assert "language AZE TRK;" not in lines
     assert "language AZE;" in lines
     assert "language TRK;" in lines

--- a/tests/builder/multi_language_test.py
+++ b/tests/builder/multi_language_test.py
@@ -1,0 +1,145 @@
+#
+# Copyright 2026 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+from textwrap import dedent
+
+from fontTools.feaLib.parser import Parser
+
+from glyphsLib import classes, to_ufos
+from glyphsLib.builder.multi_language import expand_multi_language_statements
+
+GLYPH_NAMES = ["i", "idotaccent", "Scedilla", "Scommaaccent", "Lcommaaccent"]
+
+
+def parse(fea, glyph_names=GLYPH_NAMES):
+    """Parse the feature text, raising on anything feaLib does not accept."""
+    header = "languagesystem DFLT dflt;\nlanguagesystem latn dflt;\n"
+    header += "".join(
+        f"languagesystem latn {tag};\n"
+        for tag in ("AZE", "CRT", "KAZ", "TAT", "TRK", "ROM", "MOL")
+    )
+    return Parser(io.StringIO(header + fea), glyphNames=glyph_names).parse()
+
+
+def test_named_lookup_is_defined_once_and_referenced():
+    fea = expand_multi_language_statements(dedent("""\
+        feature locl {
+        script latn;
+
+        language AZE CRT KAZ TAT TRK;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
+
+        } locl;
+    """))
+
+    lines = [line.strip() for line in fea.splitlines()]
+    # Defined under the first tag only ...
+    assert lines.count("lookup idotaccent {") == 1
+    # ... and referenced under each of the remaining four.
+    assert lines.count("lookup idotaccent;") == 4
+    for tag in ("AZE", "CRT", "KAZ", "TAT", "TRK"):
+        assert f"language {tag};" in lines
+    parse(fea)
+
+
+def test_bare_rules_are_repeated():
+    fea = expand_multi_language_statements(dedent("""\
+        feature locl {
+        script latn;
+        language ROM MOL;
+        sub Scedilla by Scommaaccent;
+        } locl;
+    """))
+
+    lines = [line.strip() for line in fea.splitlines()]
+    assert lines.count("sub Scedilla by Scommaaccent;") == 2
+    assert lines.count("language ROM;") == 1
+    assert lines.count("language MOL;") == 1
+    parse(fea)
+
+
+def test_glyph_class_is_not_redefined():
+    fea = expand_multi_language_statements(dedent("""\
+        feature locl {
+        language ROM MOL;
+        @Cedillas = [Scedilla];
+        sub @Cedillas by Scommaaccent;
+        } locl;
+    """))
+
+    lines = [line.strip() for line in fea.splitlines()]
+    assert lines.count("@Cedillas = [Scedilla];") == 1
+    assert lines.count("sub @Cedillas by Scommaaccent;") == 2
+    parse(fea)
+
+
+def test_keywords_are_kept_on_every_tag():
+    fea = expand_multi_language_statements(
+        "language ROM MOL exclude_dflt;\nsub Scedilla by Scommaaccent;\n"
+    )
+
+    lines = [line.strip() for line in fea.splitlines()]
+    assert "language ROM exclude_dflt;" in lines
+    assert "language MOL exclude_dflt;" in lines
+
+
+def test_single_tag_is_untouched():
+    original = "script latn;\nlanguage TRK;\nsub i by idotaccent;\n"
+
+    assert expand_multi_language_statements(original) == original
+
+
+def test_unparseable_statement_is_untouched():
+    """Leave it for feaLib to report rather than guess at it."""
+    original = "language TOOLONGTAG OTHER;\nsub i by idotaccent;\n"
+
+    assert expand_multi_language_statements(original) == original
+
+
+def test_to_ufos_expands_feature_code(ufo_module):
+    font = classes.GSFont()
+    font.masters.append(classes.GSFontMaster())
+    for name in ("i", "idotaccent"):
+        glyph = classes.GSGlyph(name)
+        glyph.layers.append(classes.GSLayer())
+        glyph.layers[0].layerId = font.masters[0].id
+        font.glyphs.append(glyph)
+
+    prefix = classes.GSFeaturePrefix()
+    prefix.name = "Languagesystems"
+    prefix.code = "languagesystem latn AZE;\nlanguagesystem latn TRK;\n"
+    font.featurePrefixes.append(prefix)
+
+    feature = classes.GSFeature("locl")
+    feature.code = dedent("""\
+        script latn;
+        language AZE TRK;
+        lookup idotaccent {
+            sub i by idotaccent;
+        } idotaccent;
+    """)
+    font.features.append(feature)
+
+    (ufo,) = to_ufos(font, ufo_module=ufo_module)
+
+    lines = [line.strip() for line in ufo.features.text.splitlines()]
+    assert "language AZE TRK;" not in lines
+    assert "language AZE;" in lines
+    assert "language TRK;" in lines
+    assert lines.count("lookup idotaccent;") == 1
+    Parser(io.StringIO(ufo.features.text), glyphNames=GLYPH_NAMES).parse()


### PR DESCRIPTION
Fixes #1109.

Glyphs lets a single `language` statement carry several tags and applies everything that follows to each of them:

```fea
language AZE CRT KAZ TAT TRK;
lookup idotaccent {
    sub i by idotaccent;
} idotaccent;
```

The FEA spec allows exactly one tag, so feaLib stops at the second one and the UFOs glyphsLib writes cannot be compiled at all — `<features>:N:14: Expected ';'`, column 14 being where `CRT` starts. The syntax is documented in the [Glyphs Handbook](https://handbook.glyphsapp.com/layout/multiple-languages-syntax/) and written up as a spec proposal in [adobe-type-tools/feature_file_workshops#8](https://github.com/adobe-type-tools/feature_file_workshops/pull/8). Glyphs 4 emits it from *automatic* feature generation, so a source that built yesterday stops building after a save.

This expands the shorthand into one statement per tag in `_to_ufo_features`. What reaches the UFO is then plain spec-compliant FEA that any compiler reads — feaLib, fea-rs and makeotf alike; expanding downstream would leave the UFO itself non-portable.

The scope is emitted once for the first tag and replayed for every remaining one. Named lookups cannot simply be duplicated — that would redefine them — so the replays reference the lookup defined under the first tag:

```fea
language AZE;
lookup idotaccent {
    sub i by idotaccent;
} idotaccent;
language CRT;
lookup idotaccent;
```

Glyph class and `markClass` definitions are likewise emitted only once; bare rules and `lookupflag`s are repeated verbatim, which is what the shorthand means. Trailing keywords (`exclude_dflt` and friends) are kept on every tag. A statement that is already spec-compliant, or that cannot be classified with confidence, is left untouched for feaLib to report rather than guessed at. So is a scope containing an `include()`, whose contents are not visible and therefore cannot be replayed; a statement listing `dflt` beside other tags, which has to be specified alone and which Glyphs rejects as well; one sitting outside any block, where FEA does not allow `language` at all; and one whose scope holds a statement with no closing semicolon.

**Built on feaLib's `Lexer`.** The scan walks the token stream, so a statement ends at the first `;` at brace depth zero wherever it sits on the page, and a brace or semicolon inside a comment or a string is never taken for code. What is left is classifying five statement heads (`lookup NAME {`, `@Class =`, `markClass`, `include(`, everything else): no glyph classes to resolve, no lookup bodies to understand, no name resolution. What is emitted for the first tag is sliced out of the original by offset, so comments, indentation and blank lines survive untouched; the replays are statements only, so a comment inside the scope is not duplicated. A `\blanguage\b` guard keeps the lexer off feature code that cannot contain the shorthand.

**It reproduces what Glyphs 3 wrote.** Taking a `locl` feature from a production source in both its Glyphs 3 and its Glyphs 4 form — the automatic code nobody edited, before and after a save in Glyphs 4 — expanding the shorthand gives back the Glyphs 3 text byte for byte, tabs and blank lines included. Compiled with feaLib, the two produce an identical GSUB table. A second test does the same for the shape where the language statements sit *inside* the lookup block; there the single-tag form is what Glyphs 3 wrote for another production source and the shorthand is that form collapsed by hand, since Glyphs 4 has not been seen to emit it — it pins down that the scope ends at the block's own brace, with the rules repeated rather than referenced.

**Ordering.** The expansion runs after `VariableFeatureConverter`, so `#ifndef VARIABLE` blocks are already resolved. The markers are comments and therefore not statements: expanding first would place the repeats *inside* the block, and the strip that follows would then take the second `language` statement with it. `test_conditional_block_is_resolved_before_the_expansion` pins this down.

**One-way.** The expansion is not reversed on the way back, so `.glyphs` → UFO → `.glyphs` yields the expanded form rather than the original statement. `test_expansion_does_not_round_trip` pins this down. UFO → `.glyphs` → UFO is unaffected, since the original feature text is recovered from `ORIGINAL_FEATURE_CODE_KEY`. Happy to restore the shorthand in `to_glyphs_features` instead if you would rather keep it lossless.

39 tests in `tests/builder/multi_language_test.py`, including the four counterexamples from the review, the two real-source shapes above, every line ending feaLib recognises, each shape left untouched, idempotence, two through `to_ufos` and one through the round trip. Two are invariants over a corpus of awkward sources rather than one example each: the output is either identical to the input or it compiles, and line endings do not change which rules end up under which tag. Full suite: 1376 passed, 64 skipped, 4 xfailed. `black --check` and `flake8` over `Lib tests` are clean.

