### PR TITLE
Fix Glyphs conversion edge cases

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -15,8 +15,6 @@
 
 import logging
 
-from fontTools.varLib.models import piecewiseLinearMap
-
 from glyphsLib import classes
 from glyphsLib.classes import WEIGHT_CODES, WIDTH_CODES, InstanceType
 from glyphsLib.builder.constants import WIDTH_CLASS_TO_VALUE
@@ -158,6 +156,30 @@ def is_identity(mapping):
     return all(userLoc == designLoc for userLoc, designLoc in mapping.items())
 
 
+def _validate_axis_mapping(mapping, axis_tag):
+    """Return a user-sorted mapping whose design values never decrease."""
+    ordered = sorted(mapping.items())
+    for (user1, design1), (user2, design2) in zip(ordered, ordered[1:]):
+        if design1 > design2:
+            raise ValueError(
+                f"Axis {axis_tag}: mapping output at user location {user2} "
+                f"({design2}) must not be less than the previous output at "
+                f"user location {user1} ({design1})"
+            )
+    return ordered
+
+
+def _add_axis_mapping_default(mapping, user_location, design_location):
+    # Preserve interpolated defaults without extending the mapping to accommodate
+    # invalid source locations, such as the reversed mappings in issue #993.
+    if (
+        len(mapping) > 1
+        and min(mapping) < user_location < max(mapping)
+        and design_location not in mapping.values()
+    ):
+        mapping[user_location] = design_location
+
+
 def to_designspace_axes(self):
     if not self.font.masters:
         return
@@ -194,9 +216,12 @@ def to_designspace_axes(self):
         if custom_mapping:
             if axis.tag in custom_mapping:
                 mapping = {float(k): v for k, v in custom_mapping[axis.tag].items()}
+                axis.map = _validate_axis_mapping(mapping, axis.tag)
                 regularDesignLoc = axis_def.get_design_loc(regular_master)
-                reverse_mapping = {dl: ul for ul, dl in sorted(mapping.items())}
-                regularUserLoc = piecewiseLinearMap(regularDesignLoc, reverse_mapping)
+                regularUserLoc = axis.map_backward(regularDesignLoc)
+                # Preserve the default through serialization for explicit maps,
+                # just as for mappings inferred from instances below.
+                _add_axis_mapping_default(mapping, regularUserLoc, regularDesignLoc)
             else:
                 logger.debug(
                     f"Skipping {axis.tag} since it hasn't been defined "
@@ -256,13 +281,32 @@ def to_designspace_axes(self):
                 else master_mapping
             )
 
+            # Some sources place masters just outside an instance-based mapping
+            # whose end knots are identity mappings. Extend those identity
+            # segments so the masters reverse-map inside the user-space bounds.
+            ordered_mapping = _validate_axis_mapping(mapping, axis.tag)
+            min_user, min_design = ordered_mapping[0]
+            max_user, max_design = ordered_mapping[-1]
+            for designLoc in master_mapping.values():
+                if designLoc < min_design and min_user == min_design:
+                    mapping[designLoc] = designLoc
+                elif designLoc > max_design and max_user == max_design:
+                    mapping[designLoc] = designLoc
+
             regularDesignLoc = axis_def.get_design_loc(regular_master)
             # Glyphs masters don't have a user location, so we compute it by
             # looking at the axis mapping in reverse.
-            reverse_mapping = {dl: ul for ul, dl in sorted(mapping.items())}
-            regularUserLoc = piecewiseLinearMap(regularDesignLoc, reverse_mapping)
-            # TODO make sure that the default is in mapping?
+            axis.map = _validate_axis_mapping(mapping, axis.tag)
+            regularUserLoc = axis.map_backward(regularDesignLoc)
+            # Keep an interpolated default as an explicit mapping knot.
+            # Designspace serialization rounds float attributes, and without
+            # this point the rounded default can map to a value infinitesimally
+            # different from the regular master's design location. Consumers
+            # such as varLib then fail to find a default source. A one-point
+            # map has no interpolation segment and must remain unchanged.
+            _add_axis_mapping_default(mapping, regularUserLoc, regularDesignLoc)
 
+        ordered_mapping = _validate_axis_mapping(mapping, axis.tag)
         is_identity_map = is_identity(mapping)
 
         # Virtual Masters can't have an Axis Location parameter; their coordinates
@@ -291,8 +335,7 @@ def to_designspace_axes(self):
             or not is_identity_map
             or axis_wanted
         ):
-            if not is_identity_map:
-                axis.map = sorted(mapping.items())
+            axis.map = [] if is_identity_map else ordered_mapping
             axis.minimum = minimum
             axis.maximum = maximum
             axis.default = default

--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -1074,7 +1074,15 @@ class RenameGlyphsParamHandler(AbstractParamHandler):
         ufo = ufo._owner
         for entry in rename_list:
             oldname, newname = entry.split("=")
+            if oldname not in ufo or newname not in ufo:
+                continue
             ufo[newname], ufo[oldname] = ufo[oldname], ufo[newname]
+            for glyph in ufo:
+                for component in glyph.components:
+                    if component.baseGlyph == oldname:
+                        component.baseGlyph = newname
+                    elif component.baseGlyph == newname:
+                        component.baseGlyph = oldname
             ufo[newname].unicodes, ufo[oldname].unicodes = (
                 ufo[oldname].unicodes,
                 ufo[newname].unicodes,

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     ufoLib2 >= 0.6.2
-    fonttools[ufo,unicode] >= 4.38.0
+    fonttools[ufo,unicode] >= 4.63.0
     openstep-plist >= 0.3.0
 
 [options.extras_require]

--- a/tests/builder/instances_test.py
+++ b/tests/builder/instances_test.py
@@ -232,6 +232,11 @@ def test_glyphs3_instance_properties(tmpdir):
 
 def test_rename_glyphs(tmpdir):
     font = glyphsLib.GSFont(os.path.join(DATA, "RenameGlyphsTest.glyphs"))
+    font.instances[1].customParameters["Rename Glyphs"] = [
+        "a=b",
+        "missing=a",
+        "a=missing",
+    ]
     instance_dir = tmpdir.ensure_dir("instance_ufo")
     designspace = glyphsLib.to_designspace(font, instance_dir=instance_dir)
     path = str(tmpdir / (font.familyName + ".designspace"))
@@ -249,11 +254,19 @@ def test_rename_glyphs(tmpdir):
     assert len(ufos[0]["b"][0]) == 12  # Circle
     assert ufos[0]["a"].unicode == 0x0061
     assert ufos[0]["b"].unicode == 0x0062
+    assert [component.baseGlyph for component in ufos[0]["d"].components] == [
+        "a",
+        "b",
+    ]
 
     assert len(ufos[1]["a"][0]) == 12  # Circle
     assert len(ufos[1]["b"][0]) == 4  # Square
-    assert ufos[0]["a"].unicode == 0x0061
-    assert ufos[0]["b"].unicode == 0x0062
+    assert ufos[1]["a"].unicode == 0x0061
+    assert ufos[1]["b"].unicode == 0x0062
+    assert [component.baseGlyph for component in ufos[1]["d"].components] == [
+        "b",
+        "a",
+    ]
 
 
 def test_expand_instance_naming_tokens(ufo_module):

--- a/tests/builder/interpolation_test.py
+++ b/tests/builder/interpolation_test.py
@@ -23,6 +23,8 @@ import xml.etree.ElementTree as etree
 from xmldiff import main, formatting
 
 import defcon
+from fontTools.varLib import load_designspace
+from fontTools.varLib.errors import VarLibValidationError
 from glyphsLib.builder.constants import GLYPHS_PREFIX
 from glyphsLib.builder.instances import set_weight_class, set_width_class
 from glyphsLib.classes import GSFont, GSFontMaster, GSInstance, GSFontInfoValue
@@ -239,6 +241,185 @@ class DesignspaceTest(unittest.TestCase):
         self.assertEqual(weightAxis.attrib["maximum"], "900")
 
         self.expect_designspace_roundtrip(designspace)
+
+    def test_inferred_default_is_explicit_axis_mapping_knot(self):
+        masters = [
+            makeMaster("Thin", weight=45),
+            makeMaster("Regular", weight=400),
+            makeMaster("Heavy", weight=930),
+        ]
+        instances = [
+            makeInstance("Thin", weight=("Thin", 100, 100)),
+            makeInstance("Light", weight=("Light", 300, 300)),
+            makeInstance("Regular", weight=("Regular", 400, 413)),
+            makeInstance("Black", weight=("Black", 900, 900)),
+        ]
+        font = makeFont(masters, instances, "Mapped Default")
+
+        designspace = to_designspace(font, instance_dir="out")
+        weight_axis = designspace.axes[0]
+        regular_user_location = weight_axis.default
+
+        self.assertEqual(weight_axis.minimum, masters[0].weightValue)
+        self.assertEqual(weight_axis.maximum, masters[-1].weightValue)
+        self.assertEqual(dict(weight_axis.map)[45], 45)
+        self.assertEqual(dict(weight_axis.map)[930], 930)
+        self.assertEqual(
+            dict(weight_axis.map)[regular_user_location],
+            masters[1].weightValue,
+        )
+
+        path = self.write_to_tmp_path(designspace, "mapped-default.designspace")
+        reloaded = type(designspace).fromfile(path)
+        self.assertEqual(reloaded.findDefault().styleName, "Regular")
+
+    def test_inferred_default_preserves_flat_axis_mapping(self):
+        masters = [
+            makeMaster("Thin", weight=100),
+            makeMaster("Regular", weight=350),
+            makeMaster("Black", weight=900),
+        ]
+        instances = [
+            makeInstance("Thin", weight=("Thin", 100, 100)),
+            makeInstance("Light", weight=("Light", 300, 400)),
+            makeInstance("Regular", weight=("Regular", 400, 400)),
+            makeInstance("Black", weight=("Black", 900, 900)),
+        ]
+        font = makeFont(masters, instances, "Flat Mapped Default")
+
+        designspace = to_designspace(font, instance_dir="out")
+        weight_axis = designspace.axes[0]
+        mapping = weight_axis.map
+        design_locations = [design for _, design in mapping]
+
+        self.assertEqual(design_locations, sorted(design_locations))
+        self.assertAlmostEqual(weight_axis.default, 266.6666666666667)
+        self.assertEqual(
+            dict(mapping)[weight_axis.default],
+            masters[1].weightValue,
+        )
+
+        path = self.write_to_tmp_path(designspace, "flat-mapped-default.designspace")
+        reloaded = type(designspace).fromfile(path)
+        self.assertEqual(reloaded.findDefault().styleName, "Regular")
+
+    def test_explicit_axis_mapping_default_survives_serialization(self):
+        for mapping, regular_weight in (
+            ([(100, 100), (400, 413), (900, 900)], 400),
+            ([(100, 100), (300, 400), (400, 400), (900, 900)], 350),
+            ([(100, 100), (300, 400), (400, 400), (900, 900)], 400),
+        ):
+            with self.subTest(mapping=mapping, regular_weight=regular_weight):
+                font = makeFont(
+                    [
+                        makeMaster("Thin", weight=100),
+                        makeMaster("Regular", weight=regular_weight),
+                        makeMaster("Black", weight=900),
+                    ],
+                    [],
+                    "Explicit Mapped Default",
+                )
+                font.customParameters["Axis Mappings"] = {
+                    "wght": {str(user): design for user, design in mapping}
+                }
+
+                designspace = to_designspace(font)
+                axis = designspace.axes[0]
+                self.assertEqual((axis.minimum, axis.maximum), (100, 900))
+                self.assertEqual(dict(axis.map)[axis.default], regular_weight)
+                self.assertTrue(set(mapping).issubset(axis.map))
+                expected_knots = len(mapping) + (
+                    regular_weight not in dict(mapping).values()
+                )
+                self.assertEqual(len(axis.map), expected_knots)
+
+                path = self.write_to_tmp_path(
+                    designspace, "explicit-default.designspace"
+                )
+                reloaded = type(designspace).fromfile(path)
+                self.assertEqual(reloaded.findDefault().styleName, "Regular")
+                axis = reloaded.axes[0]
+                self.assertEqual(dict(axis.map)[axis.default], regular_weight)
+                # Exercise the same default-source validation used by varLib builds.
+                load_designspace(reloaded)
+
+    def test_explicit_mapping_default_does_not_extend_bounds(self):
+        for mapping, master_locations in (
+            # Reversed AndadaPro and Familjen Grotesk mappings from issue #993.
+            ([(96, 400), (140, 840)], [96, 140]),
+            ([(120, 400), (150, 496), (165, 600), (180, 700)], [120, 180]),
+            # Also cover a default extrapolated above the mapping range.
+            ([(96, 40), (140, 84)], [96, 140]),
+        ):
+            with self.subTest(mapping=mapping):
+                font = makeFont(
+                    [
+                        makeMaster("Regular", weight=master_locations[0]),
+                        makeMaster("Black", weight=master_locations[1]),
+                    ],
+                    [],
+                    "Out-of-Range Default",
+                )
+                font.customParameters["Axis Mappings"] = {
+                    "wght": {str(user): design for user, design in mapping}
+                }
+
+                designspace = to_designspace(font)
+                axis = designspace.axes[0]
+                self.assertEqual(axis.map, mapping)
+                self.assertEqual(
+                    (axis.minimum, axis.maximum), (mapping[0][0], mapping[-1][0])
+                )
+                path = self.write_to_tmp_path(designspace, "out-of-range.designspace")
+                reloaded = type(designspace).fromfile(path)
+                # Adding a default knot must not hide the invalid source locations.
+                with self.assertRaisesRegex(VarLibValidationError, "out-of-range"):
+                    load_designspace(reloaded)
+
+    def test_explicit_flat_mapping_preserves_direction_and_endpoints(self):
+        # The valid mapping before Glyphs.app flips it in issue #993.
+        mapping = [(400, 120), (496, 150), (500, 150), (600, 165), (700, 180)]
+        font = makeFont(
+            [
+                makeMaster("Regular", weight=120),
+                makeMaster("Medium", weight=150),
+                makeMaster("Bold", weight=180),
+            ],
+            [],
+            "Flat Explicit Mapping",
+        )
+        font.customParameters["Axis Mappings"] = {
+            "wght": {str(user): design for user, design in mapping}
+        }
+
+        designspace = to_designspace(font)
+        path = self.write_to_tmp_path(designspace, "flat-explicit.designspace")
+        reloaded = type(designspace).fromfile(path)
+        axis = reloaded.axes[0]
+        self.assertEqual(axis.map, mapping)
+        self.assertEqual((axis.minimum, axis.default, axis.maximum), (400, 400, 700))
+        self.assertEqual(axis.map_forward(498), 150)
+        self.assertAlmostEqual(axis.map_backward(149), 492.8)
+        self.assertAlmostEqual(axis.map_backward(151), 506.6666666666667)
+        self.assertEqual(reloaded.findDefault().styleName, "Regular")
+        load_designspace(reloaded)
+
+    def test_non_monotonic_axis_mapping_is_rejected(self):
+        masters = [
+            makeMaster("Thin", weight=100),
+            makeMaster("Regular", weight=350),
+            makeMaster("Black", weight=900),
+        ]
+        instances = [
+            makeInstance("Thin", weight=("Thin", 100, 100)),
+            makeInstance("Light", weight=("Light", 300, 400)),
+            makeInstance("Regular", weight=("Regular", 400, 350)),
+            makeInstance("Black", weight=("Black", 900, 900)),
+        ]
+        font = makeFont(masters, instances, "Non-Monotonic Mapping")
+
+        with self.assertRaisesRegex(ValueError, "must not be less"):
+            to_designspace(font, instance_dir="out")
 
     def test_postscriptFontNameCustomParameter(self):
         master = makeMaster("Master")

--- a/tests/builder/variable_features_test.py
+++ b/tests/builder/variable_features_test.py
@@ -84,7 +84,7 @@ def convert(fea, axes=("wght",), font=None):
             "feature cpsp { pos @Uppercase 10 (wdth:80) 20 (wdth:40 opsz:28) 30; }"
             " cpsp;",
             ("wdth", "opsz"),
-            "feature cpsp { pos @Uppercase (wdth=100,opsz=12:10 wdth=80.0:20"
+            "feature cpsp { pos @Uppercase (wdth=100,opsz=12.0:10 wdth=80.0:20"
             " wdth=40.0,opsz=28.0:30); } cpsp;",
         ),
         # The handbook’s tab-indented four-value example.
@@ -97,9 +97,9 @@ def convert(fea, axes=("wght",), font=None):
                 } test;"""),
             ("wdth", "opsz"),
             "feature test {\n"
-            "pos @Digit colon' <(wdth=100,opsz=12:10 wdth=80.0:30"
-            " wdth=40.0,opsz=28.0:5) (wdth=100,opsz=12:50 wdth=80.0:40"
-            " wdth=40.0,opsz=28.0:10) (wdth=100,opsz=12:20 wdth=80.0:60"
+            "pos @Digit colon' <(wdth=100,opsz=12.0:10 wdth=80.0:30"
+            " wdth=40.0,opsz=28.0:5) (wdth=100,opsz=12.0:50 wdth=80.0:40"
+            " wdth=40.0,opsz=28.0:10) (wdth=100,opsz=12.0:20 wdth=80.0:60"
             " wdth=40.0,opsz=28.0:10) 0> @Digit;\n"
             "} test;",
         ),
@@ -107,8 +107,8 @@ def convert(fea, axes=("wght",), font=None):
         (
             "feature kern { pos a b <10 0 5 0 (wght:900) 20 10 5 2>; } kern;",
             ("wght",),
-            "feature kern { pos a b <(wght=400:10 wght=900.0:20)"
-            " (wght=400:0 wght=900.0:10) 5 (wght=400:0 wght=900.0:2)>; } kern;",
+            "feature kern { pos a b <(wght=400.0:10 wght=900.0:20)"
+            " (wght=400.0:0 wght=900.0:10) 5 (wght=400.0:0 wght=900.0:2)>; } kern;",
         ),
         (
             "feature cpsp { pos a 10 (wdth:80) 20.5; } cpsp;",
@@ -119,8 +119,8 @@ def convert(fea, axes=("wght",), font=None):
         (
             "feature kern { pos a b -10 (MSHQ:100, SPAC:50) -30; } kern;",
             ("MSHQ", "SPAC"),
-            "feature kern { pos a b (MSHQ=10,SPAC=0:-10 MSHQ=100.0,SPAC=50.0:-30); }"
-            " kern;",
+            "feature kern { pos a b (MSHQ=10.0,SPAC=0.0:-10"
+            " MSHQ=100.0,SPAC=50.0:-30); } kern;",
         ),
         # An unbounded side becomes the axis maximum.
         (
@@ -250,7 +250,7 @@ def convert(fea, axes=("wght",), font=None):
                 } conditionset_1;
 
                 variation kern conditionset_1 {
-                pos a b (wght=400:10 wght=80.0:20);
+                pos a b (wght=400.0:10 wght=80.0:20);
                 } kern;
                 """),
         ),
@@ -339,8 +339,8 @@ def convert(fea, axes=("wght",), font=None):
             ("wght",),
             "feature dist {\n"
             "markClass acutecomb <anchor 0 0> @TOP;\n"
-            "pos base a <anchor (wght=400:250 wght=1000.0:300)"
-            " (wght=400:700 wght=1000.0:760)> mark @TOP;\n"
+            "pos base a <anchor (wght=400.0:250 wght=1000.0:300)"
+            " (wght=400.0:700 wght=1000.0:760)> mark @TOP;\n"
             "} dist;",
         ),
         # Cursive anchors,
@@ -351,8 +351,8 @@ def convert(fea, axes=("wght",), font=None):
                 } dist;"""),
             ("wght",),
             "feature dist {\n"
-            "pos cursive a <anchor (wght=400:100 wght=1000.0:150)"
-            " (wght=400:200 wght=1000.0:260)> <anchor NULL>;\n"
+            "pos cursive a <anchor (wght=400.0:100 wght=1000.0:150)"
+            " (wght=400.0:200 wght=1000.0:260)> <anchor NULL>;\n"
             "} dist;",
         ),
         # A component equal across all masters stays a plain number.
@@ -363,7 +363,7 @@ def convert(fea, axes=("wght",), font=None):
                 } dist;"""),
             ("wght",),
             "feature dist {\n"
-            "pos cursive a <anchor (wght=400:100 wght=1000.0:150) 700>"
+            "pos cursive a <anchor (wght=400.0:100 wght=1000.0:150) 700>"
             " <anchor NULL>;\n"
             "} dist;",
         ),
@@ -375,8 +375,8 @@ def convert(fea, axes=("wght",), font=None):
             "} dist;",
             ("wght", "wdth"),
             "feature dist {\n"
-            "pos cursive a <anchor (wght=400,wdth=100:100"
-            " wght=1000.0,wdth=80.0:150) (wght=400,wdth=100:200"
+            "pos cursive a <anchor (wght=400.0,wdth=100:100"
+            " wght=1000.0,wdth=80.0:150) (wght=400.0,wdth=100:200"
             " wght=1000.0,wdth=80.0:260)> <anchor NULL>;\n"
             "} dist;",
         ),

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -21,7 +21,9 @@ class dircmp(filecmp.dircmp):
         self.same_files, self.diff_files, self.funny_files = fcomp
 
 
-def diff_directories(dir1, dir2):
+def diff_directories(dir1, dir2, expected_text=None):
+    # Overrides apply only to files in this directory, not its subdirectories.
+    expected_text = expected_text or {}
     compared = dircmp(dir1, dir2)
     report = []
     for l in compared.left_only:
@@ -30,13 +32,21 @@ def diff_directories(dir1, dir2):
         report.append("> %s" % r)
     for f in compared.funny_files:
         report.append("? %s" % f)
-    for d in compared.diff_files:
-        report.append("! {} - {}".format(os.path.join(dir1, d), os.path.join(dir2, d)))
-        left = open(os.path.join(dir1, d))
-        right = open(os.path.join(dir2, d))
-        report.append(
-            "".join(difflib.unified_diff(left.readlines(), right.readlines()))
-        )
+    files = set(compared.diff_files) | (expected_text.keys() & set(compared.same_files))
+    for d in sorted(files):
+        left = expected_text[d] if d in expected_text else Path(dir1, d).read_text()
+        right = Path(dir2, d).read_text()
+        if d not in expected_text or left != right:
+            report.append(
+                "! {} - {}".format(os.path.join(dir1, d), os.path.join(dir2, d))
+            )
+            report.append(
+                "".join(
+                    difflib.unified_diff(
+                        left.splitlines(keepends=True), right.splitlines(keepends=True)
+                    )
+                )
+            )
     for subdir in compared.common_dirs:
         report.extend(
             diff_directories(os.path.join(dir1, subdir), os.path.join(dir2, subdir))
@@ -55,6 +65,58 @@ TEST_FILES_GLYPHS = Path("tests/data/gf").glob("*.glyphs")
 TEST_FILES_DESIGNSPACE = Path("tests/data/designspace").glob("**/*.designspace")
 
 
+def lexend_arabic_expected_designspace(reference):
+    # main generates the reference output at the start of the CI job. Allow
+    # only the default knot introduced to survive designspace serialization.
+    old_axis = (
+        '    <axis tag="wght" name="Weight" minimum="300" maximum="700"'
+        ' default="580.851064">\n'
+        '      <map input="300" output="42"/>\n'
+        '      <map input="700" output="136"/>\n'
+        "    </axis>"
+    )
+    new_axis = old_axis.replace(
+        '      <map input="700"',
+        '      <map input="580.851064" output="108"/>\n      <map input="700"',
+    )
+    if old_axis in reference:
+        return reference.replace(old_axis, new_axis, 1)
+    # Once main includes the fix, the generated reference already has the knot.
+    assert new_axis in reference
+    return reference
+
+
+@pytest.mark.parametrize("actual", ["old\n", "expected\n", "unexpected\n"])
+def test_diff_directories_expected_text(tmp_path, actual):
+    reference = tmp_path / "reference"
+    output = tmp_path / "output"
+    reference.mkdir()
+    output.mkdir()
+    (reference / "font.designspace").write_text("old\n")
+    (output / "font.designspace").write_text(actual)
+    overrides = {"font.designspace": "expected\n"}
+    assert bool(diff_directories(reference, output, overrides)) == (
+        actual != "expected\n"
+    )
+
+    # A permitted designspace change must not hide differences inside a UFO.
+    (reference / "font.ufo").mkdir()
+    (output / "font.ufo").mkdir()
+    (reference / "font.ufo" / "lib.plist").write_text("old\n")
+    (output / "font.ufo" / "lib.plist").write_text("unexpected\n")
+    assert diff_directories(reference, output, overrides)
+
+
+def test_diff_directories_preserves_line_endings(tmp_path):
+    reference = tmp_path / "reference"
+    output = tmp_path / "output"
+    reference.mkdir()
+    output.mkdir()
+    (reference / "lib.plist").write_bytes(b"same\r\n")
+    (output / "lib.plist").write_bytes(b"same\n")
+    assert diff_directories(reference, output)
+
+
 @pytest.mark.regression_test
 @pytest.mark.parametrize("filename", TEST_FILES_GLYPHS, ids=lambda p: p.name)
 def test_glyphs_to_designspace(filename: Path, caplog: Any) -> None:
@@ -68,7 +130,21 @@ def test_glyphs_to_designspace(filename: Path, caplog: Any) -> None:
             glyphsLib.build_masters(filename, tmp_dir, None, designspace_path=ds)
 
         reference_output_dir = filename.parent / filename.stem
-        report = diff_directories(reference_output_dir, tmp_dir)
+        expected_text = {}
+        if filename.name == "Lexend-Arabic.glyphs":
+            expected_text[ds.name] = lexend_arabic_expected_designspace(
+                (reference_output_dir / ds.name).read_text()
+            )
+            reloaded = DesignSpaceDocument.fromfile(ds)
+            weight = next(axis for axis in reloaded.axes if axis.tag == "wght")
+            assert weight.default == 580.851064
+            assert dict(weight.map)[weight.default] == 108
+            assert weight.map_forward(weight.default) == 108
+            default = reloaded.findDefault()
+            assert default is not None
+            assert default.designLocation == {"Weight": 108, "Lexend": 0}
+
+        report = diff_directories(reference_output_dir, tmp_dir, expected_text)
         if report:
             print("".join(report))
         assert not report


### PR DESCRIPTION
## Summary

Fix edge cases encountered while converting Glyphs-based sources through glyphsLib and fontmake.

This change preserves default-master locations through designspace serialization and correctly handles reverse mapping around valid flat segments. It also adds missing-target handling and component-reference updates to `Rename Glyphs`.

## Changes

* Add explicit default mapping knots where needed for both instance-derived mappings and the `Axis Mappings` custom parameter.
* Extend identity mapping endpoints to include masters outside an instance-derived mapping.
* Preserve flat segments and reject mappings whose design coordinates decrease.
* Use `AxisDescriptor.map_backward()` and require fontTools 4.63.0.
* Skip `Rename Glyphs` entries whose source or destination is missing.
* Update component references when swapping glyphs while retaining Unicode assignments.
* Update variable-feature test expectations for numerically equivalent float coordinate output.

## Design rationale

### Preserve the correspondence between the axis default and the default master

In Designspace, an axis default is expressed in user coordinates, while source locations use design coordinates. Finding the default source therefore requires the mapped axis default to match the master location. See the [Designspace coordinate definitions](https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#axis-element) and [default-source lookup implementation](https://github.com/fonttools/fonttools/blob/4.63.0/Lib/fontTools/designspaceLib/__init__.py#L3095).

For a mapping of `100→100, 400→413, 900→900`, the user coordinate corresponding to a default master at design coordinate `400` is approximately `387.539936102…`. Rounding during serialization can cause that coordinate to map back to a value that is not exactly `400`, preventing default-source lookup.

Adding an explicit default knot on the existing linear segment preserves the intended mapping and its correspondence to the master. It also satisfies fontTools’ requirement that an axis mapping contain knots for its minimum, maximum, and default. This is a fontTools build requirement, not a UFO constraint. See the [mapping validation implementation](https://github.com/fonttools/fonttools/blob/4.63.0/Lib/fontTools/varLib/__init__.py#L204).

### Preserve flat segments and require the corrected reverse mapping

The OpenType `avar` specification requires increasing input coordinates but permits consecutive output coordinates to be equal. Flat segments are therefore valid, whereas decreasing output coordinates are not. See the [OpenType `avar` specification](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats).

The previous reverse-mapping implementation used a dictionary, losing one endpoint when multiple user coordinates mapped to the same design coordinate. fontTools 4.63.0 includes [PR #4085](https://github.com/fonttools/fonttools/pull/4085), which preserves both endpoints. The dependency bump ensures that glyphsLib uses this corrected implementation.

Output such as `400.0` instead of `400` is a consequence of the changed calculation, not a new formatting requirement. The reverse-mapping implementation is retained, and test expectations are updated accordingly.

### Extend identity endpoints without changing the coordinate mapping

Outside the mapping range, fontTools extrapolates using the endpoint’s offset. When the endpoint has equal user and design coordinates, that offset is zero, so the extrapolated segment is also an identity mapping. Adding identity knots at outlying master locations preserves the existing coordinate transformation. See the [extrapolation implementation](https://github.com/fonttools/fonttools/blob/4.63.0/Lib/fontTools/varLib/models.py#L581).

This extension makes an instance-derived range include the masters, satisfying varLib’s source-location bounds checks. It is a conversion policy for inferred ranges, not a general specification requirement to expand axis bounds automatically. See the [source-location validation](https://github.com/fonttools/fonttools/blob/4.63.0/Lib/fontTools/varLib/__init__.py#L1018).

### Maintain component-reference integrity when swapping glyphs

UFO components reference glyphs by name within the same layer and must not create circular references. For example, if `a.alt` references `a`, swapping only their glyph data can make the new `a` reference itself. Swapping component references as well preserves the existing component relationships. See the [UFO GLIF component specification](https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#component).

Skipping missing swap targets is an error-handling policy that allows conversion to continue; it is not a behavior directly required by the UFO specification.